### PR TITLE
Add group & user in alpine to match wheezy

### DIFF
--- a/Dockerfile-alpine.template
+++ b/Dockerfile-alpine.template
@@ -3,7 +3,8 @@ FROM alpine:3.4
 ENV NPM_CONFIG_LOGLEVEL info
 ENV NODE_VERSION 0.0.0
 
-RUN adduser -D -u 1000 node \
+RUN addgroup -g 1000 node \
+    && adduser -u 1000 -G node -s /bin/sh -D node \
     && apk add --no-cache \
         libstdc++ \
     && apk add --no-cache --virtual .build-deps \


### PR DESCRIPTION
This will add a group called `node` and a user called `node` to best mimic how [wheezy](https://github.com/nodejs/docker-node/blob/65160d372031e836a412c50f741c13bc838858a5/7.4/wheezy/Dockerfile) adds a group and user.

There doesn't appear to be a long form of the flags (`--`) so I used the short form (`-`).

Below is the full list of flags from `--help`.


### addgroup
```
Usage: addgroup [-g GID] [-S] [USER] GROUP

Add a group or add a user to a group

        -g GID  Group id
        -S      Create a system group
```

### adduser
```
Usage: adduser [OPTIONS] USER [GROUP]

Create new user, or add USER to GROUP

        -h DIR          Home directory
        -g GECOS        GECOS field
        -s SHELL        Login shell
        -G GRP          Add user to existing group
        -S              Create a system user
        -D              Don't assign a password
        -H              Don't create home directory
        -u UID          User id
        -k SKEL         Skeleton directory (/etc/skel)
```

This should be reviewed by others, particularly @LaurentGoderre @tianon @yosifkit @berstend