### PR TITLE
Add an Alpine variant.

### DIFF
--- a/4.3/alpine/Dockerfile
+++ b/4.3/alpine/Dockerfile
@@ -1,0 +1,66 @@
+FROM alpine:latest
+
+ENV NPM_CONFIG_LOGLEVEL info
+ENV NODE_VERSION=4.3.1
+
+RUN apk --no-cache update \
+    && apk --no-cache upgrade \
+    && apk add --no-cache icu libintl libuv \
+    && apk add --no-cache --virtual .build-deps \
+        gcc \
+        libgcc \
+        g++ \
+        libstdc++ \
+        make \
+        python \
+        linux-headers \
+        zlib-dev \
+        libuv-dev \
+        paxctl \
+        binutils-gold \
+        gnupg \
+        curl \
+        icu-dev \
+        openssl-dev \
+    && for key in \
+        9554F04D7259F04124DE6B476D5A82AC7E37093B \
+        94AE36675C464D64BAFA68DD7434390BDBE9B9C5 \
+        0034A06D9D9B0064CE8ADF6BF1747F4AD2306D93 \
+        FD3A5288F042B6850C66B31F09FE44734EB7990E \
+        71DCFD284A79C3B38668286BC97EC7A07EDE3FC1 \
+        DD8F2338BAE7501E3DD5AC78C273792F7D83545D \
+        B9AE9905FFD7803F25714661B63B535A4C206CA9 \
+        C4F0DFFF4E8C1A8236409D08E73BC641CC11F4C8 \
+    ; do \
+        gpg --keyserver ha.pool.sks-keyservers.net --recv-keys "$key"; \
+    done \
+    && curl -SLO "https://nodejs.org/dist/v$NODE_VERSION/node-v$NODE_VERSION.tar.xz" \
+    && curl -SLO "https://nodejs.org/dist/v$NODE_VERSION/SHASUMS256.txt.asc" \
+    && gpg --verify SHASUMS256.txt.asc \
+    && grep " node-v$NODE_VERSION.tar.xz\$" SHASUMS256.txt.asc | sha256sum -c - \
+    && mkdir -p /usr/src \
+    && tar -xJf "node-v$NODE_VERSION.tar.xz" -C /usr/src \
+    && rm node-v$NODE_VERSION.tar.xz SHASUMS256.txt.asc \
+    && cd "/usr/src/node-v$NODE_VERSION" \
+    && ./configure --prefix=/usr --with-intl=system-icu --shared-zlib --shared-libuv --shared-openssl \
+    && make -j$(getconf _NPROCESSORS_ONLN) -C out mksnapshot BUILDTYPE=Release \
+    && paxctl -cm out/Release/mksnapshot \
+    && make -j$(getconf _NPROCESSORS_ONLN) \
+    && make install \
+    && paxctl -cm /usr/bin/node \
+    && cd / \
+    && apk del --virtual .build-deps \
+    && rm -rf \
+        /usr/src/* \
+        /usr/share/doc \
+        /usr/share/man \
+        /usr/share/doc \
+        /tmp/* \
+        /var/cache/apk/* \
+        /root/.npm \
+        /root/.node-gyp \
+        /usr/lib/node_modules/npm/man \
+        /usr/lib/node_modules/npm/doc \
+        /usr/lib/node_modules/npm/html
+
+CMD [ "node" ]

--- a/4.3/alpine/Dockerfile
+++ b/4.3/alpine/Dockerfile
@@ -1,12 +1,11 @@
-FROM alpine:latest
+FROM alpine:edge
 
 ENV NPM_CONFIG_LOGLEVEL info
 ENV NODE_VERSION=4.3.1
 
-RUN apk --no-cache update \
-    && apk --no-cache upgrade \
-    && apk add --no-cache icu libintl libuv \
-    && apk add --no-cache --virtual .build-deps \
+RUN apk update --upgrade \
+    && apk add icu libintl libuv \
+    && apk add --virtual .build-deps \
         gcc \
         libgcc \
         g++ \

--- a/5.7/alpine/Dockerfile
+++ b/5.7/alpine/Dockerfile
@@ -1,12 +1,11 @@
-FROM alpine:latest
+FROM alpine:edge
 
 ENV NPM_CONFIG_LOGLEVEL info
 ENV NODE_VERSION=5.7.0
 
-RUN apk --no-cache update \
-    && apk --no-cache upgrade \
-    && apk add --no-cache icu libintl libuv \
-    && apk add --no-cache --virtual .build-deps \
+RUN apk update --upgrade \
+    && apk add icu libintl libuv \
+    && apk add --virtual .build-deps \
         gcc \
         libgcc \
         g++ \

--- a/5.7/alpine/Dockerfile
+++ b/5.7/alpine/Dockerfile
@@ -1,0 +1,66 @@
+FROM alpine:latest
+
+ENV NPM_CONFIG_LOGLEVEL info
+ENV NODE_VERSION=5.7.0
+
+RUN apk --no-cache update \
+    && apk --no-cache upgrade \
+    && apk add --no-cache icu libintl libuv \
+    && apk add --no-cache --virtual .build-deps \
+        gcc \
+        libgcc \
+        g++ \
+        libstdc++ \
+        make \
+        python \
+        linux-headers \
+        zlib-dev \
+        libuv-dev \
+        paxctl \
+        binutils-gold \
+        gnupg \
+        curl \
+        icu-dev \
+        openssl-dev \
+    && for key in \
+        9554F04D7259F04124DE6B476D5A82AC7E37093B \
+        94AE36675C464D64BAFA68DD7434390BDBE9B9C5 \
+        0034A06D9D9B0064CE8ADF6BF1747F4AD2306D93 \
+        FD3A5288F042B6850C66B31F09FE44734EB7990E \
+        71DCFD284A79C3B38668286BC97EC7A07EDE3FC1 \
+        DD8F2338BAE7501E3DD5AC78C273792F7D83545D \
+        B9AE9905FFD7803F25714661B63B535A4C206CA9 \
+        C4F0DFFF4E8C1A8236409D08E73BC641CC11F4C8 \
+    ; do \
+        gpg --keyserver ha.pool.sks-keyservers.net --recv-keys "$key"; \
+    done \
+    && curl -SLO "https://nodejs.org/dist/v$NODE_VERSION/node-v$NODE_VERSION.tar.xz" \
+    && curl -SLO "https://nodejs.org/dist/v$NODE_VERSION/SHASUMS256.txt.asc" \
+    && gpg --verify SHASUMS256.txt.asc \
+    && grep " node-v$NODE_VERSION.tar.xz\$" SHASUMS256.txt.asc | sha256sum -c - \
+    && mkdir -p /usr/src \
+    && tar -xJf "node-v$NODE_VERSION.tar.xz" -C /usr/src \
+    && rm node-v$NODE_VERSION.tar.xz SHASUMS256.txt.asc \
+    && cd "/usr/src/node-v$NODE_VERSION" \
+    && ./configure --prefix=/usr --with-intl=system-icu --shared-zlib --shared-libuv --shared-openssl \
+    && make -j$(getconf _NPROCESSORS_ONLN) -C out mksnapshot BUILDTYPE=Release \
+    && paxctl -cm out/Release/mksnapshot \
+    && make -j$(getconf _NPROCESSORS_ONLN) \
+    && make install \
+    && paxctl -cm /usr/bin/node \
+    && cd / \
+    && apk del --virtual .build-deps \
+    && rm -rf \
+        /usr/src/* \
+        /usr/share/doc \
+        /usr/share/man \
+        /usr/share/doc \
+        /tmp/* \
+        /var/cache/apk/* \
+        /root/.npm \
+        /root/.node-gyp \
+        /usr/lib/node_modules/npm/man \
+        /usr/lib/node_modules/npm/doc \
+        /usr/lib/node_modules/npm/html
+
+CMD [ "node" ]

--- a/generate-stackbrew-library.sh
+++ b/generate-stackbrew-library.sh
@@ -27,7 +27,7 @@ for version in "${versions[@]}"; do
 		echo "$va: ${url}@${commit} $version"
 	done
 
-	for variant in onbuild slim wheezy; do
+	for variant in onbuild slim wheezy alpine; do
 		commit="$(git log -1 --format='format:%H' -- "$version/$variant")"
 		echo
 		for va in "${versionAliases[@]}"; do

--- a/test-build.sh
+++ b/test-build.sh
@@ -37,7 +37,7 @@ for version in "${versions[@]}"; do
     info "Build of $tag succeeded."
   fi
   
-  variants=( onbuild slim wheezy )
+  variants=( onbuild slim wheezy alpine )
   
   for variant in "${variants[@]}"; do
     info "Building $tag-$variant variant..."

--- a/update-npm.sh
+++ b/update-npm.sh
@@ -17,7 +17,7 @@ for version in "${versions[@]}"; do
 	(
 		sed -E -i.bak '
 			s/^(ENV NPM_VERSION) .*/\1 '"$npmVersion"'/;
