### PR TITLE
Update for Node.js 5.7.1

### DIFF
--- a/5.7/Dockerfile
+++ b/5.7/Dockerfile
@@ -16,7 +16,7 @@ RUN set -ex \
   done
 
 ENV NPM_CONFIG_LOGLEVEL info
-ENV NODE_VERSION 5.7.0
+ENV NODE_VERSION 5.7.1
 
 RUN curl -SLO "https://nodejs.org/dist/v$NODE_VERSION/node-v$NODE_VERSION-linux-x64.tar.xz" \
   && curl -SLO "https://nodejs.org/dist/v$NODE_VERSION/SHASUMS256.txt.asc" \

--- a/5.7/onbuild/Dockerfile
+++ b/5.7/onbuild/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:5.7.0
+FROM node:5.7.1
 
 RUN mkdir -p /usr/src/app
 WORKDIR /usr/src/app

--- a/5.7/slim/Dockerfile
+++ b/5.7/slim/Dockerfile
@@ -16,7 +16,7 @@ RUN set -ex \
   done
 
 ENV NPM_CONFIG_LOGLEVEL info
-ENV NODE_VERSION 5.7.0
+ENV NODE_VERSION 5.7.1
 
 RUN buildDeps='xz-utils' \
     && set -x \

--- a/5.7/wheezy/Dockerfile
+++ b/5.7/wheezy/Dockerfile
@@ -16,7 +16,7 @@ RUN set -ex \
   done
 
 ENV NPM_CONFIG_LOGLEVEL info
-ENV NODE_VERSION 5.7.0
+ENV NODE_VERSION 5.7.1
 
 RUN curl -SLO "https://nodejs.org/dist/v$NODE_VERSION/node-v$NODE_VERSION-linux-x64.tar.xz" \
   && curl -SLO "https://nodejs.org/dist/v$NODE_VERSION/SHASUMS256.txt.asc" \


### PR DESCRIPTION
Per https://github.com/nodejs/node/pull/5464 and https://nodejs.org/en/blog/release/v5.7.1/