### PR TITLE
Update to use newer manifest file format

### DIFF
--- a/generate-stackbrew-library.sh
+++ b/generate-stackbrew-library.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 set -e
-set -x
 
 hash git 2>/dev/null || { echo >&2 "git not found, exiting."; }
 

--- a/generate-stackbrew-library.sh
+++ b/generate-stackbrew-library.sh
@@ -51,7 +51,7 @@ for version in "${versions[@]}"; do
 	echo "Directory: ${version}"
 	echo
 
-	variants=$(echo $version/*/ | xargs basename)
+	variants=$(echo $version/*/ | xargs -n1 basename)
 	for variant in $variants; do
 		# Skip non-docker directories
 		[ -f "$version/$variant/Dockerfile" ] || continue

--- a/generate-stackbrew-library.sh
+++ b/generate-stackbrew-library.sh
@@ -24,6 +24,7 @@ fileCommit() {
 }
 
 echo "# this file is generated via ${url}/blob/$(fileCommit "$self")/$self"
+echo
 echo "Maintainers: The Node.js Docker Team <${url}> (@nodejs)"
 echo "GitRepo: ${url}.git"
 echo

--- a/generate-stackbrew-library.sh
+++ b/generate-stackbrew-library.sh
@@ -37,11 +37,11 @@ for version in "${versions[@]}"; do
 	fullVersion="$(grep -m1 'ENV NODE_VERSION ' "$version/Dockerfile" | cut -d' ' -f3)"
 
 	versionAliases=( $fullVersion $version ${stub} )
-    echo "Tags: ${versionAliases[@]}"
-    echo "GitCommit: ${commit}"
-    echo "Directory: ${version}"
+	echo "Tags: ${versionAliases[@]}"
+	echo "GitCommit: ${commit}"
+	echo "Directory: ${version}"
 	echo
-    
+
 	variants=$(ls -d $version/*/ | awk -F"/" '{print $2}')
 	for variant in $variants; do
 		commit="$(fileCommit "$version/$variant")"

--- a/generate-stackbrew-library.sh
+++ b/generate-stackbrew-library.sh
@@ -43,7 +43,7 @@ for version in "${versions[@]}"; do
 	echo "Directory: ${version}"
 	echo
 
-	variants=$(ls -d $version/*/ | awk -F"/" '{print $2}')
+	variants=$(echo $version/*/ | xargs basename)
 	for variant in $variants; do
 		commit="$(fileCommit "$version/$variant")"
 		tagVariants=$(printf "%s-${variant} " ${versionAliases[@]})

--- a/generate-stackbrew-library.sh
+++ b/generate-stackbrew-library.sh
@@ -29,6 +29,13 @@ echo "Maintainers: The Node.js Docker Team <${url}> (@nodejs)"
 echo "GitRepo: ${url}.git"
 echo
 
+# prints "$2$1$3$1...$N"
+join() {
+	local sep="$1"; shift
+	local out; printf -v out "${sep//%/%%}%s" "$@"
+	echo "${out#$sep}"
+}
+
 for version in "${versions[@]}"; do
 	if [[ "$version" == "docs" ]]; then
 		continue
@@ -38,7 +45,8 @@ for version in "${versions[@]}"; do
 	fullVersion="$(grep -m1 'ENV NODE_VERSION ' "$version/Dockerfile" | cut -d' ' -f3)"
 
 	versionAliases=( $fullVersion $version ${stub} )
-	echo "Tags: ${versionAliases[@]}"
+	
+	echo "Tags: $(join ', ' "${versionAliases[@]}")"
 	echo "GitCommit: ${commit}"
 	echo "Directory: ${version}"
 	echo
@@ -46,8 +54,12 @@ for version in "${versions[@]}"; do
 	variants=$(echo $version/*/ | xargs basename)
 	for variant in $variants; do
 		commit="$(fileCommit "$version/$variant")"
