### PR TITLE
Node 4.0.0

### DIFF
--- a/4.0/Dockerfile
+++ b/4.0/Dockerfile
@@ -1,0 +1,26 @@
+FROM buildpack-deps:jessie
+
+# gpg keys listed at https://github.com/nodejs/node
+RUN set -ex \
+  && for key in \
+    9554F04D7259F04124DE6B476D5A82AC7E37093B \
+    94AE36675C464D64BAFA68DD7434390BDBE9B9C5 \
+    0034A06D9D9B0064CE8ADF6BF1747F4AD2306D93 \
+    FD3A5288F042B6850C66B31F09FE44734EB7990E \
+    71DCFD284A79C3B38668286BC97EC7A07EDE3FC1 \
+    DD8F2338BAE7501E3DD5AC78C273792F7D83545D \
+  ; do \
+    gpg --keyserver ha.pool.sks-keyservers.net --recv-keys "$key" \
+  done
+
+ENV NPM_CONFIG_LOGLEVEL info
+ENV NODE_VERSION 4.0.0
+
+RUN curl -SLO "https://nodejs.org/dist/v$NODE_VERSION/node-v$NODE_VERSION-linux-x64.tar.gz" \
+  && curl -SLO "https://nodejs.org/dist/v$NODE_VERSION/SHASUMS256.txt.asc" \
+  && gpg --verify SHASUMS256.txt.asc \
+  && grep " node-v$NODE_VERSION-linux-x64.tar.gz\$" SHASUMS256.txt.asc | sha256sum -c - \
+  && tar -xzf "node-v$NODE_VERSION-linux-x64.tar.gz" -C /usr/local --strip-components=1 \
+  && rm "node-v$NODE_VERSION-linux-x64.tar.gz" SHASUMS256.txt.asc
+
+CMD [ "node" ]

--- a/4.0/Dockerfile
+++ b/4.0/Dockerfile
@@ -10,7 +10,7 @@ RUN set -ex \
     71DCFD284A79C3B38668286BC97EC7A07EDE3FC1 \
     DD8F2338BAE7501E3DD5AC78C273792F7D83545D \
   ; do \
-    gpg --keyserver ha.pool.sks-keyservers.net --recv-keys "$key" \
+    gpg --keyserver ha.pool.sks-keyservers.net --recv-keys "$key"; \
   done
 
 ENV NPM_CONFIG_LOGLEVEL info

--- a/4.0/onbuild/Dockerfile
+++ b/4.0/onbuild/Dockerfile
@@ -1,0 +1,10 @@
+FROM node:4.0.0
+
+RUN mkdir -p /usr/src/app
+WORKDIR /usr/src/app
+
+ONBUILD COPY package.json /usr/src/app/
+ONBUILD RUN npm install
+ONBUILD COPY . /usr/src/app
+
+CMD [ "npm", "start" ]

--- a/4.0/slim/Dockerfile
+++ b/4.0/slim/Dockerfile
@@ -1,0 +1,26 @@
+FROM buildpack-deps:jessie-curl
+
+# gpg keys listed at https://github.com/nodejs/node
+RUN set -ex \
+  && for key in \
+    9554F04D7259F04124DE6B476D5A82AC7E37093B \
+    94AE36675C464D64BAFA68DD7434390BDBE9B9C5 \
+    0034A06D9D9B0064CE8ADF6BF1747F4AD2306D93 \
+    FD3A5288F042B6850C66B31F09FE44734EB7990E \
+    71DCFD284A79C3B38668286BC97EC7A07EDE3FC1 \
+    DD8F2338BAE7501E3DD5AC78C273792F7D83545D \
+  ; do \
+    gpg --keyserver ha.pool.sks-keyservers.net --recv-keys "$key" \
+  done
+
+ENV NPM_CONFIG_LOGLEVEL info
+ENV NODE_VERSION 4.0.0
+
+RUN curl -SLO "https://nodejs.org/dist/v$NODE_VERSION/node-v$NODE_VERSION-linux-x64.tar.gz" \
+  && curl -SLO "https://nodejs.org/dist/v$NODE_VERSION/SHASUMS256.txt.asc" \
+  && gpg --verify SHASUMS256.txt.asc \
+  && grep " node-v$NODE_VERSION-linux-x64.tar.gz\$" SHASUMS256.txt.asc | sha256sum -c - \
+  && tar -xzf "node-v$NODE_VERSION-linux-x64.tar.gz" -C /usr/local --strip-components=1 \
+  && rm "node-v$NODE_VERSION-linux-x64.tar.gz" SHASUMS256.txt.asc
+
+CMD [ "node" ]

