### PR TITLE
Fix typo in README's docker build command.

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ EXPOSE 8080
 Then simply run:
 
 ```
-$ docker build -t node-app
+$ docker build -t node-app .
 ...
 $ docker run --rm -it node-app
 ```


### PR DESCRIPTION
It's a minor update but the command will not work without giving it a path (`.` in this case).