### PR TITLE
Introduce windows images

### DIFF
--- a/4.8/windows/nanoserver/Dockerfile
+++ b/4.8/windows/nanoserver/Dockerfile
@@ -1,0 +1,57 @@
+FROM microsoft/windowsservercore as download
+
+SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
+
+ENV GPG_VERSION 2.3.4
+
+RUN Invoke-WebRequest $('https://files.gpg4win.org/gpg4win-vanilla-{0}.exe' -f $env:GPG_VERSION) -OutFile 'gpg4win.exe' -UseBasicParsing ; \
+    Start-Process .\gpg4win.exe -ArgumentList '/S' -NoNewWindow -Wait
+
+RUN @( \
+    '9554F04D7259F04124DE6B476D5A82AC7E37093B', \
+    '94AE36675C464D64BAFA68DD7434390BDBE9B9C5', \
+    'FD3A5288F042B6850C66B31F09FE44734EB7990E', \
+    '71DCFD284A79C3B38668286BC97EC7A07EDE3FC1', \
+    'DD8F2338BAE7501E3DD5AC78C273792F7D83545D', \
+    'B9AE9905FFD7803F25714661B63B535A4C206CA9', \
+    'C4F0DFFF4E8C1A8236409D08E73BC641CC11F4C8', \
+    '56730D5401028683275BD23C23EFEFE93C4CFFFE' \
+    ) | foreach { \
+      gpg --keyserver ha.pool.sks-keyservers.net --recv-keys $_ ; \
+    }
+
+ENV NODE_VERSION 4.8.4
+
+RUN Invoke-WebRequest $('https://nodejs.org/dist/v{0}/SHASUMS256.txt.asc' -f $env:NODE_VERSION) -OutFile 'SHASUMS256.txt.asc' -UseBasicParsing ; \
+    gpg --batch --decrypt --output SHASUMS256.txt SHASUMS256.txt.asc
+
+RUN Invoke-WebRequest $('https://nodejs.org/dist/v{0}/node-v{0}-win-x64.zip' -f $env:NODE_VERSION) -OutFile 'node.zip' -UseBasicParsing ; \
+    $sum = $(cat SHASUMS256.txt.asc | sls $('  node-v{0}-win-x64.zip' -f $env:NODE_VERSION)) -Split ' ' ; \
+    if ((Get-FileHash node.zip -Algorithm sha256).Hash -ne $sum[0]) { Write-Error 'SHA256 mismatch' } ; \
+    Expand-Archive node.zip -DestinationPath C:\ ; \
+    Rename-Item -Path $('C:\node-v{0}-win-x64' -f $env:NODE_VERSION) -NewName 'C:\nodejs'
+
+ENV YARN_VERSION 0.27.5
+
+RUN Invoke-WebRequest $('https://yarnpkg.com/downloads/{0}/yarn-{0}.msi' -f $env:YARN_VERSION) -OutFile yarn.msi -UseBasicParsing ; \
+    $sig = Get-AuthenticodeSignature yarn.msi ; \
+    if ($sig.Status -ne 'Valid') { Write-Error 'Authenticode signature is not valid' } ; \
+    if (@( \
+      '7E253367F8A102A91D04829E37F3410F14B68A5F' \
+      ) -notcontains $sig.SignerCertificate.Thumbprint) { Write-Error 'Unknown signer certificate' } ; \
+    Start-Process msiexec.exe -ArgumentList '/i', 'yarn.msi', '/quiet', '/norestart' -NoNewWindow -Wait
+
+FROM microsoft/nanoserver
+
+SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
+
+ENV NPM_CONFIG_LOGLEVEL info
+
+COPY --from=download /nodejs /nodejs
+COPY --from=download [ "/Program Files (x86)/yarn", "/yarn" ]
+
+RUN New-Item $($env:APPDATA + '\npm') -Type Directory ; \
+    $env:PATH = 'C:\nodejs;{0}\npm;C:\yarn\bin;{1}' -f $env:APPDATA, $env:PATH ; \
+    Set-ItemProperty -Path 'HKLM:\SYSTEM\CurrentControlSet\Control\Session Manager\Environment\' -Name Path -Value $env:PATH
+
+CMD [ "node.exe" ]

