### PR TITLE
0.12.8

### DIFF
--- a/0.12/Dockerfile
+++ b/0.12/Dockerfile
@@ -1,15 +1,17 @@
 FROM buildpack-deps:jessie
 
-# verify gpg and sha256: http://nodejs.org/dist/v0.10.30/SHASUMS256.txt.asc
-# gpg: aka "Timothy J Fontaine (Work) <tj.fontaine@joyent.com>"
-# gpg: aka "Julien Gilli <jgilli@fastmail.fm>"
+# gpg keys listed at https://github.com/nodejs/node
 RUN set -ex \
-	&& for key in \
-		7937DFD2AB06298B2293C3187D33FF9D0246406D \
-		114F43EE0176B71C7BC219DD50A3051F888C628D \
-	; do \
-		gpg --keyserver ha.pool.sks-keyservers.net --recv-keys "$key"; \
-	done
+  && for key in \
+    9554F04D7259F04124DE6B476D5A82AC7E37093B \
+    94AE36675C464D64BAFA68DD7434390BDBE9B9C5 \
+    0034A06D9D9B0064CE8ADF6BF1747F4AD2306D93 \
+    FD3A5288F042B6850C66B31F09FE44734EB7990E \
+    71DCFD284A79C3B38668286BC97EC7A07EDE3FC1 \
+    DD8F2338BAE7501E3DD5AC78C273792F7D83545D \
+  ; do \
+    gpg --keyserver ha.pool.sks-keyservers.net --recv-keys "$key"; \
+  done
 
 ENV NODE_VERSION 0.12.8
 ENV NPM_VERSION 3.4.1

--- a/0.12/Dockerfile
+++ b/0.12/Dockerfile
@@ -11,8 +11,8 @@ RUN set -ex \
 		gpg --keyserver ha.pool.sks-keyservers.net --recv-keys "$key"; \
 	done
 
-ENV NODE_VERSION 0.12.7
-ENV NPM_VERSION 2.14.1
+ENV NODE_VERSION 0.12.8
+ENV NPM_VERSION 3.4.1
 
 RUN curl -SLO "https://nodejs.org/dist/v$NODE_VERSION/node-v$NODE_VERSION-linux-x64.tar.gz" \
 	&& curl -SLO "https://nodejs.org/dist/v$NODE_VERSION/SHASUMS256.txt.asc" \

--- a/0.12/onbuild/Dockerfile
+++ b/0.12/onbuild/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:0.12.7
+FROM node:0.12.8
 
 RUN mkdir -p /usr/src/app
 WORKDIR /usr/src/app

--- a/0.12/slim/Dockerfile
+++ b/0.12/slim/Dockerfile
@@ -11,8 +11,8 @@ RUN set -ex \
 		gpg --keyserver ha.pool.sks-keyservers.net --recv-keys "$key"; \
 	done
 
-ENV NODE_VERSION 0.12.7
-ENV NPM_VERSION 2.14.1
+ENV NODE_VERSION 0.12.8
+ENV NPM_VERSION 3.4.1
 
 RUN buildDeps='curl ca-certificates' \
 	&& set -x \

--- a/0.12/slim/Dockerfile
+++ b/0.12/slim/Dockerfile
@@ -1,15 +1,17 @@
 FROM debian:jessie
 
-# verify gpg and sha256: http://nodejs.org/dist/v0.10.30/SHASUMS256.txt.asc
-# gpg: aka "Timothy J Fontaine (Work) <tj.fontaine@joyent.com>"
-# gpg: aka "Julien Gilli <jgilli@fastmail.fm>"
+# gpg keys listed at https://github.com/nodejs/node
 RUN set -ex \
-	&& for key in \
-		7937DFD2AB06298B2293C3187D33FF9D0246406D \
-		114F43EE0176B71C7BC219DD50A3051F888C628D \
-	; do \
-		gpg --keyserver ha.pool.sks-keyservers.net --recv-keys "$key"; \
-	done
+  && for key in \
+    9554F04D7259F04124DE6B476D5A82AC7E37093B \
+    94AE36675C464D64BAFA68DD7434390BDBE9B9C5 \
+    0034A06D9D9B0064CE8ADF6BF1747F4AD2306D93 \
+    FD3A5288F042B6850C66B31F09FE44734EB7990E \
+    71DCFD284A79C3B38668286BC97EC7A07EDE3FC1 \
+    DD8F2338BAE7501E3DD5AC78C273792F7D83545D \
+  ; do \
+    gpg --keyserver ha.pool.sks-keyservers.net --recv-keys "$key"; \
+  done
 
 ENV NODE_VERSION 0.12.8
 ENV NPM_VERSION 3.4.1

--- a/0.12/wheezy/Dockerfile
+++ b/0.12/wheezy/Dockerfile
@@ -1,15 +1,17 @@
 FROM buildpack-deps:wheezy
 
-# verify gpg and sha256: http://nodejs.org/dist/v0.10.30/SHASUMS256.txt.asc
-# gpg: aka "Timothy J Fontaine (Work) <tj.fontaine@joyent.com>"
-# gpg: aka "Julien Gilli <jgilli@fastmail.fm>"
+# gpg keys listed at https://github.com/nodejs/node
 RUN set -ex \
-	&& for key in \
-		7937DFD2AB06298B2293C3187D33FF9D0246406D \
-		114F43EE0176B71C7BC219DD50A3051F888C628D \
-	; do \
-		gpg --keyserver ha.pool.sks-keyservers.net --recv-keys "$key"; \
-	done
+  && for key in \
+    9554F04D7259F04124DE6B476D5A82AC7E37093B \
+    94AE36675C464D64BAFA68DD7434390BDBE9B9C5 \
+    0034A06D9D9B0064CE8ADF6BF1747F4AD2306D93 \
+    FD3A5288F042B6850C66B31F09FE44734EB7990E \
+    71DCFD284A79C3B38668286BC97EC7A07EDE3FC1 \
+    DD8F2338BAE7501E3DD5AC78C273792F7D83545D \
+  ; do \
+    gpg --keyserver ha.pool.sks-keyservers.net --recv-keys "$key"; \
+  done
 
 ENV NODE_VERSION 0.12.8
 ENV NPM_VERSION 3.4.1

--- a/0.12/wheezy/Dockerfile
+++ b/0.12/wheezy/Dockerfile
@@ -11,8 +11,8 @@ RUN set -ex \
 		gpg --keyserver ha.pool.sks-keyservers.net --recv-keys "$key"; \
 	done
 
-ENV NODE_VERSION 0.12.7
-ENV NPM_VERSION 2.14.1
+ENV NODE_VERSION 0.12.8
+ENV NPM_VERSION 3.4.1
 
 RUN curl -SLO "https://nodejs.org/dist/v$NODE_VERSION/node-v$NODE_VERSION-linux-x64.tar.gz" \
 	&& curl -SLO "https://nodejs.org/dist/v$NODE_VERSION/SHASUMS256.txt.asc" \


### PR DESCRIPTION
This updates the 0.12 version to 0.12.8 and also updates npm to 3.4.1.

Also note that this updates the gpg keys to use those listed at https://github.com/nodejs/node

Reference: 

- https://github.com/nodejs/node/pull/2806
- https://nodejs.org/en/blog/release/v0.12.8/

Test build ran successfully via test-build.sh 