### PR TITLE
Proposal: Introduce Dockerfiles for nanoserver

### DIFF
--- a/4.8/windows/nanoserver/Dockerfile
+++ b/4.8/windows/nanoserver/Dockerfile
@@ -1,0 +1,18 @@
+FROM microsoft/nanoserver
+
+SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
+
+ENV NPM_CONFIG_LOGLEVEL info
+ENV NODE_VERSION 4.8.1
+ENV NODE_SHA256 edb47c31de7891ddb58d5e1024e31c91b49b4f2226cf6c3e0c41e715ee6111e4
+
+RUN Invoke-WebRequest $('https://nodejs.org/dist/v{0}/node-v{0}-win-x64.zip' -f $env:NODE_VERSION) -OutFile 'node.zip' -UseBasicParsing ; \
+    if ((Get-FileHash node.zip -Algorithm sha256).Hash -ne $env:NODE_SHA256) {exit 1} ; \
+    Expand-Archive node.zip -DestinationPath C:\ ; \
+    Rename-Item -Path $('C:\node-v{0}-win-x64' -f $env:NODE_VERSION) -NewName 'C:\nodejs' ; \
+    New-Item $($env:APPDATA + '\npm') ; \
+    $env:PATH = 'C:\nodejs;{0}\npm;{1}' -f $env:APPDATA, $env:PATH ; \
+    Set-ItemProperty -Path 'HKLM:\SYSTEM\CurrentControlSet\Control\Session Manager\Environment\' -Name Path -Value $env:PATH ; \
+    Remove-Item -Path node.zip
+
+CMD [ "node.exe" ]

--- a/4.8/windows/nanoserver/onbuild/Dockerfile
+++ b/4.8/windows/nanoserver/onbuild/Dockerfile
@@ -1,0 +1,10 @@
+FROM node:4.8.1-nanoserver
+
+RUN mkdir \app
+WORKDIR /app
+
+ONBUILD COPY package.json package.json
+ONBUILD RUN npm install ; Remove-Item $($env:APPDATA + '\npm-cache') -Force -Recurse ; Remove-Item $($env:TEMP + '\npm-*') -Force -Recurse
+ONBUILD COPY . .
+
+CMD [ "npm.cmd", "start" ]

--- a/6.10/windows/nanoserver/Dockerfile
+++ b/6.10/windows/nanoserver/Dockerfile
@@ -1,0 +1,18 @@
+FROM microsoft/nanoserver
+
+SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
+
+ENV NPM_CONFIG_LOGLEVEL info
+ENV NODE_VERSION 6.10.1
+ENV NODE_SHA256 28923f51691bb34dc399af4ceb567da487d7f4806aec5e6f0cfab1e6c3f2dd1c
+
+RUN Invoke-WebRequest $('https://nodejs.org/dist/v{0}/node-v{0}-win-x64.zip' -f $env:NODE_VERSION) -OutFile 'node.zip' -UseBasicParsing ; \
+		if ((Get-FileHash node.zip -Algorithm sha256).Hash -ne $env:NODE_SHA256) {exit 1} ; \
+    Expand-Archive node.zip -DestinationPath C:\ ; \
+    Rename-Item -Path $('C:\node-v{0}-win-x64' -f $env:NODE_VERSION) -NewName 'C:\nodejs' ; \
+    New-Item $($env:APPDATA + '\npm') ; \
+    $env:PATH = 'C:\nodejs;{0}\npm;{1}' -f $env:APPDATA, $env:PATH ; \
+    Set-ItemProperty -Path 'HKLM:\SYSTEM\CurrentControlSet\Control\Session Manager\Environment\' -Name Path -Value $env:PATH ; \
+    Remove-Item -Path node.zip
+
+CMD [ "node.exe" ]

--- a/6.10/windows/nanoserver/onbuild/Dockerfile
+++ b/6.10/windows/nanoserver/onbuild/Dockerfile
@@ -1,0 +1,10 @@
+FROM node:6.10.1-nanoserver
+
+RUN mkdir \app
+WORKDIR /app
+
+ONBUILD COPY package.json package.json
+ONBUILD RUN npm install ; Remove-Item $($env:APPDATA + '\npm-cache') -Force -Recurse ; Remove-Item $($env:TEMP + '\npm-*') -Force -Recurse
+ONBUILD COPY . .
+
+CMD [ "npm.cmd", "start" ]

