### PR TITLE
Add CONTRIBUTING.md including Yarn version update policy

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,7 @@
+# Version Updates
+
+New **Node.js** releases are released as soon as possible.
+
+New **NPM** releases are not tracked. We simply use the NPM version bundled in the corresponding Node.js release.
+
+**Yarn** is updated to the latest version only when there is a new Node.js SemVer-minor release, and it's updated only in the branch with the new release, preferably in the same PR. The `update.sh` script does this automatically when invoked with a specific branch, e.g. `./update.sh 6.10`.


### PR DESCRIPTION
There has been some confusion recently regarding when/how Yarn versions should be updated. I think we should agree on a specific strategy and document it somewhere. A `CONTRIBUTING.md` file seems like a good place for that, especially given that there is a broken link to it in our `README.md` :smile: 

The current proposal aims to ensure that a new Yarn release does not cause regressions in an already published SemVer-minor image tag. It's partially motivated by previous issues such as #386. It might be updated after Yarn 1.0 is released.

/cc @nodejs/docker @PeterDaveHello @Daniel15 @bestander for comments.