--- a/4.8/windows/windowsservercore/Dockerfile
+++ b/4.8/windows/windowsservercore/Dockerfile
@@ -1,0 +1,57 @@
+FROM microsoft/windowsservercore as download
+
+SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
+
+ENV GPG_VERSION 2.3.4
+
+RUN Invoke-WebRequest $('https://files.gpg4win.org/gpg4win-vanilla-{0}.exe' -f $env:GPG_VERSION) -OutFile 'gpg4win.exe' -UseBasicParsing ; \
+    Start-Process .\gpg4win.exe -ArgumentList '/S' -NoNewWindow -Wait
+
+RUN @( \
+    '9554F04D7259F04124DE6B476D5A82AC7E37093B', \
+    '94AE36675C464D64BAFA68DD7434390BDBE9B9C5', \
+    'FD3A5288F042B6850C66B31F09FE44734EB7990E', \
+    '71DCFD284A79C3B38668286BC97EC7A07EDE3FC1', \
+    'DD8F2338BAE7501E3DD5AC78C273792F7D83545D', \
+    'B9AE9905FFD7803F25714661B63B535A4C206CA9', \
+    'C4F0DFFF4E8C1A8236409D08E73BC641CC11F4C8', \
+    '56730D5401028683275BD23C23EFEFE93C4CFFFE' \
+    ) | foreach { \
+      gpg --keyserver ha.pool.sks-keyservers.net --recv-keys $_ ; \
+    }
+
+ENV NODE_VERSION 4.8.4
+
+RUN Invoke-WebRequest $('https://nodejs.org/dist/v{0}/SHASUMS256.txt.asc' -f $env:NODE_VERSION) -OutFile 'SHASUMS256.txt.asc' -UseBasicParsing ; \
+    gpg --batch --decrypt --output SHASUMS256.txt SHASUMS256.txt.asc
+
+RUN Invoke-WebRequest $('https://nodejs.org/dist/v{0}/node-v{0}-win-x64.zip' -f $env:NODE_VERSION) -OutFile 'node.zip' -UseBasicParsing ; \
+    $sum = $(cat SHASUMS256.txt.asc | sls $('  node-v{0}-win-x64.zip' -f $env:NODE_VERSION)) -Split ' ' ; \
+    if ((Get-FileHash node.zip -Algorithm sha256).Hash -ne $sum[0]) { Write-Error 'SHA256 mismatch' } ; \
+    Expand-Archive node.zip -DestinationPath C:\ ; \
+    Rename-Item -Path $('C:\node-v{0}-win-x64' -f $env:NODE_VERSION) -NewName 'C:\nodejs'
+
+ENV YARN_VERSION 0.27.5
+
+RUN Invoke-WebRequest $('https://yarnpkg.com/downloads/{0}/yarn-{0}.msi' -f $env:YARN_VERSION) -OutFile yarn.msi -UseBasicParsing ; \
+    $sig = Get-AuthenticodeSignature yarn.msi ; \
+    if ($sig.Status -ne 'Valid') { Write-Error 'Authenticode signature is not valid' } ; \
+    if (@( \
+      '7E253367F8A102A91D04829E37F3410F14B68A5F' \
+      ) -notcontains $sig.SignerCertificate.Thumbprint) { Write-Error 'Unknown signer certificate' } ; \
+    Start-Process msiexec.exe -ArgumentList '/i', 'yarn.msi', '/quiet', '/norestart' -NoNewWindow -Wait
+
+FROM microsoft/windowsservercore
+
+SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
+
+ENV NPM_CONFIG_LOGLEVEL info
+
+COPY --from=download /nodejs /nodejs
+COPY --from=download [ "/Program Files (x86)/yarn", "/yarn" ]
+
+RUN New-Item $($env:APPDATA + '\npm') -Type Directory ; \
+    $env:PATH = 'C:\nodejs;{0}\npm;C:\yarn\bin;{1}' -f $env:APPDATA, $env:PATH ; \
+    [Environment]::SetEnvironmentVariable('PATH', $env:PATH, [EnvironmentVariableTarget]::Machine)
+
+CMD [ "node.exe" ]

--- a/6.11/windows/nanoserver/Dockerfile
+++ b/6.11/windows/nanoserver/Dockerfile
@@ -1,0 +1,57 @@
+FROM microsoft/windowsservercore as download
+
+SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
+
+ENV GPG_VERSION 2.3.4
+
+RUN Invoke-WebRequest $('https://files.gpg4win.org/gpg4win-vanilla-{0}.exe' -f $env:GPG_VERSION) -OutFile 'gpg4win.exe' -UseBasicParsing ; \
+    Start-Process .\gpg4win.exe -ArgumentList '/S' -NoNewWindow -Wait
+
+RUN @( \
+    '9554F04D7259F04124DE6B476D5A82AC7E37093B', \
+    '94AE36675C464D64BAFA68DD7434390BDBE9B9C5', \
+    'FD3A5288F042B6850C66B31F09FE44734EB7990E', \
+    '71DCFD284A79C3B38668286BC97EC7A07EDE3FC1', \
+    'DD8F2338BAE7501E3DD5AC78C273792F7D83545D', \
+    'B9AE9905FFD7803F25714661B63B535A4C206CA9', \
+    'C4F0DFFF4E8C1A8236409D08E73BC641CC11F4C8', \
+    '56730D5401028683275BD23C23EFEFE93C4CFFFE' \
+    ) | foreach { \
+      gpg --keyserver ha.pool.sks-keyservers.net --recv-keys $_ ; \
+    }
+
+ENV NODE_VERSION 6.11.1
+
+RUN Invoke-WebRequest $('https://nodejs.org/dist/v{0}/SHASUMS256.txt.asc' -f $env:NODE_VERSION) -OutFile 'SHASUMS256.txt.asc' -UseBasicParsing ; \
+    gpg --batch --decrypt --output SHASUMS256.txt SHASUMS256.txt.asc
+
+RUN Invoke-WebRequest $('https://nodejs.org/dist/v{0}/node-v{0}-win-x64.zip' -f $env:NODE_VERSION) -OutFile 'node.zip' -UseBasicParsing ; \
+    $sum = $(cat SHASUMS256.txt.asc | sls $('  node-v{0}-win-x64.zip' -f $env:NODE_VERSION)) -Split ' ' ; \
+    if ((Get-FileHash node.zip -Algorithm sha256).Hash -ne $sum[0]) { Write-Error 'SHA256 mismatch' } ; \
+    Expand-Archive node.zip -DestinationPath C:\ ; \
+    Rename-Item -Path $('C:\node-v{0}-win-x64' -f $env:NODE_VERSION) -NewName 'C:\nodejs'
+
+ENV YARN_VERSION 0.27.5
+
+RUN Invoke-WebRequest $('https://yarnpkg.com/downloads/{0}/yarn-{0}.msi' -f $env:YARN_VERSION) -OutFile yarn.msi -UseBasicParsing ; \
+    $sig = Get-AuthenticodeSignature yarn.msi ; \
+    if ($sig.Status -ne 'Valid') { Write-Error 'Authenticode signature is not valid' } ; \
+    if (@( \
+      '7E253367F8A102A91D04829E37F3410F14B68A5F' \
+      ) -notcontains $sig.SignerCertificate.Thumbprint) { Write-Error 'Unknown signer certificate' } ; \
+    Start-Process msiexec.exe -ArgumentList '/i', 'yarn.msi', '/quiet', '/norestart' -NoNewWindow -Wait
+
+FROM microsoft/nanoserver
+
+SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
+
+ENV NPM_CONFIG_LOGLEVEL info
+
+COPY --from=download /nodejs /nodejs
+COPY --from=download [ "/Program Files (x86)/yarn", "/yarn" ]
+
+RUN New-Item $($env:APPDATA + '\npm') -Type Directory ; \
+    $env:PATH = 'C:\nodejs;{0}\npm;C:\yarn\bin;{1}' -f $env:APPDATA, $env:PATH ; \
+    Set-ItemProperty -Path 'HKLM:\SYSTEM\CurrentControlSet\Control\Session Manager\Environment\' -Name Path -Value $env:PATH
+
+CMD [ "node.exe" ]

