### PR TITLE
Openssl updates 20160505

### DIFF
--- a/0.10/Dockerfile
+++ b/0.10/Dockerfile
@@ -15,7 +15,7 @@ RUN set -ex \
     gpg --keyserver ha.pool.sks-keyservers.net --recv-keys "$key"; \
   done
 
-ENV NODE_VERSION 0.10.44
+ENV NODE_VERSION 0.10.45
 
 RUN curl -SLO "https://nodejs.org/dist/v$NODE_VERSION/node-v$NODE_VERSION-linux-x64.tar.xz" \
   && curl -SLO "https://nodejs.org/dist/v$NODE_VERSION/SHASUMS256.txt.asc" \

--- a/0.10/onbuild/Dockerfile
+++ b/0.10/onbuild/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:0.10.44
+FROM node:0.10.45
 
 RUN mkdir -p /usr/src/app
 WORKDIR /usr/src/app

--- a/0.10/slim/Dockerfile
+++ b/0.10/slim/Dockerfile
@@ -15,7 +15,7 @@ RUN set -ex \
     gpg --keyserver ha.pool.sks-keyservers.net --recv-keys "$key"; \
   done
 
-ENV NODE_VERSION 0.10.44
+ENV NODE_VERSION 0.10.45
 
 RUN buildDeps='xz-utils' \
     && set -x \

--- a/0.10/wheezy/Dockerfile
+++ b/0.10/wheezy/Dockerfile
@@ -15,7 +15,7 @@ RUN set -ex \
     gpg --keyserver ha.pool.sks-keyservers.net --recv-keys "$key"; \
   done
 
-ENV NODE_VERSION 0.10.44
+ENV NODE_VERSION 0.10.45
 
 RUN curl -SLO "https://nodejs.org/dist/v$NODE_VERSION/node-v$NODE_VERSION-linux-x64.tar.xz" \
   && curl -SLO "https://nodejs.org/dist/v$NODE_VERSION/SHASUMS256.txt.asc" \

--- a/0.12/Dockerfile
+++ b/0.12/Dockerfile
@@ -15,7 +15,7 @@ RUN set -ex \
     gpg --keyserver ha.pool.sks-keyservers.net --recv-keys "$key"; \
   done
 
-ENV NODE_VERSION 0.12.13
+ENV NODE_VERSION 0.12.14
 
 RUN curl -SLO "https://nodejs.org/dist/v$NODE_VERSION/node-v$NODE_VERSION-linux-x64.tar.xz" \
   && curl -SLO "https://nodejs.org/dist/v$NODE_VERSION/SHASUMS256.txt.asc" \

--- a/0.12/onbuild/Dockerfile
+++ b/0.12/onbuild/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:0.12.13
+FROM node:0.12.14
 
 RUN mkdir -p /usr/src/app
 WORKDIR /usr/src/app

--- a/0.12/slim/Dockerfile
+++ b/0.12/slim/Dockerfile
@@ -15,7 +15,7 @@ RUN set -ex \
     gpg --keyserver ha.pool.sks-keyservers.net --recv-keys "$key"; \
   done
 
-ENV NODE_VERSION 0.12.13
+ENV NODE_VERSION 0.12.14
 
 RUN buildDeps='xz-utils' \
     && set -x \

--- a/0.12/wheezy/Dockerfile
+++ b/0.12/wheezy/Dockerfile
@@ -15,7 +15,7 @@ RUN set -ex \
     gpg --keyserver ha.pool.sks-keyservers.net --recv-keys "$key"; \
   done
 
-ENV NODE_VERSION 0.12.13
+ENV NODE_VERSION 0.12.14
 
 RUN curl -SLO "https://nodejs.org/dist/v$NODE_VERSION/node-v$NODE_VERSION-linux-x64.tar.xz" \
   && curl -SLO "https://nodejs.org/dist/v$NODE_VERSION/SHASUMS256.txt.asc" \

--- a/4.4/Dockerfile
+++ b/4.4/Dockerfile
@@ -16,7 +16,7 @@ RUN set -ex \
   done
 
 ENV NPM_CONFIG_LOGLEVEL info
-ENV NODE_VERSION 4.4.3
+ENV NODE_VERSION 4.4.4
 
 RUN curl -SLO "https://nodejs.org/dist/v$NODE_VERSION/node-v$NODE_VERSION-linux-x64.tar.xz" \
   && curl -SLO "https://nodejs.org/dist/v$NODE_VERSION/SHASUMS256.txt.asc" \

--- a/4.4/onbuild/Dockerfile
+++ b/4.4/onbuild/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:4.4.3
+FROM node:4.4.4
 
 RUN mkdir -p /usr/src/app
 WORKDIR /usr/src/app

--- a/4.4/slim/Dockerfile
+++ b/4.4/slim/Dockerfile
@@ -16,7 +16,7 @@ RUN set -ex \
   done
 
 ENV NPM_CONFIG_LOGLEVEL info
