### PR TITLE
Add Simen Brekkhus (@SimenB) as a collaborator

### DIFF
--- a/README.md
+++ b/README.md
@@ -250,3 +250,4 @@ about the expectations for all contributors to this project.
 
  * Mikeal Rogers ([mikeal](https://github.com/mikeal))
  * Laurent Goderre ([LaurentGoderre](https://github.com/LaurentGoderre))
+ * Simen Bekkhus ([SimenB](https://github.com/SimenB))


### PR DESCRIPTION
From  [Docker WG Governance Document on Collaborators](https://github.com/nodejs/docker-node/blob/master/GOVERNANCE.md#collaborators):

> Individuals making significant and valuable contributions are made Collaborators and given commit-access to the project. These individuals are identified by the WG and their addition as Collaborators is discussed as a pull request to this project's README.md.

I propose adding Simen Brekkhus (@SimenB) as a _Collaborator_ to the @nodejs/docker team for his contributions to #272 #377 #383 #400 #411 and soon #412 #413.