### PR TITLE
Upgrade Node to 5.4.1

### DIFF
--- a/5.4/Dockerfile
+++ b/5.4/Dockerfile
@@ -14,7 +14,7 @@ RUN set -ex \
   done
 
 ENV NPM_CONFIG_LOGLEVEL info
-ENV NODE_VERSION 5.4.0
+ENV NODE_VERSION 5.4.1
 
 RUN curl -SLO "https://nodejs.org/dist/v$NODE_VERSION/node-v$NODE_VERSION-linux-x64.tar.gz" \
   && curl -SLO "https://nodejs.org/dist/v$NODE_VERSION/SHASUMS256.txt.asc" \

--- a/5.4/onbuild/Dockerfile
+++ b/5.4/onbuild/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:5.4.0
+FROM node:5.4.1
 
 RUN mkdir -p /usr/src/app
 WORKDIR /usr/src/app

--- a/5.4/slim/Dockerfile
+++ b/5.4/slim/Dockerfile
@@ -14,7 +14,7 @@ RUN set -ex \
   done
 
 ENV NPM_CONFIG_LOGLEVEL info
-ENV NODE_VERSION 5.4.0
+ENV NODE_VERSION 5.4.1
 
 RUN curl -SLO "https://nodejs.org/dist/v$NODE_VERSION/node-v$NODE_VERSION-linux-x64.tar.gz" \
   && curl -SLO "https://nodejs.org/dist/v$NODE_VERSION/SHASUMS256.txt.asc" \

--- a/5.4/wheezy/Dockerfile
+++ b/5.4/wheezy/Dockerfile
@@ -14,7 +14,7 @@ RUN set -ex \
   done
 
 ENV NPM_CONFIG_LOGLEVEL info
-ENV NODE_VERSION 5.4.0
+ENV NODE_VERSION 5.4.1
 
 RUN curl -SLO "https://nodejs.org/dist/v$NODE_VERSION/node-v$NODE_VERSION-linux-x64.tar.gz" \
   && curl -SLO "https://nodejs.org/dist/v$NODE_VERSION/SHASUMS256.txt.asc" \


### PR DESCRIPTION
This PR upgrades Node.js to v5.4.1.

Related: nodejs/node#4626

Signed-off-by: Hans Kristian Flaatten <hans.kristian.flaatten@dnt.no>