### PR TITLE
feat(docker): update alpine linux to v.3.5 and add dumb-init

### DIFF
--- a/4.7/alpine/Dockerfile
+++ b/4.7/alpine/Dockerfile
@@ -1,10 +1,11 @@
-FROM alpine:3.4
+FROM alpine:3.5
 
 ENV NPM_CONFIG_LOGLEVEL info
 ENV NODE_VERSION 4.7.2
 
 RUN adduser -D -u 1000 node \
     && apk add --no-cache \
+        dumb-init \
         libstdc++ \
     && apk add --no-cache --virtual .build-deps \
         binutils-gold \
@@ -42,4 +43,5 @@ RUN adduser -D -u 1000 node \
     && rm -Rf "node-v$NODE_VERSION" \
     && rm "node-v$NODE_VERSION.tar.xz" SHASUMS256.txt.asc SHASUMS256.txt
 
+ENTRYPOINT [ "dumb-init", "--" ]
 CMD [ "node" ]

--- a/6.9/alpine/Dockerfile
+++ b/6.9/alpine/Dockerfile
@@ -1,10 +1,11 @@
-FROM alpine:3.4
+FROM alpine:3.5
 
 ENV NPM_CONFIG_LOGLEVEL info
 ENV NODE_VERSION 6.9.4
 
 RUN adduser -D -u 1000 node \
     && apk add --no-cache \
+        dumb-init \
         libstdc++ \
     && apk add --no-cache --virtual .build-deps \
         binutils-gold \
@@ -42,4 +43,5 @@ RUN adduser -D -u 1000 node \
     && rm -Rf "node-v$NODE_VERSION" \
     && rm "node-v$NODE_VERSION.tar.xz" SHASUMS256.txt.asc SHASUMS256.txt
 
+ENTRYPOINT [ "dumb-init", "--" ]
 CMD [ "node" ]

--- a/7.4/alpine/Dockerfile
+++ b/7.4/alpine/Dockerfile
@@ -1,10 +1,11 @@
-FROM alpine:3.4
+FROM alpine:3.5
 
 ENV NPM_CONFIG_LOGLEVEL info
 ENV NODE_VERSION 7.4.0
 
 RUN adduser -D -u 1000 node \
     && apk add --no-cache \
+        dumb-init \
         libstdc++ \
     && apk add --no-cache --virtual .build-deps \
         binutils-gold \
@@ -42,4 +43,5 @@ RUN adduser -D -u 1000 node \
     && rm -Rf "node-v$NODE_VERSION" \
     && rm "node-v$NODE_VERSION.tar.xz" SHASUMS256.txt.asc SHASUMS256.txt
 
+ENTRYPOINT [ "dumb-init", "--" ]
 CMD [ "node" ]


### PR DESCRIPTION
# Update for Node.js Alpine Linux

- Update Alpine Linux to Version 3.5
- Add [dumb-init](https://github.com/Yelp/dumb-init) to prevent [zombie processes](https://blog.phusion.nl/2015/01/20/docker-and-the-pid-1-zombie-reaping-problem/)

![like](http://i.giphy.com/F0XPSvNDyGpos.gif)