### PR TITLE
Security updates, September 2016. Closes #235

### DIFF
--- a/0.10/Dockerfile
+++ b/0.10/Dockerfile
@@ -15,7 +15,7 @@ RUN set -ex \
     gpg --keyserver ha.pool.sks-keyservers.net --recv-keys "$key"; \
   done
 
-ENV NODE_VERSION 0.10.46
+ENV NODE_VERSION 0.10.47
 
 RUN curl -SLO "https://nodejs.org/dist/v$NODE_VERSION/node-v$NODE_VERSION-linux-x64.tar.xz" \
   && curl -SLO "https://nodejs.org/dist/v$NODE_VERSION/SHASUMS256.txt.asc" \

--- a/0.10/onbuild/Dockerfile
+++ b/0.10/onbuild/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:0.10.46
+FROM node:0.10.47
 
 RUN mkdir -p /usr/src/app
 WORKDIR /usr/src/app

--- a/0.10/slim/Dockerfile
+++ b/0.10/slim/Dockerfile
@@ -15,7 +15,7 @@ RUN set -ex \
     gpg --keyserver ha.pool.sks-keyservers.net --recv-keys "$key"; \
   done
 
-ENV NODE_VERSION 0.10.46
+ENV NODE_VERSION 0.10.47
 
 RUN buildDeps='xz-utils' \
     && set -x \

--- a/0.10/wheezy/Dockerfile
+++ b/0.10/wheezy/Dockerfile
@@ -15,7 +15,7 @@ RUN set -ex \
     gpg --keyserver ha.pool.sks-keyservers.net --recv-keys "$key"; \
   done
 
-ENV NODE_VERSION 0.10.46
+ENV NODE_VERSION 0.10.47
 
 RUN curl -SLO "https://nodejs.org/dist/v$NODE_VERSION/node-v$NODE_VERSION-linux-x64.tar.xz" \
   && curl -SLO "https://nodejs.org/dist/v$NODE_VERSION/SHASUMS256.txt.asc" \

--- a/0.12/Dockerfile
+++ b/0.12/Dockerfile
@@ -15,7 +15,7 @@ RUN set -ex \
     gpg --keyserver ha.pool.sks-keyservers.net --recv-keys "$key"; \
   done
 
-ENV NODE_VERSION 0.12.15
+ENV NODE_VERSION 0.12.16
 
 RUN curl -SLO "https://nodejs.org/dist/v$NODE_VERSION/node-v$NODE_VERSION-linux-x64.tar.xz" \
   && curl -SLO "https://nodejs.org/dist/v$NODE_VERSION/SHASUMS256.txt.asc" \

--- a/0.12/onbuild/Dockerfile
+++ b/0.12/onbuild/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:0.12.15
+FROM node:0.12.16
 
 RUN mkdir -p /usr/src/app
 WORKDIR /usr/src/app

--- a/0.12/slim/Dockerfile
+++ b/0.12/slim/Dockerfile
@@ -15,7 +15,7 @@ RUN set -ex \
     gpg --keyserver ha.pool.sks-keyservers.net --recv-keys "$key"; \
   done
 
-ENV NODE_VERSION 0.12.15
+ENV NODE_VERSION 0.12.16
 
 RUN buildDeps='xz-utils' \
     && set -x \

--- a/0.12/wheezy/Dockerfile
+++ b/0.12/wheezy/Dockerfile
@@ -15,7 +15,7 @@ RUN set -ex \
     gpg --keyserver ha.pool.sks-keyservers.net --recv-keys "$key"; \
   done
 
-ENV NODE_VERSION 0.12.15
+ENV NODE_VERSION 0.12.16
 
 RUN curl -SLO "https://nodejs.org/dist/v$NODE_VERSION/node-v$NODE_VERSION-linux-x64.tar.xz" \
   && curl -SLO "https://nodejs.org/dist/v$NODE_VERSION/SHASUMS256.txt.asc" \

--- a/4.6/Dockerfile
+++ b/4.6/Dockerfile
@@ -1,4 +1,4 @@
-FROM buildpack-deps:wheezy
+FROM buildpack-deps:jessie
 
 # gpg keys listed at https://github.com/nodejs/node
 RUN set -ex \
@@ -16,7 +16,7 @@ RUN set -ex \
   done
 
 ENV NPM_CONFIG_LOGLEVEL info
