### PR TITLE
Update stackbrew for nodejs org change

### DIFF
--- a/generate-stackbrew-library.sh
+++ b/generate-stackbrew-library.sh
@@ -9,9 +9,9 @@ cd $(cd ${0%/*} && pwd -P);
 
 versions=( */ )
 versions=( "${versions[@]%/}" )
-url='git://github.com/joyent/docker-node'
+url='git://github.com/nodejs/docker-node'
 
-echo '# maintainer: Joyent Image Team <image-team@joyent.com> (@joyent)'
+echo '# maintainer: Node.js Docker Team <https://github.com/nodejs/docker-node> (@nodejs)'
 
 for version in "${versions[@]}"; do
 	eval stub=$(echo "$version" | awk -F. '{ print "$array_" $1 "_" $2 }');


### PR DESCRIPTION
This updates the generate-stackbrew-library.sh script to reflect the recent org change to nodejs. Once this lands I'll proceed with the pull request to https://github.com/docker-library/official-images to get things updated.

cc @nodejs/docker 