--- a/6.11/windows/windowsservercore/Dockerfile
+++ b/6.11/windows/windowsservercore/Dockerfile
@@ -1,0 +1,57 @@
+FROM microsoft/windowsservercore as download
+
+SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
+
+ENV GPG_VERSION 2.3.4
+
+RUN Invoke-WebRequest $('https://files.gpg4win.org/gpg4win-vanilla-{0}.exe' -f $env:GPG_VERSION) -OutFile 'gpg4win.exe' -UseBasicParsing ; \
+    Start-Process .\gpg4win.exe -ArgumentList '/S' -NoNewWindow -Wait
+
+RUN @( \
+    '9554F04D7259F04124DE6B476D5A82AC7E37093B', \
+    '94AE36675C464D64BAFA68DD7434390BDBE9B9C5', \
+    'FD3A5288F042B6850C66B31F09FE44734EB7990E', \
+    '71DCFD284A79C3B38668286BC97EC7A07EDE3FC1', \
+    'DD8F2338BAE7501E3DD5AC78C273792F7D83545D', \
+    'B9AE9905FFD7803F25714661B63B535A4C206CA9', \
+    'C4F0DFFF4E8C1A8236409D08E73BC641CC11F4C8', \
+    '56730D5401028683275BD23C23EFEFE93C4CFFFE' \
+    ) | foreach { \
+      gpg --keyserver ha.pool.sks-keyservers.net --recv-keys $_ ; \
+    }
+
+ENV NODE_VERSION 6.11.1
+
+RUN Invoke-WebRequest $('https://nodejs.org/dist/v{0}/SHASUMS256.txt.asc' -f $env:NODE_VERSION) -OutFile 'SHASUMS256.txt.asc' -UseBasicParsing ; \
+    gpg --batch --decrypt --output SHASUMS256.txt SHASUMS256.txt.asc
+
+RUN Invoke-WebRequest $('https://nodejs.org/dist/v{0}/node-v{0}-win-x64.zip' -f $env:NODE_VERSION) -OutFile 'node.zip' -UseBasicParsing ; \
+    $sum = $(cat SHASUMS256.txt.asc | sls $('  node-v{0}-win-x64.zip' -f $env:NODE_VERSION)) -Split ' ' ; \
+    if ((Get-FileHash node.zip -Algorithm sha256).Hash -ne $sum[0]) { Write-Error 'SHA256 mismatch' } ; \
+    Expand-Archive node.zip -DestinationPath C:\ ; \
+    Rename-Item -Path $('C:\node-v{0}-win-x64' -f $env:NODE_VERSION) -NewName 'C:\nodejs'
+
+ENV YARN_VERSION 0.27.5
+
+RUN Invoke-WebRequest $('https://yarnpkg.com/downloads/{0}/yarn-{0}.msi' -f $env:YARN_VERSION) -OutFile yarn.msi -UseBasicParsing ; \
+    $sig = Get-AuthenticodeSignature yarn.msi ; \
+    if ($sig.Status -ne 'Valid') { Write-Error 'Authenticode signature is not valid' } ; \
+    if (@( \
+      '7E253367F8A102A91D04829E37F3410F14B68A5F' \
+      ) -notcontains $sig.SignerCertificate.Thumbprint) { Write-Error 'Unknown signer certificate' } ; \
+    Start-Process msiexec.exe -ArgumentList '/i', 'yarn.msi', '/quiet', '/norestart' -NoNewWindow -Wait
+
+FROM microsoft/windowsservercore
+
+SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
+
+ENV NPM_CONFIG_LOGLEVEL info
+
+COPY --from=download /nodejs /nodejs
+COPY --from=download [ "/Program Files (x86)/yarn", "/yarn" ]
+
+RUN New-Item $($env:APPDATA + '\npm') -Type Directory ; \
+    $env:PATH = 'C:\nodejs;{0}\npm;C:\yarn\bin;{1}' -f $env:APPDATA, $env:PATH ; \
+    [Environment]::SetEnvironmentVariable('PATH', $env:PATH, [EnvironmentVariableTarget]::Machine)
+
+CMD [ "node.exe" ]

--- a/7.10/slim/Dockerfile
+++ b/7.10/slim/Dockerfile
@@ -42,7 +42,7 @@ RUN buildDeps='xz-utils' \
     && apt-get purge -y --auto-remove $buildDeps \
     && ln -s /usr/local/bin/node /usr/local/bin/nodejs
 
-ENV YARN_VERSION 0.24.4
+ENV YARN_VERSION 0.27.5
 
 RUN set -ex \
   && for key in \

