### PR TITLE
Upgrade Node to 6.3.0

### DIFF
--- a/6.3/Dockerfile
+++ b/6.3/Dockerfile
@@ -1,4 +1,4 @@
-FROM buildpack-deps:wheezy
+FROM buildpack-deps:jessie
 
 # gpg keys listed at https://github.com/nodejs/node
 RUN set -ex \
@@ -16,7 +16,7 @@ RUN set -ex \
   done
 
 ENV NPM_CONFIG_LOGLEVEL info
-ENV NODE_VERSION 6.2.2
+ENV NODE_VERSION 6.3.0
 
 RUN curl -SLO "https://nodejs.org/dist/v$NODE_VERSION/node-v$NODE_VERSION-linux-x64.tar.xz" \
   && curl -SLO "https://nodejs.org/dist/v$NODE_VERSION/SHASUMS256.txt.asc" \

--- a/6.3/onbuild/Dockerfile
+++ b/6.3/onbuild/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:6.2.2
+FROM node:6.3.0
 
 RUN mkdir -p /usr/src/app
 WORKDIR /usr/src/app

--- a/6.3/slim/Dockerfile
+++ b/6.3/slim/Dockerfile
@@ -16,7 +16,7 @@ RUN set -ex \
   done
 
 ENV NPM_CONFIG_LOGLEVEL info
-ENV NODE_VERSION 6.2.2
+ENV NODE_VERSION 6.3.0
 
 RUN buildDeps='xz-utils' \
     && set -x \

--- a/6.3/wheezy/Dockerfile
+++ b/6.3/wheezy/Dockerfile
@@ -1,4 +1,4 @@
-FROM buildpack-deps:jessie
+FROM buildpack-deps:wheezy
 
 # gpg keys listed at https://github.com/nodejs/node
 RUN set -ex \
@@ -16,7 +16,7 @@ RUN set -ex \
   done
 
 ENV NPM_CONFIG_LOGLEVEL info
-ENV NODE_VERSION 6.2.2
+ENV NODE_VERSION 6.3.0
 
 RUN curl -SLO "https://nodejs.org/dist/v$NODE_VERSION/node-v$NODE_VERSION-linux-x64.tar.xz" \
   && curl -SLO "https://nodejs.org/dist/v$NODE_VERSION/SHASUMS256.txt.asc" \


### PR DESCRIPTION
Upgrade Node v6 Docker Image to v6.3.0.

Related: nodejs/node#7550, nodejs/node#7441
Signed-off-by: Hans Kristian Flaatten <hans.kristian.flaatten@dnt.no>