### PR TITLE
Use clang to build nodejs in alpine

### DIFF
--- a/4.7/alpine/Dockerfile
+++ b/4.7/alpine/Dockerfile
@@ -2,6 +2,8 @@ FROM alpine:3.4
 
 ENV NPM_CONFIG_LOGLEVEL info
 ENV NODE_VERSION 4.7.0
+ENV CC=clang
+ENV CXX=clang++
 
 RUN adduser -D -u 1000 node \
     && apk add --no-cache \
@@ -9,6 +11,8 @@ RUN adduser -D -u 1000 node \
     && apk add --no-cache --virtual .build-deps \
         binutils-gold \
         curl \
+        clang \
+        clang-dev \
         g++ \
         gcc \
         gnupg \

--- a/6.9/alpine/Dockerfile
+++ b/6.9/alpine/Dockerfile
@@ -2,6 +2,8 @@ FROM alpine:3.4
 
 ENV NPM_CONFIG_LOGLEVEL info
 ENV NODE_VERSION 6.9.2
+ENV CC=clang
+ENV CXX=clang++
 
 RUN adduser -D -u 1000 node \
     && apk add --no-cache \
@@ -9,6 +11,8 @@ RUN adduser -D -u 1000 node \
     && apk add --no-cache --virtual .build-deps \
         binutils-gold \
         curl \
+        clang \
+        clang-dev \
         g++ \
         gcc \
         gnupg \

--- a/7.2/alpine/Dockerfile
+++ b/7.2/alpine/Dockerfile
@@ -2,6 +2,8 @@ FROM alpine:3.4
 
 ENV NPM_CONFIG_LOGLEVEL info
 ENV NODE_VERSION 7.2.1
+ENV CC=clang
+ENV CXX=clang++
 
 RUN adduser -D -u 1000 node \
     && apk add --no-cache \
@@ -9,6 +11,8 @@ RUN adduser -D -u 1000 node \
     && apk add --no-cache --virtual .build-deps \
         binutils-gold \
         curl \
+        clang \
+        clang-dev \
         g++ \
         gcc \
         gnupg \


### PR DESCRIPTION
Two reasons:
1. Faster speed
2. Smaller image