### PR TITLE
docs: fix best-practices memory heading level

### DIFF
--- a/docs/BestPractices.md
+++ b/docs/BestPractices.md
@@ -23,7 +23,7 @@ FROM node:4.1.2-onbuild
 RUN groupadd -r node && useradd -r -g node node
 ```
 
-#### Memory
+## Memory
 
 By default, any Docker Container may consume as much of the hardware such as CPU and RAM. If you are running multiple containers on the same host you should limit how much memory they can consume.     
 


### PR DESCRIPTION
Seems like a H2 is more suitable than a H4, since Memory has nothing to do with non-root users