-		' "$version/Dockerfile" "$version/slim/Dockerfile" "$version/wheezy/Dockerfile"
-		rm $version/Dockerfile.bak $version/slim/Dockerfile.bak $version/wheezy/Dockerfile.bak
+		' "$version/Dockerfile" "$version/slim/Dockerfile" "$version/wheezy/Dockerfile"  "$version/alpine/Dockerfile"
+		rm $version/Dockerfile.bak $version/slim/Dockerfile.bak $version/wheezy/Dockerfile.bak $version/alpine/Dockerfile.bak
 	)
 done

--- a/update.sh
+++ b/update.sh
@@ -14,8 +14,8 @@ for version in "${versions[@]}"; do
 	(
 		sed -E -i.bak '
 			s/^(ENV NODE_VERSION) .*/\1 '"$version.$fullVersion"'/;
-		' "$version/Dockerfile" "$version/slim/Dockerfile" "$version/wheezy/Dockerfile"
-		rm $version/Dockerfile.bak $version/slim/Dockerfile.bak $version/wheezy/Dockerfile.bak
+		' "$version/Dockerfile" "$version/slim/Dockerfile" "$version/wheezy/Dockerfile" "$version/alpine/Dockerfile"
+		rm $version/Dockerfile.bak $version/slim/Dockerfile.bak $version/wheezy/Dockerfile.bak $version/alpine/Dockerfile.bak
 
 		sed -E -i.bak 's/^(FROM node):.*/\1:'"$version.$fullVersion"'/' "$version/onbuild/Dockerfile"
 		rm $version/onbuild/Dockerfile.bak


### PR DESCRIPTION
Fixes #46.

Because of alpine libmusl we have to compile nodejs, we can't simply download & use the official binary tarballs.

This PR is inspired from https://github.com/mhart/alpine-node (except node wasn't compiled like official binary distributions are, with the small-icu option.)