--- a/7.7/windows/nanoserver/Dockerfile
+++ b/7.7/windows/nanoserver/Dockerfile
@@ -1,0 +1,18 @@
+FROM microsoft/nanoserver
+
+SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
+
+ENV NPM_CONFIG_LOGLEVEL info
+ENV NODE_VERSION 7.7.4
+ENV NODE_SHA256 dd573367cda68db3594544b973be2367c0df8fc5345402672079e6be873931cd
+
+RUN Invoke-WebRequest $('https://nodejs.org/dist/v{0}/node-v{0}-win-x64.zip' -f $env:NODE_VERSION) -OutFile 'node.zip' -UseBasicParsing ; \
+		if ((Get-FileHash node.zip -Algorithm sha256).Hash -ne $env:NODE_SHA256) {exit 1} ; \
+    Expand-Archive node.zip -DestinationPath C:\ ; \
+    Rename-Item -Path $('C:\node-v{0}-win-x64' -f $env:NODE_VERSION) -NewName 'C:\nodejs' ; \
+    New-Item $($env:APPDATA + '\npm') ; \
+    $env:PATH = 'C:\nodejs;{0}\npm;{1}' -f $env:APPDATA, $env:PATH ; \
+    Set-ItemProperty -Path 'HKLM:\SYSTEM\CurrentControlSet\Control\Session Manager\Environment\' -Name Path -Value $env:PATH ; \
+    Remove-Item -Path node.zip
+
+CMD [ "node.exe" ]

--- a/7.7/windows/nanoserver/onbuild/Dockerfile
+++ b/7.7/windows/nanoserver/onbuild/Dockerfile
@@ -1,0 +1,10 @@
+FROM node:7.7.4-nanoserver
+
+RUN mkdir \app
+WORKDIR /app
+
+ONBUILD COPY package.json package.json
+ONBUILD RUN npm install ; Remove-Item $($env:APPDATA + '\npm-cache') -Force -Recurse ; Remove-Item $($env:TEMP + '\npm-*') -Force -Recurse
+ONBUILD COPY . .
+
+CMD [ "npm.cmd", "start" ]

--- a/test-build.ps1
+++ b/test-build.ps1
@@ -1,0 +1,8 @@
+docker build --isolation=hyperv -t node:4.8.1-nanoserver 4.8/windows/nanoserver
+docker build --isolation=hyperv -t node:4.8.1-nanoserver-onbuild 4.8/windows/nanoserver/onbuild
+
+docker build --isolation=hyperv -t node:6.10.1-nanoserver 6.10/windows/nanoserver
+docker build --isolation=hyperv -t node:6.10.1-nanoserver-onbuild 6.10/windows/nanoserver/onbuild
+
+docker build --isolation=hyperv -t node:7.7.4-nanoserver 7.7/windows/nanoserver
+docker build --isolation=hyperv -t node:7.7.4-nanoserver-onbuild 7.7/windows/nanoserver/onbuild


### PR DESCRIPTION
As mentioned in #222 here is a proposal to build Windows Docker images with Node.js 4.7.0, 6.9.2 and 7.2.1 based on the Windows `nanoserver` base image.

This allows Windows 10 1607 and Server 2016 users build and run Node.js in a Docker container.

The `test-build.ps1` can be called to build the images, either on a Windows 10 machine or a Windows Server 2016 machine. It downloads the ZIP files for Node.js 4.7.0, 6.9.2 and 7.2.1 and builds these Docker images:

- node:4.7.0-nanoserver
- node:4.7.0-nanoserver-onbuild
- node:6.9.2-nanoserver
- node:6.9.2-nanoserver-onbuild
- node:7.2.1-nanoserver
- node:7.2.1-nanoserver-onbuild

For information about how to get Docker running on Windows, please see the relevant "Quick Start" guide provided by Microsoft:
- [Windows Server Quick Start](https://msdn.microsoft.com/en-us/virtualization/windowscontainers/quick_start/quick_start_windows_server)
- [Windows 10 Quick Start](https://msdn.microsoft.com/en-us/virtualization/windowscontainers/quick_start/quick_start_windows_10)

or use **Docker for Windows Beta 26++** to try this PR.

Notes:

~~Using `curl` or `wget` in PowerShell in NanoServer is far from easy. The only working example I used for this Dockerfiles is from [nanoserver/golang](https://github.com/Microsoft/Virtualization-Documentation/blob/master/windows-container-samples/nanoserver/golang/Dockerfile) in the Microsoft/Virtualization-Documentation repo.~~

Further thoughts about size:

My previous work which just does a COPY deployment of Node.js into a nanoserver container image and results in smaller Docker images than running the PowerShell script downloading the ZIP etc.

```
PS C:\Users\vagrant\docker-node> docker images
REPOSITORY                   TAG                        IMAGE ID            CREATED              SIZE
node                         6.4.0-nanoserver-onbuild   e1dae6267768        About a minute ago   1.006 GB
node                         6.4.0-nanoserver           7737552eb883        About a minute ago   1.004 GB
node                         4.5.0-nanoserver-onbuild   4102e90ae44f        3 minutes ago        1.003 GB
node                         4.5.0-nanoserver           c69755c3eaa4        4 minutes ago        1.001 GB
stefanscherer/node-windows   6-nano                     8aaa86fdc12a        3 days ago           999 MB
stefanscherer/node-windows   4-nano                     384c4d4b0cee        3 days ago           995.2 MB
microsoft/nanoserver         latest                     3a703c6e97a2        10 weeks ago         969.8 MB
```
