### PR TITLE
Update for v7.2.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,4 +11,4 @@ env:
         - NODE_VERSION: '0.12'
         - NODE_VERSION: '4.6'
         - NODE_VERSION: '6.9'
-        - NODE_VERSION: '7.1'
+        - NODE_VERSION: '7.2'

--- a/generate-stackbrew-library.sh
+++ b/generate-stackbrew-library.sh
@@ -6,7 +6,7 @@ hash git 2>/dev/null || { echo >&2 "git not found, exiting."; }
 array_0_12='0';
 array_4_6='4 argon';
 array_6_9='6 boron';
-array_7_1='7 latest';
+array_7_2='7 latest';
 
 cd $(cd ${0%/*} && pwd -P);
 


### PR DESCRIPTION
Sets 7.2.0 as the 'latest'

This got missed from the v7.2.0 update