-ENV NODE_VERSION 6.6.0
+ENV NODE_VERSION 4.6.0
 
 RUN curl -SLO "https://nodejs.org/dist/v$NODE_VERSION/node-v$NODE_VERSION-linux-x64.tar.xz" \
   && curl -SLO "https://nodejs.org/dist/v$NODE_VERSION/SHASUMS256.txt.asc" \

--- a/4.6/onbuild/Dockerfile
+++ b/4.6/onbuild/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:6.6.0
+FROM node:4.6.0
 
 RUN mkdir -p /usr/src/app
 WORKDIR /usr/src/app

--- a/4.6/slim/Dockerfile
+++ b/4.6/slim/Dockerfile
@@ -16,7 +16,7 @@ RUN set -ex \
   done
 
 ENV NPM_CONFIG_LOGLEVEL info
-ENV NODE_VERSION 6.6.0
+ENV NODE_VERSION 4.6.0
 
 RUN buildDeps='xz-utils' \
     && set -x \

--- a/4.6/wheezy/Dockerfile
+++ b/4.6/wheezy/Dockerfile
@@ -1,4 +1,4 @@
-FROM buildpack-deps:jessie
+FROM buildpack-deps:wheezy
 
 # gpg keys listed at https://github.com/nodejs/node
 RUN set -ex \
@@ -16,7 +16,7 @@ RUN set -ex \
   done
 
 ENV NPM_CONFIG_LOGLEVEL info
-ENV NODE_VERSION 4.5.0
+ENV NODE_VERSION 4.6.0
 
 RUN curl -SLO "https://nodejs.org/dist/v$NODE_VERSION/node-v$NODE_VERSION-linux-x64.tar.xz" \
   && curl -SLO "https://nodejs.org/dist/v$NODE_VERSION/SHASUMS256.txt.asc" \

--- a/6.7/Dockerfile
+++ b/6.7/Dockerfile
@@ -16,7 +16,7 @@ RUN set -ex \
   done
 
 ENV NPM_CONFIG_LOGLEVEL info
-ENV NODE_VERSION 6.6.0
+ENV NODE_VERSION 6.7.0
 
 RUN curl -SLO "https://nodejs.org/dist/v$NODE_VERSION/node-v$NODE_VERSION-linux-x64.tar.xz" \
   && curl -SLO "https://nodejs.org/dist/v$NODE_VERSION/SHASUMS256.txt.asc" \

--- a/6.7/onbuild/Dockerfile
+++ b/6.7/onbuild/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:4.5.0
+FROM node:6.7.0
 
 RUN mkdir -p /usr/src/app
 WORKDIR /usr/src/app

--- a/6.7/slim/Dockerfile
+++ b/6.7/slim/Dockerfile
@@ -16,7 +16,7 @@ RUN set -ex \
   done
 
 ENV NPM_CONFIG_LOGLEVEL info
-ENV NODE_VERSION 4.5.0
+ENV NODE_VERSION 6.7.0
 
 RUN buildDeps='xz-utils' \
     && set -x \

--- a/6.7/wheezy/Dockerfile
+++ b/6.7/wheezy/Dockerfile
@@ -16,7 +16,7 @@ RUN set -ex \
   done
 
 ENV NPM_CONFIG_LOGLEVEL info
-ENV NODE_VERSION 4.5.0
+ENV NODE_VERSION 6.7.0
 
 RUN curl -SLO "https://nodejs.org/dist/v$NODE_VERSION/node-v$NODE_VERSION-linux-x64.tar.xz" \
   && curl -SLO "https://nodejs.org/dist/v$NODE_VERSION/SHASUMS256.txt.asc" \

--- a/generate-stackbrew-library.sh
+++ b/generate-stackbrew-library.sh
@@ -4,8 +4,8 @@ set -e
 hash git 2>/dev/null || { echo >&2 "git not found, exiting."; }
 
 array_0_12='0';
-array_4_5='4 argon';
-array_6_6='6 latest';
+array_4_6='4 argon';
+array_6_7='6 latest';
 
 cd $(cd ${0%/*} && pwd -P);
 


### PR DESCRIPTION
This is an update for:

- Node.js v6.7.0
- Node.js v4.6.0
- Node.js v0.12.16
- Node.js v0.10.47

See:

- https://nodejs.org/en/blog/vulnerability/september-2016-security-release
s/
- https://nodejs.org/en/blog/release/v6.7.0/
- https://nodejs.org/en/blog/release/v4.6.0/
- https://nodejs.org/en/blog/release/v0.12.16/
- https://nodejs.org/en/blog/release/v0.10.47/