--- a/4.0/slim/Dockerfile
+++ b/4.0/slim/Dockerfile
@@ -10,7 +10,7 @@ RUN set -ex \
     71DCFD284A79C3B38668286BC97EC7A07EDE3FC1 \
     DD8F2338BAE7501E3DD5AC78C273792F7D83545D \
   ; do \
-    gpg --keyserver ha.pool.sks-keyservers.net --recv-keys "$key" \
+    gpg --keyserver ha.pool.sks-keyservers.net --recv-keys "$key"; \
   done
 
 ENV NPM_CONFIG_LOGLEVEL info

--- a/4.0/wheezy/Dockerfile
+++ b/4.0/wheezy/Dockerfile
@@ -1,0 +1,26 @@
+FROM buildpack-deps:wheezy
+
+# gpg keys listed at https://github.com/nodejs/node
+RUN set -ex \
+  && for key in \
+    9554F04D7259F04124DE6B476D5A82AC7E37093B \
+    94AE36675C464D64BAFA68DD7434390BDBE9B9C5 \
+    0034A06D9D9B0064CE8ADF6BF1747F4AD2306D93 \
+    FD3A5288F042B6850C66B31F09FE44734EB7990E \
+    71DCFD284A79C3B38668286BC97EC7A07EDE3FC1 \
+    DD8F2338BAE7501E3DD5AC78C273792F7D83545D \
+  ; do \
+    gpg --keyserver ha.pool.sks-keyservers.net --recv-keys "$key" \
+  done
+
+ENV NPM_CONFIG_LOGLEVEL info
+ENV NODE_VERSION 4.0.0
+
+RUN curl -SLO "https://nodejs.org/dist/v$NODE_VERSION/node-v$NODE_VERSION-linux-x64.tar.gz" \
+  && curl -SLO "https://nodejs.org/dist/v$NODE_VERSION/SHASUMS256.txt.asc" \
+  && gpg --verify SHASUMS256.txt.asc \
+  && grep " node-v$NODE_VERSION-linux-x64.tar.gz\$" SHASUMS256.txt.asc | sha256sum -c - \
+  && tar -xzf "node-v$NODE_VERSION-linux-x64.tar.gz" -C /usr/local --strip-components=1 \
+  && rm "node-v$NODE_VERSION-linux-x64.tar.gz" SHASUMS256.txt.asc
+
+CMD [ "node" ]

--- a/4.0/wheezy/Dockerfile
+++ b/4.0/wheezy/Dockerfile
@@ -10,7 +10,7 @@ RUN set -ex \
     71DCFD284A79C3B38668286BC97EC7A07EDE3FC1 \
     DD8F2338BAE7501E3DD5AC78C273792F7D83545D \
   ; do \
-    gpg --keyserver ha.pool.sks-keyservers.net --recv-keys "$key" \
+    gpg --keyserver ha.pool.sks-keyservers.net --recv-keys "$key"; \
   done
 
 ENV NPM_CONFIG_LOGLEVEL info

--- a/generate-stackbrew-library.sh
+++ b/generate-stackbrew-library.sh
@@ -3,7 +3,7 @@ set -e
 
 hash git 2>/dev/null || { echo >&2 "git not found, exiting."; }
 
-array_0_12='0 latest';
+array_4_0='0 latest';
 
 cd $(cd ${0%/*} && pwd -P);
 


### PR DESCRIPTION
This adds Node.js v4.0.0 and sets it as the "latest" image.

Things to note:

- The slim variant is based on iojs version of slim which is based off buildpack-deps:jessie-curl. This seemed a cleaner way to go rather than the fancy footwork approach of install/uninstalling curl and ca-certificates that was done in the slim variants of 0.10 and 0.12.
- I'm including a wheezy variant similar to the Node.js 0.10 and 0.12 to keep things consistent.
- generate-stackbrew-library.sh has been updated to set "latest" to 4.0
- https://github.com/nodejs/docker-node/pull/41 will need to be merged first to avoid conflicts

Test build via test-build.sh passes :)

Closes #39

cc @nodejs/docker