### PR TITLE
Update BestPractices.md to remove alpine user

### DIFF
--- a/docs/BestPractices.md
+++ b/docs/BestPractices.md
@@ -30,13 +30,8 @@ When using the `onbuild` variant, add the user like so:
 FROM node:4.1.2-onbuild
 # Add our user and group first to make sure their IDs get assigned consistently
 RUN groupadd -r node && useradd -r -g node node
-```
-
-When using the `alpine` variant, add the user like so:
-
-```Dockerfile
-FROM node:7.3.0-alpine
-RUN addgroup -S node && adduser -S -g node node 
+# Set the user to use when running this image
+USER node
 ```
 
 ## Memory


### PR DESCRIPTION
Since the `node` user was added to the alpine variant, there is no need to recommend that they need to create the `node` user. In fact, it would break. Only the `onbuild` variant does not have the user.

I also added the `USER node` syntax to show how to [set the user](https://docs.docker.com/engine/reference/builder/#user) in the dockerfile.