-ENV NODE_VERSION 4.4.3
+ENV NODE_VERSION 4.4.4
 
 RUN buildDeps='xz-utils' \
     && set -x \

--- a/4.4/wheezy/Dockerfile
+++ b/4.4/wheezy/Dockerfile
@@ -16,7 +16,7 @@ RUN set -ex \
   done
 
 ENV NPM_CONFIG_LOGLEVEL info
-ENV NODE_VERSION 4.4.3
+ENV NODE_VERSION 4.4.4
 
 RUN curl -SLO "https://nodejs.org/dist/v$NODE_VERSION/node-v$NODE_VERSION-linux-x64.tar.xz" \
   && curl -SLO "https://nodejs.org/dist/v$NODE_VERSION/SHASUMS256.txt.asc" \

--- a/5.11/Dockerfile
+++ b/5.11/Dockerfile
@@ -16,7 +16,7 @@ RUN set -ex \
   done
 
 ENV NPM_CONFIG_LOGLEVEL info
-ENV NODE_VERSION 5.11.0
+ENV NODE_VERSION 5.11.1
 
 RUN curl -SLO "https://nodejs.org/dist/v$NODE_VERSION/node-v$NODE_VERSION-linux-x64.tar.xz" \
   && curl -SLO "https://nodejs.org/dist/v$NODE_VERSION/SHASUMS256.txt.asc" \

--- a/5.11/onbuild/Dockerfile
+++ b/5.11/onbuild/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:5.11.0
+FROM node:5.11.1
 
 RUN mkdir -p /usr/src/app
 WORKDIR /usr/src/app

--- a/5.11/slim/Dockerfile
+++ b/5.11/slim/Dockerfile
@@ -16,7 +16,7 @@ RUN set -ex \
   done
 
 ENV NPM_CONFIG_LOGLEVEL info
-ENV NODE_VERSION 5.11.0
+ENV NODE_VERSION 5.11.1
 
 RUN buildDeps='xz-utils' \
     && set -x \

--- a/5.11/wheezy/Dockerfile
+++ b/5.11/wheezy/Dockerfile
@@ -16,7 +16,7 @@ RUN set -ex \
   done
 
 ENV NPM_CONFIG_LOGLEVEL info
-ENV NODE_VERSION 5.11.0
+ENV NODE_VERSION 5.11.1
 
 RUN curl -SLO "https://nodejs.org/dist/v$NODE_VERSION/node-v$NODE_VERSION-linux-x64.tar.xz" \
   && curl -SLO "https://nodejs.org/dist/v$NODE_VERSION/SHASUMS256.txt.asc" \

--- a/6.1/Dockerfile
+++ b/6.1/Dockerfile
@@ -16,7 +16,7 @@ RUN set -ex \
   done
 
 ENV NPM_CONFIG_LOGLEVEL info
-ENV NODE_VERSION 6.0.0
+ENV NODE_VERSION 6.1.0
 
 RUN curl -SLO "https://nodejs.org/dist/v$NODE_VERSION/node-v$NODE_VERSION-linux-x64.tar.xz" \
   && curl -SLO "https://nodejs.org/dist/v$NODE_VERSION/SHASUMS256.txt.asc" \

--- a/6.1/onbuild/Dockerfile
+++ b/6.1/onbuild/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:6.0.0
+FROM node:6.1.0
 
 RUN mkdir -p /usr/src/app
 WORKDIR /usr/src/app

--- a/6.1/slim/Dockerfile
+++ b/6.1/slim/Dockerfile
@@ -16,7 +16,7 @@ RUN set -ex \
   done
 
 ENV NPM_CONFIG_LOGLEVEL info
-ENV NODE_VERSION 6.0.0
+ENV NODE_VERSION 6.1.0
 
 RUN buildDeps='xz-utils' \
     && set -x \

--- a/6.1/wheezy/Dockerfile
+++ b/6.1/wheezy/Dockerfile
@@ -16,7 +16,7 @@ RUN set -ex \
   done
 
 ENV NPM_CONFIG_LOGLEVEL info
-ENV NODE_VERSION 6.0.0
+ENV NODE_VERSION 6.1.0
 
 RUN curl -SLO "https://nodejs.org/dist/v$NODE_VERSION/node-v$NODE_VERSION-linux-x64.tar.xz" \
   && curl -SLO "https://nodejs.org/dist/v$NODE_VERSION/SHASUMS256.txt.asc" \

--- a/generate-stackbrew-library.sh
+++ b/generate-stackbrew-library.sh
@@ -6,7 +6,7 @@ hash git 2>/dev/null || { echo >&2 "git not found, exiting."; }
 array_0_12='0';
 array_4_4='4 argon';
 array_5_11='5';
-array_6_0='6 latest';
+array_6_1='6 latest';
 
 cd $(cd ${0%/*} && pwd -P);
 


### PR DESCRIPTION
Node.js updates for:

- v6.1.0
- v5.11.1
- v4.4.4
- v0.12.14
- v0.10.45

See #177

Closes #178 and closes #179