### PR TITLE
Create .dockerignore

### DIFF
--- a/6.4/onbuild/.dockerignore
+++ b/6.4/onbuild/.dockerignore
@@ -1,0 +1,1 @@
+node_modules


### PR DESCRIPTION
Without the dockerignore, docker will copy everything including the node_modules. This breaks modules which are compiled when installed and also makes the `npm install` command in the dockerfile irrelevant...