### PR TITLE
Enable travis-ci test builds. Closes #13

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,7 @@
+sudo: required
+
+services:
+    - docker
+  
+script:
+    - ./test-build.sh


### PR DESCRIPTION
This enables Travis-CI for a simple test build of the docker-node images. This will streamline image updates a bit as the build test we use (via ./testbuild.sh) will happen automatically for pull requests etc.

We'll need Travis-CI enabled for this GitHub repo as well.

I'll do a follow-up PR to the README.md so it shows the build status :)