--- a/7.10/windows/nanoserver/Dockerfile
+++ b/7.10/windows/nanoserver/Dockerfile
@@ -1,0 +1,57 @@
+FROM microsoft/windowsservercore as download
+
+SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
+
+ENV GPG_VERSION 2.3.4
+
+RUN Invoke-WebRequest $('https://files.gpg4win.org/gpg4win-vanilla-{0}.exe' -f $env:GPG_VERSION) -OutFile 'gpg4win.exe' -UseBasicParsing ; \
+    Start-Process .\gpg4win.exe -ArgumentList '/S' -NoNewWindow -Wait
+
+RUN @( \
+    '9554F04D7259F04124DE6B476D5A82AC7E37093B', \
+    '94AE36675C464D64BAFA68DD7434390BDBE9B9C5', \
+    'FD3A5288F042B6850C66B31F09FE44734EB7990E', \
+    '71DCFD284A79C3B38668286BC97EC7A07EDE3FC1', \
+    'DD8F2338BAE7501E3DD5AC78C273792F7D83545D', \
+    'B9AE9905FFD7803F25714661B63B535A4C206CA9', \
+    'C4F0DFFF4E8C1A8236409D08E73BC641CC11F4C8', \
+    '56730D5401028683275BD23C23EFEFE93C4CFFFE' \
+    ) | foreach { \
+      gpg --keyserver ha.pool.sks-keyservers.net --recv-keys $_ ; \
+    }
+
+ENV NODE_VERSION 7.10.1
+
+RUN Invoke-WebRequest $('https://nodejs.org/dist/v{0}/SHASUMS256.txt.asc' -f $env:NODE_VERSION) -OutFile 'SHASUMS256.txt.asc' -UseBasicParsing ; \
+    gpg --batch --decrypt --output SHASUMS256.txt SHASUMS256.txt.asc
+
+RUN Invoke-WebRequest $('https://nodejs.org/dist/v{0}/node-v{0}-win-x64.zip' -f $env:NODE_VERSION) -OutFile 'node.zip' -UseBasicParsing ; \
+    $sum = $(cat SHASUMS256.txt.asc | sls $('  node-v{0}-win-x64.zip' -f $env:NODE_VERSION)) -Split ' ' ; \
+    if ((Get-FileHash node.zip -Algorithm sha256).Hash -ne $sum[0]) { Write-Error 'SHA256 mismatch' } ; \
+    Expand-Archive node.zip -DestinationPath C:\ ; \
+    Rename-Item -Path $('C:\node-v{0}-win-x64' -f $env:NODE_VERSION) -NewName 'C:\nodejs'
+
+ENV YARN_VERSION 0.27.5
+
+RUN Invoke-WebRequest $('https://yarnpkg.com/downloads/{0}/yarn-{0}.msi' -f $env:YARN_VERSION) -OutFile yarn.msi -UseBasicParsing ; \
+    $sig = Get-AuthenticodeSignature yarn.msi ; \
+    if ($sig.Status -ne 'Valid') { Write-Error 'Authenticode signature is not valid' } ; \
+    if (@( \
+      '7E253367F8A102A91D04829E37F3410F14B68A5F' \
+      ) -notcontains $sig.SignerCertificate.Thumbprint) { Write-Error 'Unknown signer certificate' } ; \
+    Start-Process msiexec.exe -ArgumentList '/i', 'yarn.msi', '/quiet', '/norestart' -NoNewWindow -Wait
+
+FROM microsoft/nanoserver
+
+SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
+
+ENV NPM_CONFIG_LOGLEVEL info
+
+COPY --from=download /nodejs /nodejs
+COPY --from=download [ "/Program Files (x86)/yarn", "/yarn" ]
+
+RUN New-Item $($env:APPDATA + '\npm') -Type Directory ; \
+    $env:PATH = 'C:\nodejs;{0}\npm;C:\yarn\bin;{1}' -f $env:APPDATA, $env:PATH ; \
+    Set-ItemProperty -Path 'HKLM:\SYSTEM\CurrentControlSet\Control\Session Manager\Environment\' -Name Path -Value $env:PATH
+
+CMD [ "node.exe" ]

--- a/7.10/windows/windowsservercore/Dockerfile
+++ b/7.10/windows/windowsservercore/Dockerfile
@@ -1,0 +1,57 @@
+FROM microsoft/windowsservercore as download
+
+SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
+
+ENV GPG_VERSION 2.3.4
+
+RUN Invoke-WebRequest $('https://files.gpg4win.org/gpg4win-vanilla-{0}.exe' -f $env:GPG_VERSION) -OutFile 'gpg4win.exe' -UseBasicParsing ; \
+    Start-Process .\gpg4win.exe -ArgumentList '/S' -NoNewWindow -Wait
+
+RUN @( \
+    '9554F04D7259F04124DE6B476D5A82AC7E37093B', \
+    '94AE36675C464D64BAFA68DD7434390BDBE9B9C5', \
+    'FD3A5288F042B6850C66B31F09FE44734EB7990E', \
+    '71DCFD284A79C3B38668286BC97EC7A07EDE3FC1', \
+    'DD8F2338BAE7501E3DD5AC78C273792F7D83545D', \
+    'B9AE9905FFD7803F25714661B63B535A4C206CA9', \
+    'C4F0DFFF4E8C1A8236409D08E73BC641CC11F4C8', \
+    '56730D5401028683275BD23C23EFEFE93C4CFFFE' \
+    ) | foreach { \
+      gpg --keyserver ha.pool.sks-keyservers.net --recv-keys $_ ; \
+    }
+
+ENV NODE_VERSION 7.10.1
+
+RUN Invoke-WebRequest $('https://nodejs.org/dist/v{0}/SHASUMS256.txt.asc' -f $env:NODE_VERSION) -OutFile 'SHASUMS256.txt.asc' -UseBasicParsing ; \
+    gpg --batch --decrypt --output SHASUMS256.txt SHASUMS256.txt.asc
+
+RUN Invoke-WebRequest $('https://nodejs.org/dist/v{0}/node-v{0}-win-x64.zip' -f $env:NODE_VERSION) -OutFile 'node.zip' -UseBasicParsing ; \
+    $sum = $(cat SHASUMS256.txt.asc | sls $('  node-v{0}-win-x64.zip' -f $env:NODE_VERSION)) -Split ' ' ; \
+    if ((Get-FileHash node.zip -Algorithm sha256).Hash -ne $sum[0]) { Write-Error 'SHA256 mismatch' } ; \
+    Expand-Archive node.zip -DestinationPath C:\ ; \
+    Rename-Item -Path $('C:\node-v{0}-win-x64' -f $env:NODE_VERSION) -NewName 'C:\nodejs'
+
+ENV YARN_VERSION 0.27.5
+
+RUN Invoke-WebRequest $('https://yarnpkg.com/downloads/{0}/yarn-{0}.msi' -f $env:YARN_VERSION) -OutFile yarn.msi -UseBasicParsing ; \
+    $sig = Get-AuthenticodeSignature yarn.msi ; \
+    if ($sig.Status -ne 'Valid') { Write-Error 'Authenticode signature is not valid' } ; \
+    if (@( \
+      '7E253367F8A102A91D04829E37F3410F14B68A5F' \
+      ) -notcontains $sig.SignerCertificate.Thumbprint) { Write-Error 'Unknown signer certificate' } ; \
+    Start-Process msiexec.exe -ArgumentList '/i', 'yarn.msi', '/quiet', '/norestart' -NoNewWindow -Wait
+
+FROM microsoft/windowsservercore
+
+SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
+
+ENV NPM_CONFIG_LOGLEVEL info
+
+COPY --from=download /nodejs /nodejs
+COPY --from=download [ "/Program Files (x86)/yarn", "/yarn" ]
+
+RUN New-Item $($env:APPDATA + '\npm') -Type Directory ; \
+    $env:PATH = 'C:\nodejs;{0}\npm;C:\yarn\bin;{1}' -f $env:APPDATA, $env:PATH ; \
+    [Environment]::SetEnvironmentVariable('PATH', $env:PATH, [EnvironmentVariableTarget]::Machine)
+
+CMD [ "node.exe" ]