-		tagVariants=$(printf "%s-${variant} " ${versionAliases[@]})
-		echo "Tags: ${tagVariants}"
+		
+		slash='/'
+		variantAliases=( "${versionAliases[@]/%/-${variant//$slash/-}}" )
+		variantAliases=( "${variantAliases[@]//latest-/}" )
+
+		echo "Tags: $(join ', ' "${variantAliases[@]}")"
 		echo "GitCommit: ${commit}"
 		echo "Directory: ${version}/${variant}"
 		echo

--- a/generate-stackbrew-library.sh
+++ b/generate-stackbrew-library.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 set -e
+set -x
 
 hash git 2>/dev/null || { echo >&2 "git not found, exiting."; }
 
@@ -37,9 +38,9 @@ join() {
 }
 
 for version in "${versions[@]}"; do
-	if [[ "$version" == "docs" ]]; then
-		continue
-	fi
+	# Skip "docs" and other non-docker directories
+	[ -f "$version/Dockerfile" ] || continue
+	
 	eval stub=$(echo "$version" | awk -F. '{ print "$array_" $1 "_" $2 }');
 	commit="$(fileCommit "$version")"
 	fullVersion="$(grep -m1 'ENV NODE_VERSION ' "$version/Dockerfile" | cut -d' ' -f3)"
@@ -53,6 +54,9 @@ for version in "${versions[@]}"; do
 
 	variants=$(echo $version/*/ | xargs basename)
 	for variant in $variants; do
+		# Skip non-docker directories
+		[ -f "$version/$variant/Dockerfile" ] || continue
+		
 		commit="$(fileCommit "$version/$variant")"
 		
 		slash='/'

--- a/generate-stackbrew-library.sh
+++ b/generate-stackbrew-library.sh
@@ -11,9 +11,11 @@ cd $(cd ${0%/*} && pwd -P);
 
 versions=( */ )
 versions=( "${versions[@]%/}" )
-url='git://github.com/nodejs/docker-node'
+url='https://github.com/nodejs/docker-node'
 
-echo '# maintainer: Node.js Docker Team <https://github.com/nodejs/docker-node> (@nodejs)'
+echo "Maintainers: The Node.js Docker Team <${url}> (@nodejs)"
+echo "GitRepo: ${url}.git"
+echo
 
 for version in "${versions[@]}"; do
 	if [[ "$version" == "docs" ]]; then
@@ -24,22 +26,18 @@ for version in "${versions[@]}"; do
 	fullVersion="$(grep -m1 'ENV NODE_VERSION ' "$version/Dockerfile" | cut -d' ' -f3)"
 
 	versionAliases=( $fullVersion $version ${stub} )
-
+    echo "Tags: ${versionAliases[@]}"
+    echo "GitCommit: ${commit}"
+    echo "Directory: ${version}"
 	echo
-	for va in "${versionAliases[@]}"; do
-		echo "$va: ${url}@${commit} $version"
-	done
-
-	for variant in onbuild slim wheezy; do
+    
+	variants=$(ls -d $version/*/ | awk -F"/" '{print $2}')
+	for variant in $variants; do
 		commit="$(git log -1 --format='format:%H' -- "$version/$variant")"
+		tagVariants=$(printf "%s-${variant} " ${versionAliases[@]})
+		echo "Tags: ${tagVariants}"
+		echo "GitCommit: ${commit}"
+		echo "Directory: ${version}/${variant}"
 		echo
-		for va in "${versionAliases[@]}"; do
-			if [ "$va" = 'latest' ]; then
-				va="$variant"
-			else
-				va="$va-$variant"
-			fi
-			echo "$va: ${url}@${commit} $version/$variant"
-		done
 	done
 done


### PR DESCRIPTION
The new format is based on RFC 2822.

See:

https://github.com/docker-library/official-images#instruction-format

Also, generate-stackbrew-library.sh now no longer hardcodes the variant
names (onbuild slim wheezy)