### PR TITLE
Upgrade to latest alpine stable (3.5)

### DIFF
--- a/4.7/alpine/Dockerfile
+++ b/4.7/alpine/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.4
+FROM alpine:3.5
 
 ENV NPM_CONFIG_LOGLEVEL info
 ENV NODE_VERSION 4.7.0

--- a/6.9/alpine/Dockerfile
+++ b/6.9/alpine/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.4
+FROM alpine:3.5
 
 ENV NPM_CONFIG_LOGLEVEL info
 ENV NODE_VERSION 6.9.2

--- a/7.3/alpine/Dockerfile
+++ b/7.3/alpine/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.4
+FROM alpine:3.5
 
 ENV NPM_CONFIG_LOGLEVEL info
 ENV NODE_VERSION 7.3.0

--- a/Dockerfile-alpine.template
+++ b/Dockerfile-alpine.template
@@ -1,4 +1,4 @@
-FROM alpine:3.4
+FROM alpine:3.5
 
 ENV NPM_CONFIG_LOGLEVEL info
 ENV NODE_VERSION 0.0.0


### PR DESCRIPTION
As alpine 3.5 officialy support ocaml, it's easier to embed [flow](https://flowtype.org/) inside a node container.