--- a/8.2/windows/nanoserver/Dockerfile
+++ b/8.2/windows/nanoserver/Dockerfile
@@ -1,0 +1,57 @@
+FROM microsoft/windowsservercore as download
+
+SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
+
+ENV GPG_VERSION 2.3.4
+
+RUN Invoke-WebRequest $('https://files.gpg4win.org/gpg4win-vanilla-{0}.exe' -f $env:GPG_VERSION) -OutFile 'gpg4win.exe' -UseBasicParsing ; \
+    Start-Process .\gpg4win.exe -ArgumentList '/S' -NoNewWindow -Wait
+
+RUN @( \
+    '9554F04D7259F04124DE6B476D5A82AC7E37093B', \
+    '94AE36675C464D64BAFA68DD7434390BDBE9B9C5', \
+    'FD3A5288F042B6850C66B31F09FE44734EB7990E', \
+    '71DCFD284A79C3B38668286BC97EC7A07EDE3FC1', \
+    'DD8F2338BAE7501E3DD5AC78C273792F7D83545D', \
+    'B9AE9905FFD7803F25714661B63B535A4C206CA9', \
+    'C4F0DFFF4E8C1A8236409D08E73BC641CC11F4C8', \
+    '56730D5401028683275BD23C23EFEFE93C4CFFFE' \
+    ) | foreach { \
+      gpg --keyserver ha.pool.sks-keyservers.net --recv-keys $_ ; \
+    }
+
+ENV NODE_VERSION 8.2.1
+
+RUN Invoke-WebRequest $('https://nodejs.org/dist/v{0}/SHASUMS256.txt.asc' -f $env:NODE_VERSION) -OutFile 'SHASUMS256.txt.asc' -UseBasicParsing ; \
+    gpg --batch --decrypt --output SHASUMS256.txt SHASUMS256.txt.asc
+
+RUN Invoke-WebRequest $('https://nodejs.org/dist/v{0}/node-v{0}-win-x64.zip' -f $env:NODE_VERSION) -OutFile 'node.zip' -UseBasicParsing ; \
+    $sum = $(cat SHASUMS256.txt.asc | sls $('  node-v{0}-win-x64.zip' -f $env:NODE_VERSION)) -Split ' ' ; \
+    if ((Get-FileHash node.zip -Algorithm sha256).Hash -ne $sum[0]) { Write-Error 'SHA256 mismatch' } ; \
+    Expand-Archive node.zip -DestinationPath C:\ ; \
+    Rename-Item -Path $('C:\node-v{0}-win-x64' -f $env:NODE_VERSION) -NewName 'C:\nodejs'
+
+ENV YARN_VERSION 0.27.5
+
+RUN Invoke-WebRequest $('https://yarnpkg.com/downloads/{0}/yarn-{0}.msi' -f $env:YARN_VERSION) -OutFile yarn.msi -UseBasicParsing ; \
+    $sig = Get-AuthenticodeSignature yarn.msi ; \
+    if ($sig.Status -ne 'Valid') { Write-Error 'Authenticode signature is not valid' } ; \
+    if (@( \
+      '7E253367F8A102A91D04829E37F3410F14B68A5F' \
+      ) -notcontains $sig.SignerCertificate.Thumbprint) { Write-Error 'Unknown signer certificate' } ; \
+    Start-Process msiexec.exe -ArgumentList '/i', 'yarn.msi', '/quiet', '/norestart' -NoNewWindow -Wait
+
+FROM microsoft/nanoserver
+
+SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
+
+ENV NPM_CONFIG_LOGLEVEL info
+
+COPY --from=download /nodejs /nodejs
+COPY --from=download [ "/Program Files (x86)/yarn", "/yarn" ]
+
+RUN New-Item $($env:APPDATA + '\npm') -Type Directory ; \
+    $env:PATH = 'C:\nodejs;{0}\npm;C:\yarn\bin;{1}' -f $env:APPDATA, $env:PATH ; \
+    Set-ItemProperty -Path 'HKLM:\SYSTEM\CurrentControlSet\Control\Session Manager\Environment\' -Name Path -Value $env:PATH
+
+CMD [ "node.exe" ]

