### PR TITLE
feat: add libelf1

### DIFF
--- a/4.8/Dockerfile
+++ b/4.8/Dockerfile
@@ -21,7 +21,11 @@ RUN set -ex \
 ENV NPM_CONFIG_LOGLEVEL info
 ENV NODE_VERSION 4.8.1
 
-RUN curl -SLO "https://nodejs.org/dist/v$NODE_VERSION/node-v$NODE_VERSION-linux-x64.tar.xz" \
+RUN set -ex \
+  && apt-get update \
+  && apt-get install -y libelf1 \
+  && rm -rf /var/lib/apt/lists/* \
+  && curl -SLO "https://nodejs.org/dist/v$NODE_VERSION/node-v$NODE_VERSION-linux-x64.tar.xz" \
   && curl -SLO "https://nodejs.org/dist/v$NODE_VERSION/SHASUMS256.txt.asc" \
   && gpg --batch --decrypt --output SHASUMS256.txt SHASUMS256.txt.asc \
   && grep " node-v$NODE_VERSION-linux-x64.tar.xz\$" SHASUMS256.txt | sha256sum -c - \

--- a/6.10/Dockerfile
+++ b/6.10/Dockerfile
@@ -21,7 +21,11 @@ RUN set -ex \
 ENV NPM_CONFIG_LOGLEVEL info
 ENV NODE_VERSION 6.10.1
 
-RUN curl -SLO "https://nodejs.org/dist/v$NODE_VERSION/node-v$NODE_VERSION-linux-x64.tar.xz" \
+RUN set -ex \
+  && apt-get update \
+  && apt-get install -y libelf1 \
+  && rm -rf /var/lib/apt/lists/* \
+  && curl -SLO "https://nodejs.org/dist/v$NODE_VERSION/node-v$NODE_VERSION-linux-x64.tar.xz" \
   && curl -SLO "https://nodejs.org/dist/v$NODE_VERSION/SHASUMS256.txt.asc" \
   && gpg --batch --decrypt --output SHASUMS256.txt SHASUMS256.txt.asc \
   && grep " node-v$NODE_VERSION-linux-x64.tar.xz\$" SHASUMS256.txt | sha256sum -c - \

--- a/7.7/Dockerfile
+++ b/7.7/Dockerfile
@@ -21,7 +21,11 @@ RUN set -ex \
 ENV NPM_CONFIG_LOGLEVEL info
 ENV NODE_VERSION 7.7.4
 
-RUN curl -SLO "https://nodejs.org/dist/v$NODE_VERSION/node-v$NODE_VERSION-linux-x64.tar.xz" \
+RUN set -ex \
+  && apt-get update \
+  && apt-get install -y libelf1 \
+  && rm -rf /var/lib/apt/lists/* \
+  && curl -SLO "https://nodejs.org/dist/v$NODE_VERSION/node-v$NODE_VERSION-linux-x64.tar.xz" \
   && curl -SLO "https://nodejs.org/dist/v$NODE_VERSION/SHASUMS256.txt.asc" \
   && gpg --batch --decrypt --output SHASUMS256.txt SHASUMS256.txt.asc \
   && grep " node-v$NODE_VERSION-linux-x64.tar.xz\$" SHASUMS256.txt | sha256sum -c - \


### PR DESCRIPTION
libelf1 is required by Flowtype (https://flowtype.org/) to store binaries and extract them at the runtime. Running `flow-bin` on a machine without libelf1 will product the following error:

```
/srv/node_modules/flow-bin/flow-linux64-v0.41.0/flow: error while loading shared libraries: libelf.so.1: cannot open shared object file: No such file or directory
```

https://www.npmjs.com/package/flow-bin is a popular program (over 880k downloads a month). Lack of an official Node.js image with flow-bin support results in a lot of avoidable image builds for the sole purpose of adding libelf1.

Adding libelf1 increases the final image size by 2MB (from 666MB to 668MB, measured using the 7.7 base image).

Fixes:

* https://github.com/flowtype/flow-bin/issues/58
* https://github.com/facebook/flow/issues/210