### PR TITLE
Don't clean npm cache after install

### DIFF
--- a/8.0/onbuild/Dockerfile
+++ b/8.0/onbuild/Dockerfile
@@ -6,7 +6,7 @@ WORKDIR /usr/src/app
 ONBUILD ARG NODE_ENV
 ONBUILD ENV NODE_ENV $NODE_ENV
 ONBUILD COPY package.json /usr/src/app/
-ONBUILD RUN npm install && npm cache clean
+ONBUILD RUN npm install
 ONBUILD COPY . /usr/src/app
 
 CMD [ "npm", "start" ]


### PR DESCRIPTION
This now errors:

```
npm ERR! As of npm@5, the npm cache self-heals from corruption issues and data extracted from the cache is guaranteed to be valid. If you want to make sure everything is consistent, use 'npm cache verify' instead.
npm ERR!
npm ERR! If you're sure you want to delete the entire cache, rerun this command with --force.
```

Fixes: https://github.com/nodejs/docker-node/issues/419