--- a/8.2/windows/windowsservercore/Dockerfile
+++ b/8.2/windows/windowsservercore/Dockerfile
@@ -1,0 +1,57 @@
+FROM microsoft/windowsservercore as download
+
+SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
+
+ENV GPG_VERSION 2.3.4
+
+RUN Invoke-WebRequest $('https://files.gpg4win.org/gpg4win-vanilla-{0}.exe' -f $env:GPG_VERSION) -OutFile 'gpg4win.exe' -UseBasicParsing ; \
+    Start-Process .\gpg4win.exe -ArgumentList '/S' -NoNewWindow -Wait
+
+RUN @( \
+    '9554F04D7259F04124DE6B476D5A82AC7E37093B', \
+    '94AE36675C464D64BAFA68DD7434390BDBE9B9C5', \
+    'FD3A5288F042B6850C66B31F09FE44734EB7990E', \
+    '71DCFD284A79C3B38668286BC97EC7A07EDE3FC1', \
+    'DD8F2338BAE7501E3DD5AC78C273792F7D83545D', \
+    'B9AE9905FFD7803F25714661B63B535A4C206CA9', \
+    'C4F0DFFF4E8C1A8236409D08E73BC641CC11F4C8', \
+    '56730D5401028683275BD23C23EFEFE93C4CFFFE' \
+    ) | foreach { \
+      gpg --keyserver ha.pool.sks-keyservers.net --recv-keys $_ ; \
+    }
+
+ENV NODE_VERSION 8.2.1
+
+RUN Invoke-WebRequest $('https://nodejs.org/dist/v{0}/SHASUMS256.txt.asc' -f $env:NODE_VERSION) -OutFile 'SHASUMS256.txt.asc' -UseBasicParsing ; \
+    gpg --batch --decrypt --output SHASUMS256.txt SHASUMS256.txt.asc
+
+RUN Invoke-WebRequest $('https://nodejs.org/dist/v{0}/node-v{0}-win-x64.zip' -f $env:NODE_VERSION) -OutFile 'node.zip' -UseBasicParsing ; \
+    $sum = $(cat SHASUMS256.txt.asc | sls $('  node-v{0}-win-x64.zip' -f $env:NODE_VERSION)) -Split ' ' ; \
+    if ((Get-FileHash node.zip -Algorithm sha256).Hash -ne $sum[0]) { Write-Error 'SHA256 mismatch' } ; \
+    Expand-Archive node.zip -DestinationPath C:\ ; \
+    Rename-Item -Path $('C:\node-v{0}-win-x64' -f $env:NODE_VERSION) -NewName 'C:\nodejs'
+
+ENV YARN_VERSION 0.27.5
+
+RUN Invoke-WebRequest $('https://yarnpkg.com/downloads/{0}/yarn-{0}.msi' -f $env:YARN_VERSION) -OutFile yarn.msi -UseBasicParsing ; \
+    $sig = Get-AuthenticodeSignature yarn.msi ; \
+    if ($sig.Status -ne 'Valid') { Write-Error 'Authenticode signature is not valid' } ; \
+    if (@( \
+      '7E253367F8A102A91D04829E37F3410F14B68A5F' \
+      ) -notcontains $sig.SignerCertificate.Thumbprint) { Write-Error 'Unknown signer certificate' } ; \
+    Start-Process msiexec.exe -ArgumentList '/i', 'yarn.msi', '/quiet', '/norestart' -NoNewWindow -Wait
+
+FROM microsoft/windowsservercore
+
+SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
+
+ENV NPM_CONFIG_LOGLEVEL info
+
+COPY --from=download /nodejs /nodejs
+COPY --from=download [ "/Program Files (x86)/yarn", "/yarn" ]
+
+RUN New-Item $($env:APPDATA + '\npm') -Type Directory ; \
+    $env:PATH = 'C:\nodejs;{0}\npm;C:\yarn\bin;{1}' -f $env:APPDATA, $env:PATH ; \
+    [Environment]::SetEnvironmentVariable('PATH', $env:PATH, [EnvironmentVariableTarget]::Machine)
+
+CMD [ "node.exe" ]

--- a/Dockerfile-nanoserver.template
+++ b/Dockerfile-nanoserver.template
@@ -1,0 +1,57 @@
+FROM microsoft/windowsservercore as download
+
+SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
+
+ENV GPG_VERSION 2.3.4
+
+RUN Invoke-WebRequest $('https://files.gpg4win.org/gpg4win-vanilla-{0}.exe' -f $env:GPG_VERSION) -OutFile 'gpg4win.exe' -UseBasicParsing ; \
+    Start-Process .\gpg4win.exe -ArgumentList '/S' -NoNewWindow -Wait
+
+RUN @( \
+    '9554F04D7259F04124DE6B476D5A82AC7E37093B', \
+    '94AE36675C464D64BAFA68DD7434390BDBE9B9C5', \
+    'FD3A5288F042B6850C66B31F09FE44734EB7990E', \
+    '71DCFD284A79C3B38668286BC97EC7A07EDE3FC1', \
+    'DD8F2338BAE7501E3DD5AC78C273792F7D83545D', \
+    'B9AE9905FFD7803F25714661B63B535A4C206CA9', \
+    'C4F0DFFF4E8C1A8236409D08E73BC641CC11F4C8', \
+    '56730D5401028683275BD23C23EFEFE93C4CFFFE' \
+    ) | foreach { \
+      gpg --keyserver ha.pool.sks-keyservers.net --recv-keys $_ ; \
+    }
+
+ENV NODE_VERSION 0.0.0
+
+RUN Invoke-WebRequest $('https://nodejs.org/dist/v{0}/SHASUMS256.txt.asc' -f $env:NODE_VERSION) -OutFile 'SHASUMS256.txt.asc' -UseBasicParsing ; \
+    gpg --batch --decrypt --output SHASUMS256.txt SHASUMS256.txt.asc
+
+RUN Invoke-WebRequest $('https://nodejs.org/dist/v{0}/node-v{0}-win-x64.zip' -f $env:NODE_VERSION) -OutFile 'node.zip' -UseBasicParsing ; \
+    $sum = $(cat SHASUMS256.txt.asc | sls $('  node-v{0}-win-x64.zip' -f $env:NODE_VERSION)) -Split ' ' ; \
+    if ((Get-FileHash node.zip -Algorithm sha256).Hash -ne $sum[0]) { Write-Error 'SHA256 mismatch' } ; \
+    Expand-Archive node.zip -DestinationPath C:\ ; \
+    Rename-Item -Path $('C:\node-v{0}-win-x64' -f $env:NODE_VERSION) -NewName 'C:\nodejs'
+
+ENV YARN_VERSION 0.0.0
+
+RUN Invoke-WebRequest $('https://yarnpkg.com/downloads/{0}/yarn-{0}.msi' -f $env:YARN_VERSION) -OutFile yarn.msi -UseBasicParsing ; \
+    $sig = Get-AuthenticodeSignature yarn.msi ; \
+    if ($sig.Status -ne 'Valid') { Write-Error 'Authenticode signature is not valid' } ; \
+    if (@( \
+      '7E253367F8A102A91D04829E37F3410F14B68A5F' \
+      ) -notcontains $sig.SignerCertificate.Thumbprint) { Write-Error 'Unknown signer certificate' } ; \
+    Start-Process msiexec.exe -ArgumentList '/i', 'yarn.msi', '/quiet', '/norestart' -NoNewWindow -Wait
+
+FROM microsoft/nanoserver
+
+SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
+
+ENV NPM_CONFIG_LOGLEVEL info
+
+COPY --from=download /nodejs /nodejs
+COPY --from=download [ "/Program Files (x86)/yarn", "/yarn" ]
+
+RUN New-Item $($env:APPDATA + '\npm') -Type Directory ; \
+    $env:PATH = 'C:\nodejs;{0}\npm;C:\yarn\bin;{1}' -f $env:APPDATA, $env:PATH ; \
+    Set-ItemProperty -Path 'HKLM:\SYSTEM\CurrentControlSet\Control\Session Manager\Environment\' -Name Path -Value $env:PATH
+
+CMD [ "node.exe" ]

