### PR TITLE
Use buildpack-deps:jessie-curl for 0.10 and 0.12 slim images. See #144

### DIFF
--- a/0.10/slim/Dockerfile
+++ b/0.10/slim/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:jessie
+FROM buildpack-deps:jessie-curl
 
 # gpg keys listed at https://github.com/nodejs/node
 RUN set -ex \
@@ -17,7 +17,7 @@ RUN set -ex \
 
 ENV NODE_VERSION 0.10.44
 
-RUN buildDeps='curl ca-certificates xz-utils' \
+RUN buildDeps='xz-utils' \
 	&& set -x \
 	&& apt-get update && apt-get install -y $buildDeps --no-install-recommends \
 	&& rm -rf /var/lib/apt/lists/* \

--- a/0.12/slim/Dockerfile
+++ b/0.12/slim/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:jessie
+FROM buildpack-deps:jessie-curl
 
 # gpg keys listed at https://github.com/nodejs/node
 RUN set -ex \
@@ -17,7 +17,7 @@ RUN set -ex \
 
 ENV NODE_VERSION 0.12.13
 
-RUN buildDeps='curl ca-certificates xz-utils' \
+RUN buildDeps='xz-utils' \
 	&& set -x \
 	&& apt-get update && apt-get install -y $buildDeps --no-install-recommends \
 	&& rm -rf /var/lib/apt/lists/* \


### PR DESCRIPTION
This updates the 0.10 and 0.12 slim variant Dockerfiles to be consistent with the 4.x and 5.x slim variants:

- Base the image off of `buildpack-deps:jessie-curl` instead of debian:jessie
- Only install the xz-utils package

Test build looks good: https://travis-ci.org/chorrell/docker-node/builds/122896535