### PR TITLE
Exclude docs directory. Fixes #126

### DIFF
--- a/generate-stackbrew-library.sh
+++ b/generate-stackbrew-library.sh
@@ -16,6 +16,9 @@ url='git://github.com/nodejs/docker-node'
 echo '# maintainer: Node.js Docker Team <https://github.com/nodejs/docker-node> (@nodejs)'
 
 for version in "${versions[@]}"; do
+	if [[ "$version" == "docs" ]]; then
+		continue
+	fi
 	eval stub=$(echo "$version" | awk -F. '{ print "$array_" $1 "_" $2 }');
 	commit="$(git log -1 --format='format:%H' -- "$version")"
 	fullVersion="$(grep -m1 'ENV NODE_VERSION ' "$version/Dockerfile" | cut -d' ' -f3)"

--- a/test-build.sh
+++ b/test-build.sh
@@ -25,6 +25,9 @@ fi
 versions=( "${versions[@]%/}" )
 
 for version in "${versions[@]}"; do
+  if [[ "$version" == "docs" ]]; then
+    continue
+  fi
   
   tag=$(cat $version/Dockerfile | grep "ENV NODE_VERSION" | cut -d' ' -f3)
   

--- a/update.sh
+++ b/update.sh
@@ -10,6 +10,10 @@ fi
 versions=( "${versions[@]%/}" )
 
 for version in "${versions[@]}"; do
+	if [[ "$version" == "docs" ]]; then
+		continue
+	fi
+
 	fullVersion="$(curl -sSL --compressed 'https://nodejs.org/dist' | grep '<a href="v'"$version." | sed -E 's!.*<a href="v([^"/]+)/?".*!\1!' | cut -f 3 -d . | sort -n | tail -1)"
 	(
 		sed -E -i.bak '


### PR DESCRIPTION
I added some logic to the maintenance scripts to exclude the new "docs" directory. Previously the scripts treated all directories as if they were "image" versions.