--- a/Dockerfile-windowsservercore.template
+++ b/Dockerfile-windowsservercore.template
@@ -1,0 +1,57 @@
+FROM microsoft/windowsservercore as download
+
+SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
+
+ENV GPG_VERSION 2.3.4
+
+RUN Invoke-WebRequest $('https://files.gpg4win.org/gpg4win-vanilla-{0}.exe' -f $env:GPG_VERSION) -OutFile 'gpg4win.exe' -UseBasicParsing ; \
+    Start-Process .\gpg4win.exe -ArgumentList '/S' -NoNewWindow -Wait
+
+RUN @( \
+    '9554F04D7259F04124DE6B476D5A82AC7E37093B', \
+    '94AE36675C464D64BAFA68DD7434390BDBE9B9C5', \
+    'FD3A5288F042B6850C66B31F09FE44734EB7990E', \
+    '71DCFD284A79C3B38668286BC97EC7A07EDE3FC1', \
+    'DD8F2338BAE7501E3DD5AC78C273792F7D83545D', \
+    'B9AE9905FFD7803F25714661B63B535A4C206CA9', \
+    'C4F0DFFF4E8C1A8236409D08E73BC641CC11F4C8', \
+    '56730D5401028683275BD23C23EFEFE93C4CFFFE' \
+    ) | foreach { \
+      gpg --keyserver ha.pool.sks-keyservers.net --recv-keys $_ ; \
+    }
+
+ENV NODE_VERSION 0.0.0
+
+RUN Invoke-WebRequest $('https://nodejs.org/dist/v{0}/SHASUMS256.txt.asc' -f $env:NODE_VERSION) -OutFile 'SHASUMS256.txt.asc' -UseBasicParsing ; \
+    gpg --batch --decrypt --output SHASUMS256.txt SHASUMS256.txt.asc
+
+RUN Invoke-WebRequest $('https://nodejs.org/dist/v{0}/node-v{0}-win-x64.zip' -f $env:NODE_VERSION) -OutFile 'node.zip' -UseBasicParsing ; \
+    $sum = $(cat SHASUMS256.txt.asc | sls $('  node-v{0}-win-x64.zip' -f $env:NODE_VERSION)) -Split ' ' ; \
+    if ((Get-FileHash node.zip -Algorithm sha256).Hash -ne $sum[0]) { Write-Error 'SHA256 mismatch' } ; \
+    Expand-Archive node.zip -DestinationPath C:\ ; \
+    Rename-Item -Path $('C:\node-v{0}-win-x64' -f $env:NODE_VERSION) -NewName 'C:\nodejs'
+
+ENV YARN_VERSION 0.0.0
+
+RUN Invoke-WebRequest $('https://yarnpkg.com/downloads/{0}/yarn-{0}.msi' -f $env:YARN_VERSION) -OutFile yarn.msi -UseBasicParsing ; \
+    $sig = Get-AuthenticodeSignature yarn.msi ; \
+    if ($sig.Status -ne 'Valid') { Write-Error 'Authenticode signature is not valid' } ; \
+    if (@( \
+      '7E253367F8A102A91D04829E37F3410F14B68A5F' \
+      ) -notcontains $sig.SignerCertificate.Thumbprint) { Write-Error 'Unknown signer certificate' } ; \
+    Start-Process msiexec.exe -ArgumentList '/i', 'yarn.msi', '/quiet', '/norestart' -NoNewWindow -Wait
+
+FROM microsoft/windowsservercore
+
+SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
+
+ENV NPM_CONFIG_LOGLEVEL info
+
+COPY --from=download /nodejs /nodejs
+COPY --from=download [ "/Program Files (x86)/yarn", "/yarn" ]
+
+RUN New-Item $($env:APPDATA + '\npm') -Type Directory ; \
+    $env:PATH = 'C:\nodejs;{0}\npm;C:\yarn\bin;{1}' -f $env:APPDATA, $env:PATH ; \
+    [Environment]::SetEnvironmentVariable('PATH', $env:PATH, [EnvironmentVariableTarget]::Machine)
+
+CMD [ "node.exe" ]

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,9 @@
+version: 1.0.{build}
+image: Visual Studio 2017
+
+build_script:
+  - ps: Install-Package -Name docker -ProviderName DockerMsftProvider -RequiredVersion 17.06.1-ee-1-rc1 -Force
+  - ps: start-service docker
+  - docker pull microsoft/windowsservercore
+  - docker pull microsoft/nanoserver
+  - ps: .\test-build.ps1

--- a/architectures
+++ b/architectures
@@ -1,3 +1,4 @@
 bashbrew-arch   variants
 amd64     default,alpine,onbuild,slim,stretch,wheezy
 ppc64le default,onbuild,slim,stretch
