### PR TITLE
Run 'npm cache clean' after 'npm install' in onbuild variants

### DIFF
--- a/4.7/onbuild/Dockerfile
+++ b/4.7/onbuild/Dockerfile
@@ -6,7 +6,7 @@ WORKDIR /usr/src/app
 ONBUILD ARG NODE_ENV
 ONBUILD ENV NODE_ENV $NODE_ENV
 ONBUILD COPY package.json /usr/src/app/
-ONBUILD RUN npm install
+ONBUILD RUN npm install && npm cache clean
 ONBUILD COPY . /usr/src/app
 
 CMD [ "npm", "start" ]

--- a/6.9/onbuild/Dockerfile
+++ b/6.9/onbuild/Dockerfile
@@ -6,7 +6,7 @@ WORKDIR /usr/src/app
 ONBUILD ARG NODE_ENV
 ONBUILD ENV NODE_ENV $NODE_ENV
 ONBUILD COPY package.json /usr/src/app/
-ONBUILD RUN npm install
+ONBUILD RUN npm install && npm cache clean
 ONBUILD COPY . /usr/src/app
 
 CMD [ "npm", "start" ]

--- a/7.4/onbuild/Dockerfile
+++ b/7.4/onbuild/Dockerfile
@@ -6,7 +6,7 @@ WORKDIR /usr/src/app
 ONBUILD ARG NODE_ENV
 ONBUILD ENV NODE_ENV $NODE_ENV
 ONBUILD COPY package.json /usr/src/app/
-ONBUILD RUN npm install
+ONBUILD RUN npm install && npm cache clean
 ONBUILD COPY . /usr/src/app
 
 CMD [ "npm", "start" ]

--- a/Dockerfile-onbuild.template
+++ b/Dockerfile-onbuild.template
@@ -6,7 +6,7 @@ WORKDIR /usr/src/app
 ONBUILD ARG NODE_ENV
 ONBUILD ENV NODE_ENV $NODE_ENV
 ONBUILD COPY package.json /usr/src/app/
-ONBUILD RUN npm install
+ONBUILD RUN npm install && npm cache clean
 ONBUILD COPY . /usr/src/app
 
 CMD [ "npm", "start" ]


### PR DESCRIPTION
Cleaning out the npm modules cache after installing will help keep down the size of images built with the _onbuild_ variant. Follows practices used in other dockerfiles with package-managers.