### PR TITLE
Add postinstall step

### DIFF
--- a/Dockerfile-onbuild.template
+++ b/Dockerfile-onbuild.template
@@ -8,5 +8,6 @@ ONBUILD ENV NODE_ENV $NODE_ENV
 ONBUILD COPY package.json /usr/src/app/
 ONBUILD RUN npm install && npm cache clean
 ONBUILD COPY . /usr/src/app
+ONBUILD RUN npm run postinstall
 
 CMD [ "npm", "start" ]


### PR DESCRIPTION
AS the initial install won't actually run the postinstall, running the postinstall would probably be a good idea after copying the rest of the application.  This would be much closer to the expected behavior.