### PR TITLE
Proposal: Introduce Dockerfiles for windowsservercore

### DIFF
--- a/4.8/windows/windowsservercore/Dockerfile
+++ b/4.8/windows/windowsservercore/Dockerfile
@@ -1,0 +1,18 @@
+FROM microsoft/windowsservercore
+
+SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
+
+ENV NPM_CONFIG_LOGLEVEL info
+ENV NODE_VERSION 4.8.1
+ENV NODE_SHA256 edb47c31de7891ddb58d5e1024e31c91b49b4f2226cf6c3e0c41e715ee6111e4
+
+RUN Invoke-WebRequest $('https://nodejs.org/dist/v{0}/node-v{0}-win-x64.zip' -f $env:NODE_VERSION) -OutFile 'node.zip' -UseBasicParsing ; \
+    if ((Get-FileHash node.zip -Algorithm sha256).Hash -ne $env:NODE_SHA256) {exit 1} ; \
+    Expand-Archive node.zip -DestinationPath C:\ ; \
+    Rename-Item -Path $('C:\node-v{0}-win-x64' -f $env:NODE_VERSION) -NewName 'C:\nodejs' ; \
+    New-Item $($env:APPDATA + '\npm') ; \
+    $env:PATH = 'C:\nodejs;{0}\npm;{1}' -f $env:APPDATA, $env:PATH ; \
+    [Environment]::SetEnvironmentVariable('PATH', $env:PATH, [EnvironmentVariableTarget]::Machine) ; \
+    Remove-Item -Path node.zip
+
+CMD [ "node.exe" ]

--- a/4.8/windows/windowsservercore/onbuild/Dockerfile
+++ b/4.8/windows/windowsservercore/onbuild/Dockerfile
@@ -1,0 +1,10 @@
+FROM node:4.8.1-windowsservercore
+
+RUN mkdir \app
+WORKDIR /app
+
+ONBUILD COPY package.json package.json
+ONBUILD RUN npm install ; Remove-Item $($env:APPDATA + '\npm-cache') -Force -Recurse ; Remove-Item $($env:TEMP + '\npm-*') -Force -Recurse
+ONBUILD COPY . .
+
+CMD [ "npm.cmd", "start" ]

--- a/6.10/windows/windowsservercore/Dockerfile
+++ b/6.10/windows/windowsservercore/Dockerfile
@@ -1,0 +1,18 @@
+FROM microsoft/windowsservercore
+
+SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
+
+ENV NPM_CONFIG_LOGLEVEL info
+ENV NODE_VERSION 6.10.1
+ENV NODE_SHA256 28923f51691bb34dc399af4ceb567da487d7f4806aec5e6f0cfab1e6c3f2dd1c
+
+RUN Invoke-WebRequest $('https://nodejs.org/dist/v{0}/node-v{0}-win-x64.zip' -f $env:NODE_VERSION) -OutFile 'node.zip' -UseBasicParsing ; \
+    if ((Get-FileHash node.zip -Algorithm sha256).Hash -ne $env:NODE_SHA256) {exit 1} ; \
+    Expand-Archive node.zip -DestinationPath C:\ ; \
+    Rename-Item -Path $('C:\node-v{0}-win-x64' -f $env:NODE_VERSION) -NewName 'C:\nodejs' ; \
+    New-Item $($env:APPDATA + '\npm') ; \
+    $env:PATH = 'C:\nodejs;{0}\npm;{1}' -f $env:APPDATA, $env:PATH ; \
+    [Environment]::SetEnvironmentVariable('PATH', $env:PATH, [EnvironmentVariableTarget]::Machine) ; \
+    Remove-Item -Path node.zip
+
+CMD [ "node.exe" ]

--- a/6.10/windows/windowsservercore/onbuild/Dockerfile
+++ b/6.10/windows/windowsservercore/onbuild/Dockerfile
@@ -1,0 +1,10 @@
+FROM node:6.10.1-windowsservercore
+
+RUN mkdir \app
+WORKDIR /app
+
+ONBUILD COPY package.json package.json
+ONBUILD RUN npm install ; Remove-Item $($env:APPDATA + '\npm-cache') -Force -Recurse ; Remove-Item $($env:TEMP + '\npm-*') -Force -Recurse
+ONBUILD COPY . .
+
+CMD [ "npm.cmd", "start" ]

