### PR TITLE
Force cache cleaning

### DIFF
--- a/8.0/onbuild/Dockerfile
+++ b/8.0/onbuild/Dockerfile
@@ -6,7 +6,7 @@ WORKDIR /usr/src/app
 ONBUILD ARG NODE_ENV
 ONBUILD ENV NODE_ENV $NODE_ENV
 ONBUILD COPY package.json /usr/src/app/
-ONBUILD RUN npm install && npm cache clean
+ONBUILD RUN npm install && npm cache clean --force
 ONBUILD COPY . /usr/src/app
 
 CMD [ "npm", "start" ]

--- a/Dockerfile-onbuild.template
+++ b/Dockerfile-onbuild.template
@@ -6,7 +6,7 @@ WORKDIR /usr/src/app
 ONBUILD ARG NODE_ENV
 ONBUILD ENV NODE_ENV $NODE_ENV
 ONBUILD COPY package.json /usr/src/app/
-ONBUILD RUN npm install && npm cache clean
+ONBUILD RUN npm install && npm cache clean --force
 ONBUILD COPY . /usr/src/app
 
 CMD [ "npm", "start" ]


### PR DESCRIPTION
Fixes #419 properly
Replaces #420 #421 

Only updated the 8.x Dockerfile for now, because the fix only concerns NPM 5. It is backwards-compatible so future updates to older branches won't be an issue.