### PR TITLE
Update to 4.2.1

### DIFF
--- a/4.2/Dockerfile
+++ b/4.2/Dockerfile
@@ -14,7 +14,7 @@ RUN set -ex \
   done
 
 ENV NPM_CONFIG_LOGLEVEL info
-ENV NODE_VERSION 4.2.0
+ENV NODE_VERSION 4.2.1
 
 RUN curl -SLO "https://nodejs.org/dist/v$NODE_VERSION/node-v$NODE_VERSION-linux-x64.tar.gz" \
   && curl -SLO "https://nodejs.org/dist/v$NODE_VERSION/SHASUMS256.txt.asc" \

--- a/4.2/onbuild/Dockerfile
+++ b/4.2/onbuild/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:4.2.0
+FROM node:4.2.1
 
 RUN mkdir -p /usr/src/app
 WORKDIR /usr/src/app

--- a/4.2/slim/Dockerfile
+++ b/4.2/slim/Dockerfile
@@ -14,7 +14,7 @@ RUN set -ex \
   done
 
 ENV NPM_CONFIG_LOGLEVEL info
-ENV NODE_VERSION 4.2.0
+ENV NODE_VERSION 4.2.1
 
 RUN curl -SLO "https://nodejs.org/dist/v$NODE_VERSION/node-v$NODE_VERSION-linux-x64.tar.gz" \
   && curl -SLO "https://nodejs.org/dist/v$NODE_VERSION/SHASUMS256.txt.asc" \

--- a/4.2/wheezy/Dockerfile
+++ b/4.2/wheezy/Dockerfile
@@ -14,7 +14,7 @@ RUN set -ex \
   done
 
 ENV NPM_CONFIG_LOGLEVEL info
-ENV NODE_VERSION 4.2.0
+ENV NODE_VERSION 4.2.1
 
 RUN curl -SLO "https://nodejs.org/dist/v$NODE_VERSION/node-v$NODE_VERSION-linux-x64.tar.gz" \
   && curl -SLO "https://nodejs.org/dist/v$NODE_VERSION/SHASUMS256.txt.asc" \


### PR DESCRIPTION
Update Node.js to v4.2.1 ('Argon' (LTS) Release)

Related: nodejs/node#3337