--- a/7.7/windows/windowsservercore/Dockerfile
+++ b/7.7/windows/windowsservercore/Dockerfile
@@ -1,0 +1,18 @@
+FROM microsoft/windowsservercore
+
+SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
+
+ENV NPM_CONFIG_LOGLEVEL info
+ENV NODE_VERSION 7.7.4
+ENV NODE_SHA256 dd573367cda68db3594544b973be2367c0df8fc5345402672079e6be873931cd
+
+RUN Invoke-WebRequest $('https://nodejs.org/dist/v{0}/node-v{0}-win-x64.zip' -f $env:NODE_VERSION) -OutFile 'node.zip' -UseBasicParsing ; \
+    if ((Get-FileHash node.zip -Algorithm sha256).Hash -ne $env:NODE_SHA256) {exit 1} ; \
+    Expand-Archive node.zip -DestinationPath C:\ ; \
+    Rename-Item -Path $('C:\node-v{0}-win-x64' -f $env:NODE_VERSION) -NewName 'C:\nodejs' ; \
+    New-Item $($env:APPDATA + '\npm') ; \
+    $env:PATH = 'C:\nodejs;{0}\npm;{1}' -f $env:APPDATA, $env:PATH ; \
+    [Environment]::SetEnvironmentVariable('PATH', $env:PATH, [EnvironmentVariableTarget]::Machine) ; \
+    Remove-Item -Path node.zip
+
+CMD [ "node.exe" ]

--- a/7.7/windows/windowsservercore/onbuild/Dockerfile
+++ b/7.7/windows/windowsservercore/onbuild/Dockerfile
@@ -1,0 +1,10 @@
+FROM node:7.7.4-windowsservercore
+
+RUN mkdir \app
+WORKDIR /app
+
+ONBUILD COPY package.json package.json
+ONBUILD RUN npm install ; Remove-Item $($env:APPDATA + '\npm-cache') -Force -Recurse ; Remove-Item $($env:TEMP + '\npm-*') -Force -Recurse
+ONBUILD COPY . .
+
+CMD [ "npm.cmd", "start" ]

--- a/test-build.ps1
+++ b/test-build.ps1
@@ -1,0 +1,8 @@
+docker build -t node:4.7.0-windowsservercore 4.7/windows/windowsservercore
+docker build -t node:4.7.0-windowsservercore-onbuild 4.7/windows/windowsservercore/onbuild
+
+docker build -t node:6.9.2-windowsservercore 6.9/windows/windowsservercore
+docker build -t node:6.9.2-windowsservercore-onbuild 6.9/windows/windowsservercore/onbuild
+
+docker build -t node:7.2.1-windowsservercore 7.2/windows/windowsservercore
+docker build -t node:7.2.1-windowsservercore-onbuild 7.2/windows/windowsservercore/onbuild


### PR DESCRIPTION
After `golang` now has its first Windows Docker image on [Docker Hub](https://hub.docker.com/_/golang/) it is time for `node` to provide an official Windows Docker image as well.

This PR is a proposal to build and push Windows Docker images for the `windowsservercore` variant which works on Windows 10 + Docker 4 Windows Beta 31++ or Windows Server 2016.

The `test-build.ps1` can be called to build the images. It downloads the ZIP files for Node.js 4.7.0, 6.9.2 and 7.2.1 and builds these Docker images:

- node:4.7.0-windowsservercore
- node:4.7.0-windowsservercore-onbuild
- node:6.9.2-windowsservercore
- node:6.9.2-windowsservercore-onbuild
- node:7.2.1-windowsservercore
- node:7.2.1-windowsservercore-onbuild

In my previous work building a Windows Docker image I used the MSI packages which can be found here https://github.com/StefanScherer/dockerfiles-windows/tree/master/node, but this results in a slightly bigger Docker image as Windows caches the MSI packages in a second place even after removing it in the Dockerfile. So I switched to the ZIP files.

The labels for the Docker images are based on the work for the `golang` Docker images.

See also:
- https://github.com/docker-library/golang/pull/106
- https://hub.docker.com/_/golang/

For information about how to get Docker running on Windows, please see the relevant [Windows Server Quick Start](https://msdn.microsoft.com/en-us/virtualization/windowscontainers/quick_start/quick_start_windows_server) guide provided by Microsoft.

See also #223 for the nanoserver Dockerfile proposal.
