### PR TITLE
Add NODE_ENV ARG to onbuild template

### DIFF
--- a/Dockerfile-onbuild.template
+++ b/Dockerfile-onbuild.template
@@ -1,5 +1,7 @@
 FROM node:0.0.0
 
+ARG NODE_ENV
+
 RUN mkdir -p /usr/src/app
 WORKDIR /usr/src/app
 

--- a/Dockerfile-onbuild.template
+++ b/Dockerfile-onbuild.template
@@ -1,10 +1,9 @@
 FROM node:0.0.0
 
-ARG NODE_ENV
-
 RUN mkdir -p /usr/src/app
 WORKDIR /usr/src/app
 
+ONBUILD ARG NODE_ENV
 ONBUILD COPY package.json /usr/src/app/
 ONBUILD RUN npm install
 ONBUILD COPY . /usr/src/app

--- a/README.md
+++ b/README.md
@@ -150,6 +150,10 @@ This `onbuild` variant will only install npm packages according to the
 discussion in
 [`nodejs/docker-node#65`](https://github.com/nodejs/docker-node/issues/65).
 
+Note that npm installs devDependencies by default, which is undesirable if
+you're building a production image. To avoid this pass NODE_ENV as a build
+argument i.e. `docker build --build-arg NODE_ENV=production …`.
+
 ## `node:slim`
 
 This image does not contain the common packages contained in the default tag and


### PR DESCRIPTION
It's currently impossible to prevent npm installing devDependencies when using the node onbuild images. Adding a NODE_ENV ARG enables `docker build --build-arg NODE_ENV=production .`, which is the equivalent of `npm install --production`. Providing the `--build-arg` is optional, so this is backwards-compatible.