### PR TITLE
Upgrade alpine in node@8 to 3.6

### DIFF
--- a/8.0/alpine/Dockerfile
+++ b/8.0/alpine/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.4
+FROM alpine:3.6
 
 ENV NPM_CONFIG_LOGLEVEL info
 ENV NODE_VERSION 8.0.0


### PR DESCRIPTION
Just 8.0, right?

This does _not_ update `Dockerfile-alpine.template`, which means running `update.sh` will rollback the version in this dockerfile. Is that expected/wanted?