### PR TITLE
Slimmer slim variants and a few consistency fixes

### DIFF
--- a/0.10/Dockerfile
+++ b/0.10/Dockerfile
@@ -1,8 +1,4 @@
-FROM buildpack-deps
-
-RUN apt-get update && apt-get install -y \
-		ca-certificates \
-		curl
+FROM buildpack-deps:jessie
 
 # verify gpg and sha256: http://nodejs.org/dist/v0.10.31/SHASUMS256.txt.asc
 # gpg: aka "Timothy J Fontaine (Work) <tj.fontaine@joyent.com>"

--- a/0.10/slim/Dockerfile
+++ b/0.10/slim/Dockerfile
@@ -1,13 +1,4 @@
-FROM debian:wheezy
-
-RUN apt-get update && apt-get install -y --no-install-recommends \
-		ca-certificates \
-		curl \
-		build-essential \
-		pkg-config \
-		git \
-		python \
-	&& rm -rf /var/lib/apt/lists/*
+FROM debian:jessie
 
 # verify gpg and sha256: http://nodejs.org/dist/v0.10.31/SHASUMS256.txt.asc
 # gpg: aka "Timothy J Fontaine (Work) <tj.fontaine@joyent.com>"
@@ -17,12 +8,17 @@ RUN gpg --keyserver pool.sks-keyservers.net --recv-keys 7937DFD2AB06298B2293C318
 ENV NODE_VERSION 0.10.35
 ENV NPM_VERSION 2.2.0
 
-RUN curl -SLO "http://nodejs.org/dist/v$NODE_VERSION/node-v$NODE_VERSION-linux-x64.tar.gz" \
+RUN buildDeps='curl' \
+	&& set -x \
+	&& apt-get update && apt-get install -y $buildDeps --no-install-recommends \
+	&& rm -rf /var/lib/apt/lists/* \
+	&& curl -SLO "http://nodejs.org/dist/v$NODE_VERSION/node-v$NODE_VERSION-linux-x64.tar.gz" \
 	&& curl -SLO "http://nodejs.org/dist/v$NODE_VERSION/SHASUMS256.txt.asc" \
 	&& gpg --verify SHASUMS256.txt.asc \
 	&& grep " node-v$NODE_VERSION-linux-x64.tar.gz\$" SHASUMS256.txt.asc | sha256sum -c - \
 	&& tar -xzf "node-v$NODE_VERSION-linux-x64.tar.gz" -C /usr/local --strip-components=1 \
 	&& rm "node-v$NODE_VERSION-linux-x64.tar.gz" SHASUMS256.txt.asc \
+	&& apt-get purge -y --auto-remove $buildDeps \
 	&& npm install -g npm@"$NPM_VERSION" \
 	&& npm cache clear
 

--- a/0.11/Dockerfile
+++ b/0.11/Dockerfile
@@ -1,8 +1,4 @@
-FROM buildpack-deps
-
-RUN apt-get update && apt-get install -y \
-		ca-certificates \
-		curl
+FROM buildpack-deps:jessie
 
 # verify gpg and sha256: http://nodejs.org/dist/v0.10.30/SHASUMS256.txt.asc
 # gpg: aka "Timothy J Fontaine (Work) <tj.fontaine@joyent.com>"

--- a/0.11/slim/Dockerfile
+++ b/0.11/slim/Dockerfile
@@ -1,13 +1,4 @@
-FROM debian:wheezy
-
-RUN apt-get update && apt-get install -y --no-install-recommends \
-		ca-certificates \
-		curl \
-		build-essential \
-		pkg-config \
-		git \
-		python \
-	&& rm -rf /var/lib/apt/lists/*
+FROM debian:jessie
 
 # verify gpg and sha256: http://nodejs.org/dist/v0.10.30/SHASUMS256.txt.asc
 # gpg: aka "Timothy J Fontaine (Work) <tj.fontaine@joyent.com>"
@@ -17,12 +8,17 @@ RUN gpg --keyserver pool.sks-keyservers.net --recv-keys 7937DFD2AB06298B2293C318
 ENV NODE_VERSION 0.11.15
 ENV NPM_VERSION 2.2.0
 
-RUN curl -SLO "http://nodejs.org/dist/v$NODE_VERSION/node-v$NODE_VERSION-linux-x64.tar.gz" \
+RUN buildDeps='curl' \
+	&& set -x \
+	&& apt-get update && apt-get install -y $buildDeps --no-install-recommends \
+	&& rm -rf /var/lib/apt/lists/* \
+	&& curl -SLO "http://nodejs.org/dist/v$NODE_VERSION/node-v$NODE_VERSION-linux-x64.tar.gz" \
 	&& curl -SLO "http://nodejs.org/dist/v$NODE_VERSION/SHASUMS256.txt.asc" \
 	&& gpg --verify SHASUMS256.txt.asc \
 	&& grep " node-v$NODE_VERSION-linux-x64.tar.gz\$" SHASUMS256.txt.asc | sha256sum -c - \
 	&& tar -xzf "node-v$NODE_VERSION-linux-x64.tar.gz" -C /usr/local --strip-components=1 \
 	&& rm "node-v$NODE_VERSION-linux-x64.tar.gz" SHASUMS256.txt.asc \
+	&& apt-get purge -y --auto-remove $buildDeps \
 	&& npm install -g npm@"$NPM_VERSION" \
 	&& npm cache clear
 

--- a/0.8/Dockerfile
+++ b/0.8/Dockerfile
@@ -1,8 +1,4 @@
-FROM buildpack-deps
-
-RUN apt-get update && apt-get install -y \
-		ca-certificates \
-		curl
+FROM buildpack-deps:jessie
 
 # verify gpg and sha256: http://nodejs.org/dist/v0.10.30/SHASUMS256.txt.asc
 # gpg: aka "Timothy J Fontaine (Work) <tj.fontaine@joyent.com>"

--- a/0.8/slim/Dockerfile
+++ b/0.8/slim/Dockerfile
@@ -1,13 +1,4 @@
-FROM debian:wheezy
-
-RUN apt-get update && apt-get install -y --no-install-recommends \
-		ca-certificates \
-		curl \
-		build-essential \
-		pkg-config \
-		git \
-		python \
-	&& rm -rf /var/lib/apt/lists/*
+FROM debian:jessie
 
 # verify gpg and sha256: http://nodejs.org/dist/v0.10.30/SHASUMS256.txt.asc
 # gpg: aka "Timothy J Fontaine (Work) <tj.fontaine@joyent.com>"
@@ -17,12 +8,17 @@ RUN gpg --keyserver pool.sks-keyservers.net --recv-keys 7937DFD2AB06298B2293C318
 ENV NODE_VERSION 0.8.28
 ENV NPM_VERSION 2.2.0
 
-RUN curl -SLO "http://nodejs.org/dist/v$NODE_VERSION/node-v$NODE_VERSION-linux-x64.tar.gz" \
+RUN buildDeps='curl' \
+	&& set -x \
+	&& apt-get update && apt-get install -y $buildDeps --no-install-recommends \
+	&& rm -rf /var/lib/apt/lists/* \
+	&& curl -SLO "http://nodejs.org/dist/v$NODE_VERSION/node-v$NODE_VERSION-linux-x64.tar.gz" \
 	&& curl -SLO "http://nodejs.org/dist/v$NODE_VERSION/SHASUMS256.txt.asc" \
 	&& gpg --verify SHASUMS256.txt.asc \
 	&& grep " node-v$NODE_VERSION-linux-x64.tar.gz\$" SHASUMS256.txt.asc | sha256sum -c - \
 	&& tar -xzf "node-v$NODE_VERSION-linux-x64.tar.gz" -C /usr/local --strip-components=1 \
 	&& rm "node-v$NODE_VERSION-linux-x64.tar.gz" SHASUMS256.txt.asc \
+	&& apt-get purge -y --auto-remove $buildDeps \
 	&& npm install -g npm@1.4.28 \
 	&& npm install -g npm@"$NPM_VERSION" \
 	&& npm cache clear


### PR DESCRIPTION
This removes almost all of the dependencies from the slim variant.  The rationale for this is that the slim variants are intentionally supposed to be for people who really know what they're doing and want to create an image that's as small as is reasonably possible for their very specific use case (meaning that if they want to be able to, for example, `npm install` native modules, they'll need to know which packages that requires), where the normal variant is supposed to be as generic as possible for the majority of use cases (hence why it is `FROM buildpack-deps` -- see https://registry.hub.docker.com/_/buildpack-deps/ for more information about that and what's included there).

This also updates `FROM buildpack-deps` to be the more explicit (but currently equivalent) `FROM buildpack-deps:jessie`, and updated the slim variants to use `debian:jessie` instead of `debian:wheezy` so that they all have the same base underneath.

``` console
$ docker images node
REPOSITORY          TAG                 IMAGE ID            CREATED             VIRTUAL SIZE
node                0.8-slim            3c0b9c2ee34f        4 hours ago         286.3 MB
node                0.8                 45c9764d3191        4 hours ago         704.1 MB
node                0.11-slim           869731dd5c7f        4 hours ago         296.2 MB
node                0.11                c26e7af3ade7        4 hours ago         714 MB
node                0.10-slim           af6b79e3e7dd        4 hours ago         287.3 MB
node                0.10                9787c55efe92        4 hours ago         705 MB
$ ./generate-stackbrew-library.sh | sed 's!joyent/docker-node!infosiftr/node!' > node
$ bashbrew build ./node
Fetching node (git://github.com/infosiftr/node) ...
Processing node:0.10.35 ...
...
Processing node:0.8-slim ...
$ docker images node
REPOSITORY          TAG                 IMAGE ID            CREATED             VIRTUAL SIZE
node                0.8-slim            ef20a87f7564        39 seconds ago      149.3 MB
node                0.8                 a62c349fcfbd        2 minutes ago       694.6 MB
node                0.11-slim           9cf495665fa1        3 minutes ago       159.2 MB
node                0.11                9671c6b7befe        6 minutes ago       704.5 MB
node                0.10-slim           eda61ceff5e2        7 minutes ago       150.3 MB
node                0.10                2895ad48803c        10 minutes ago      695.6 MB
```
