### PR TITLE
npm install --production

### DIFF
--- a/0.10/onbuild/Dockerfile
+++ b/0.10/onbuild/Dockerfile
@@ -4,7 +4,7 @@ RUN mkdir -p /usr/src/app
 WORKDIR /usr/src/app
 
 ONBUILD COPY package.json /usr/src/app/
-ONBUILD RUN npm install
+ONBUILD RUN npm install --production
 ONBUILD COPY . /usr/src/app
 
 CMD [ "npm", "start" ]

--- a/0.12/onbuild/Dockerfile
+++ b/0.12/onbuild/Dockerfile
@@ -4,7 +4,7 @@ RUN mkdir -p /usr/src/app
 WORKDIR /usr/src/app
 
 ONBUILD COPY package.json /usr/src/app/
-ONBUILD RUN npm install
+ONBUILD RUN npm install --production
 ONBUILD COPY . /usr/src/app
 
 CMD [ "npm", "start" ]

--- a/0.8/onbuild/Dockerfile
+++ b/0.8/onbuild/Dockerfile
@@ -4,7 +4,7 @@ RUN mkdir -p /usr/src/app
 WORKDIR /usr/src/app
 
 ONBUILD COPY package.json /usr/src/app/
-ONBUILD RUN npm install
+ONBUILD RUN npm install --production
 ONBUILD COPY . /usr/src/app
 
 CMD [ "npm", "start" ]


### PR DESCRIPTION
Was there a reason not to use `npm install --production` in the `onbuild` Dockerfiles?

I found my `docker build` downloading all my dev dependencies and wondered...

Cheers