### PR TITLE
Set correct default version for node:5

### DIFF
--- a/generate-stackbrew-library.sh
+++ b/generate-stackbrew-library.sh
@@ -5,7 +5,7 @@ hash git 2>/dev/null || { echo >&2 "git not found, exiting."; }
 
 array_0_12='0';
 array_4_4='4 argon';
-array_5_10='5';
+array_5_11='5';
 array_6_0='6 latest';
 
 cd $(cd ${0%/*} && pwd -P);


### PR DESCRIPTION
It should default to v5.11.0. Partially fixes #174.

Once this lands we'll need a PR to the docker hub to get this fixed upstream.

I think we also need to look at the update script and see if we can get some logic added to update generate-stackbrew-library.sh