### PR TITLE
Remove mkdir -p command

### DIFF
--- a/0.10/onbuild/Dockerfile
+++ b/0.10/onbuild/Dockerfile
@@ -1,6 +1,5 @@
 FROM node:0.10.45
 
-RUN mkdir -p /usr/src/app
 WORKDIR /usr/src/app
 
 ONBUILD COPY package.json /usr/src/app/

--- a/0.12/onbuild/Dockerfile
+++ b/0.12/onbuild/Dockerfile
@@ -1,6 +1,5 @@
 FROM node:0.12.14
 
-RUN mkdir -p /usr/src/app
 WORKDIR /usr/src/app
 
 ONBUILD COPY package.json /usr/src/app/

--- a/4.4/onbuild/Dockerfile
+++ b/4.4/onbuild/Dockerfile
@@ -1,6 +1,5 @@
 FROM node:4.4.5
 
-RUN mkdir -p /usr/src/app
 WORKDIR /usr/src/app
 
 ONBUILD COPY package.json /usr/src/app/

--- a/5.11/onbuild/Dockerfile
+++ b/5.11/onbuild/Dockerfile
@@ -1,6 +1,5 @@
 FROM node:5.11.1
 
-RUN mkdir -p /usr/src/app
 WORKDIR /usr/src/app
 
 ONBUILD COPY package.json /usr/src/app/

--- a/6.2/onbuild/Dockerfile
+++ b/6.2/onbuild/Dockerfile
@@ -1,6 +1,5 @@
 FROM node:6.2.0
 
-RUN mkdir -p /usr/src/app
 WORKDIR /usr/src/app
 
 ONBUILD COPY package.json /usr/src/app/

--- a/Dockerfile-onbuild.template
+++ b/Dockerfile-onbuild.template
@@ -1,6 +1,5 @@
 FROM node:0.0.0
 
-RUN mkdir -p /usr/src/app
 WORKDIR /usr/src/app
 
 ONBUILD COPY package.json /usr/src/app/


### PR DESCRIPTION
The [documentation for `WORKDIR`](https://docs.docker.com/engine/reference/builder/) mentions that:

>  If the `WORKDIR` doesn’t exist, it will be created even if its not used in any subsequent `Dockerfile` instruction.

Based on the [PR that added that to the 1.10 docs](https://github.com/docker/docker/pull/21340), it appears that it's been like this for a long time.

I've also been creating non-onbuild Dockerfiles without any `mkdir -p` commands for a while and have no problems on 1.10. 

This PR removes the `RUN mkdir -p /usr/src/app` line from the `onbuild` Dockerfiles, which I believe is redundant :)