### PR TITLE
Set ENV for NODE_ENV

### DIFF
--- a/0.10/onbuild/Dockerfile
+++ b/0.10/onbuild/Dockerfile
@@ -4,6 +4,7 @@ RUN mkdir -p /usr/src/app
 WORKDIR /usr/src/app
 
 ONBUILD ARG NODE_ENV
+ONBUILD ENV NODE_ENV $NODE_ENV
 ONBUILD COPY package.json /usr/src/app/
 ONBUILD RUN npm install
 ONBUILD COPY . /usr/src/app

--- a/0.12/onbuild/Dockerfile
+++ b/0.12/onbuild/Dockerfile
@@ -4,6 +4,7 @@ RUN mkdir -p /usr/src/app
 WORKDIR /usr/src/app
 
 ONBUILD ARG NODE_ENV
+ONBUILD ENV NODE_ENV $NODE_ENV
 ONBUILD COPY package.json /usr/src/app/
 ONBUILD RUN npm install
 ONBUILD COPY . /usr/src/app

--- a/4.5/onbuild/Dockerfile
+++ b/4.5/onbuild/Dockerfile
@@ -4,6 +4,7 @@ RUN mkdir -p /usr/src/app
 WORKDIR /usr/src/app
 
 ONBUILD ARG NODE_ENV
+ONBUILD ENV NODE_ENV $NODE_ENV
 ONBUILD COPY package.json /usr/src/app/
 ONBUILD RUN npm install
 ONBUILD COPY . /usr/src/app

--- a/6.6/onbuild/Dockerfile
+++ b/6.6/onbuild/Dockerfile
@@ -4,6 +4,7 @@ RUN mkdir -p /usr/src/app
 WORKDIR /usr/src/app
 
 ONBUILD ARG NODE_ENV
+ONBUILD ENV NODE_ENV $NODE_ENV
 ONBUILD COPY package.json /usr/src/app/
 ONBUILD RUN npm install
 ONBUILD COPY . /usr/src/app

--- a/Dockerfile-onbuild.template
+++ b/Dockerfile-onbuild.template
@@ -4,6 +4,7 @@ RUN mkdir -p /usr/src/app
 WORKDIR /usr/src/app
 
 ONBUILD ARG NODE_ENV
+ONBUILD ENV NODE_ENV $NODE_ENV
 ONBUILD COPY package.json /usr/src/app/
 ONBUILD RUN npm install
 ONBUILD COPY . /usr/src/app


### PR DESCRIPTION
This ensures that the value of NODE_ENV is made available to the CMD
context. This ensures commands such as `npm start` or `node index.js`
are using the correct NODE_ENV.

See comments in
https://github.com/docker-library/official-images/pull/2156