+windows-amd64  windowsservercore,nanoserver

--- a/functions.sh
+++ b/functions.sh
@@ -36,8 +36,12 @@ function get_arch() {
 function get_variants() {
 	local arch
 	arch=$(get_arch)
+	if [[ $# -eq 1 ]]; then
+		arch=$1
+		shift
+	fi
 	local variants
-	variants=$(grep "$arch" architectures | sed -E 's/'"$arch"'\s*//' | sed -E 's/,/ /g')
+	variants=$(grep "^$arch" architectures | sed -E 's/'"$arch"'\s*//' | sed -E 's/,/ /g')
 	echo "$variants"
 }
 

--- a/generate-stackbrew-library.sh
+++ b/generate-stackbrew-library.sh
@@ -63,7 +63,7 @@ for version in "${versions[@]}"; do
 
 	# Get supported variants according to the target architecture.
 	# See details in function.sh
-	variants=$(get_variants | tr ' ' '\n')
+	variants=$(get_variants "$(get_arch)" | tr ' ' '\n')
 	for variant in $variants; do
 		# Skip non-docker directories
 		[ -f "$version/$variant/Dockerfile" ] || continue
@@ -81,6 +81,27 @@ for version in "${versions[@]}"; do
 		echo "Architectures: $(join ', ' "${supportedArches[@]}")"
 		echo "GitCommit: ${commit}"
 		echo "Directory: ${version}/${variant}"
+		echo
+	done
+
+	variants=$(get_variants windows-amd64 | tr ' ' '\n')
+	for variant in $variants; do
+		# Skip non-docker directories
+		[ -f "$version/windows/$variant/Dockerfile" ] || continue
+
+		commit="$(fileCommit "$version/windows/$variant")"
+
+		slash='/'
+		variantAliases=( "${versionAliases[@]/%/-${variant//$slash/-}}" )
+		variantAliases=( "${variantAliases[@]//latest-/}" )
+		# Get supported architectures for a specific version and variant.
+		# See details in function.sh
+		supportedArches=( $(get_supported_arches "$version" "$variant") )
+
+		echo "Tags: $(join ', ' "${variantAliases[@]}")"
+		echo "Architectures: $(join ', ' "${supportedArches[@]}")"
+		echo "GitCommit: ${commit}"
+		echo "Directory: ${version}/windows/${variant}"
 		echo
 	done
 done

--- a/test-build.ps1
+++ b/test-build.ps1
@@ -1,0 +1,18 @@
+$ErrorActionPreference = 'Stop'
+
+ForEach ($Dir in dir -directory | where { $_.Name -ne "docs" }) {
+  $tag = ((cat $Dir\windows\windowsservercore\Dockerfile | Select-String -Pattern 'ENV NODE_VERSION') -split ' ')[2]
+
+  $variants = @('windowsservercore', 'nanoserver')
+  ForEach ($variant in $variants) {
+    Write-Host Building node:$tag-$variant
+    docker build -t node:$tag-$variant $Dir/windows/$variant
+
+    $OUTPUT=$(docker run --rm node:$tag-$variant node -e "process.stdout.write(process.versions.node)")
+    if ( "$OUTPUT" -Ne "$tag" ) {
+      Write-Error "Test of $tag-$variant failed!"
+    } else {
+      Write-Host "Test of $tag-$variant succeeded."
+    }
+  }
+}

--- a/test-build.sh
+++ b/test-build.sh
@@ -47,7 +47,7 @@ for version in "${versions[@]}"; do
 
   # Get supported variants according to the target architecture.
   # See details in function.sh
-  variants=$(get_variants | tr ' ' '\n')
+  variants=$(get_variants "$(get_arch)" | tr ' ' '\n')
 
   for variant in $variants; do
     # Skip non-docker directories

--- a/update.sh
+++ b/update.sh
@@ -40,7 +40,7 @@ function update_node_version {
 		fi
 
 		sed -E -i.bak 's/^FROM (.*)/FROM '"$fromprefix"'\1/' "$dockerfile" && rm "$dockerfile".bak
-		sed -E -i.bak 's/^(ENV NODE_VERSION |FROM .*node:).*/\1'"$version.$fullVersion"'/' "$dockerfile" && rm "$dockerfile".bak
+		sed -E -i.bak 's/^(ENV NODE_VERSION |FROM .*node:)0.0.0/\1'"$version.$fullVersion"'/' "$dockerfile" && rm "$dockerfile".bak
 		sed -E -i.bak 's/^(ENV YARN_VERSION ).*/\1'"$yarnVersion"'/' "$dockerfile" && rm "$dockerfile".bak
 		if [[ "${version/.*/}" -ge 8 || "$arch" = "ppc64le" ]]; then
 			sed -E -i.bak 's/FROM (.*)alpine:3.4/FROM \1alpine:3.6/' "$dockerfile"
@@ -63,6 +63,16 @@ for version in "${versions[@]}"; do
 		# Skip non-docker directories
 		[ -f "$version/$variant/Dockerfile" ] || continue
 		update_node_version "Dockerfile-$variant.template" "$version/$variant/Dockerfile" "$variant"
+	done
 
+	variants=$(get_variants windows-amd64)
+
+	for variant in $variants; do
+		# Skip non-docker directories
+		echo "$version/windows/$variant/Dockerfile"
+		[ -f "$version/windows/$variant/Dockerfile" ] || continue
+		slash='/'
+		variantDash=${variant//$slash/-}
+		update_node_version "Dockerfile-$variantDash.template" "$version/windows/$variant/Dockerfile" "$variant"
 	done
 done


### PR DESCRIPTION
This PR introduces Dockerfiles for both Windows base OS images `windowsservercore` and `nanoserver`.

You can use AppVeyor for test builds like the Travis builds for Linux. The `appveyor.yml` is provided with this PR. It runs `test-build.ps1` which builds and tests the images like the `test-build.sh` script.

See https://ci.appveyor.com/project/StefanScherer/docker-node for an example.

Supersedes #222 and #223 