### PR TITLE
Add node group/user with gid/uid 1000 and a home directory

### DIFF
--- a/Dockerfile-alpine.template
+++ b/Dockerfile-alpine.template
@@ -3,8 +3,7 @@ FROM alpine:3.4
 ENV NPM_CONFIG_LOGLEVEL info
 ENV NODE_VERSION 0.0.0
 
-RUN addgroup -S node \
-    && adduser -D -S -h /var/cache/node -s /sbin/nologin -G node node \
+RUN adduser -D -u 1000 node \
     && apk add --no-cache \
         libstdc++ \
     && apk add --no-cache --virtual .build-deps \

--- a/Dockerfile-slim.template
+++ b/Dockerfile-slim.template
@@ -1,6 +1,7 @@
 FROM buildpack-deps:jessie-curl
 
-RUN groupadd -r node && useradd -r -g node node
+RUN groupadd --gid 1000 node \
+  && useradd --uid 1000 --gid node --shell /bin/bash --create-home node
 
 # gpg keys listed at https://github.com/nodejs/node
 RUN set -ex \

--- a/Dockerfile-wheezy.template
+++ b/Dockerfile-wheezy.template
@@ -1,6 +1,7 @@
 FROM buildpack-deps:wheezy
 
-RUN groupadd -r node && useradd -r -g node node
+RUN groupadd --gid 1000 node \
+  && useradd --uid 1000 --gid node --shell /bin/bash --create-home node
 
 # gpg keys listed at https://github.com/nodejs/node
 RUN set -ex \

--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -1,6 +1,7 @@
 FROM buildpack-deps:jessie
 
-RUN groupadd -r node && useradd -r -g node node
+RUN groupadd --gid 1000 node \
+  && useradd --uid 1000 --gid node --shell /bin/bash --create-home node
 
 # gpg keys listed at https://github.com/nodejs/node
 RUN set -ex \


### PR DESCRIPTION
This is a workaround for docker-machine/boot2docker issue 581, see
https://github.com/boot2docker/boot2docker/issues/581
Although Docker for Mac/Windows doesn't have this issue, there are still many developers using docker-machine with VirtualBox+NFS for performance reasons.

Using a normal user with a home directory instead of a system user faciliates usage of the docker images as e.g. installing packages can simply done in the home directory.