### PR TITLE
Automated Docker Library PR's

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,17 @@
 sudo: required
-
 services:
-    - docker
-
+- docker
 script:
-    - ./test-build.sh $NODE_VERSION
-
+- "./test-build.sh $NODE_VERSION"
 env:
-    matrix :
-        - NODE_VERSION: '4.8'
-        - NODE_VERSION: '6.11'
-        - NODE_VERSION: '8.1'
+  matrix:
+  - NODE_VERSION: '4.8'
+  - NODE_VERSION: '6.11'
+  - NODE_VERSION: '8.1'
+  global:
+    secure: kV7nldhsQlx4MaRfk8lgUnSsIJ0ZciF63GUUQLPogAEaO4/lgM8nC81OXmnHwkhyFSdZbIDl3E8LCLLsx7nVnlzjY2yrjQPkEEnPsMcD6chudLBDtnyDv7drjYbt/3MeT8ZV8WKwrM69GkV0AK+/MZwRCXHSqpG5XYNlNnzJHoA=
+deploy:
+  provider: script
+  script: generate-stackbrew-pr.sh
+  on:
+    branch: master

--- a/generate-stackbrew-library.sh
+++ b/generate-stackbrew-library.sh
@@ -26,6 +26,7 @@ fileCommit() {
 echo "# this file is generated via ${url}/blob/$(fileCommit "$self")/$self"
 echo
 echo "Maintainers: The Node.js Docker Team <${url}> (@nodejs)"
+echo "PR Bot Maintainer: Hank Brekke <brekkehj@hnryjms.io> (@hnryjms)"
 echo "GitRepo: ${url}.git"
 echo
 
@@ -39,6 +40,7 @@ join() {
 for version in "${versions[@]}"; do
 	# Skip "docs" and other non-docker directories
 	[ -f "$version/Dockerfile" ] || continue
+	[ "$version" != "docker-images" ] || continue
 
 	eval stub=$(echo "$version" | awk -F. '{ print "$array_" $1 "_" $2 }');
 	commit="$(fileCommit "$version")"

--- a/generate-stackbrew-library.sh
+++ b/generate-stackbrew-library.sh
@@ -26,7 +26,7 @@ fileCommit() {
 echo "# this file is generated via ${url}/blob/$(fileCommit "$self")/$self"
 echo
 echo "Maintainers: The Node.js Docker Team <${url}> (@nodejs)"
-echo "PR Bot Maintainer: Hank Brekke <brekkehj@hnryjms.io> (@hnryjms)"
+echo "# PR Bot Maintainer: Hank Brekke <brekkehj@hnryjms.io> (@hnryjms)"
 echo "GitRepo: ${url}.git"
 echo
 

--- a/generate-stackbrew-pr.sh
+++ b/generate-stackbrew-pr.sh
@@ -1,0 +1,67 @@
+#!/bin/bash
+set -e
+
+GITHUB_USERNAME="nodejs-docker-bot"
+IMAGES_FILE="library/node"
+
+TRIGGER_COMMIT="$(git log -1 --pretty=%B)"
+ISSUE_REFS=$(echo "$TRIGGER_COMMIT" | grep -o "[#][0-9]*" | sed "s/^/nodejs\/docker-node/")
+GITHUB_USER_INFO="$(curl -H "Authorization: token $GITHUB_API_TOKEN" https://api.github.com/user)"
+GIT_NAME=$(echo "$GITHUB_USER_INFO" | jq -r '.name')
+GIT_EMAIL=$(echo "$GITHUB_USER_INFO" | jq -r '.email')
+
+# Clone this bot's fork of the `official-images` repo.
+git clone \
+    "https://$GITHUB_API_TOKEN:x-oauth-basic@github.com/$GITHUB_USERNAME/official-images.git" \
+    docker-images
+
+# Reset this fork's `master` branch to `master` of fork origin.
+cd docker-images
+git config user.name "$GIT_NAME"
+git config user.email "$GIT_EMAIL"
+git remote add upstream "https://github.com/docker-library/official-images.git"
+git fetch upstream
+git reset --hard upstream/master
+
+../generate-stackbrew-library.sh > "$IMAGES_FILE"
+
+SHOULD_CREATE_PR=false
+
+if ! git diff --quiet HEAD "$IMAGES_FILE"; then
+    SHOULD_CREATE_PR=true
+    git add "$IMAGES_FILE"
+
+    # TODO: Determine what's new when drafting a commit message
+    git commit -m "Node updates from $ISSUE_REFS"
+fi
+
+# Push changes to the fork.
+git push origin master --force
+
+cd ..
+rm -rf docker-images
+
+if [ $SHOULD_CREATE_PR != false ]; then
+    PR_BODY=$(cat <<EOF
+Related:
+$ISSUE_REFS
+
+This PR is automatically generated on changes to the Node.js Docker repository.
+EOF)
+
+    PR_DATA=$(cat <<EOF
+{
+    "title": "[Bot]: Update Node.js Images"
+    "head": "$GITHUB_USERNAME:master"
+    "base": "master"
+    "body": "$(echo "$PR_BODY" | awk '{printf "%s\\n", $0}')"
+}
+EOF)
+
+    curl -H "Authorization: token $GITHUB_API_TOKEN" \
+        -X POST \
+        -d "$PR_DATA" \
+        "https://api.github.com/repos/docker-library/official-images/pulls"
+else
+    echo "Docker Library is already up-to-date."
+fi


### PR DESCRIPTION
I created a robot (@nodejs-docker-bot) to send Docker library changes automatically.

This script is tested locally up to the point of creating the PR itself, but to spare the maintainers of the [docker-library/official-images](https://github.com/docker-library/official-images), I had only tried the final `curl` command at the bottom of the script by changing `curl => echo` and seeing that the network request normally created looks right. If/when we want to merge this, we can test out that the `master` branch gets PR's created successfully, and the body/title looks like something those maintainers would like to see.

### Remaining Tasks

- [x] Comment `PR Bot Maintainer:` line - https://github.com/nodejs/docker-node/pull/431#discussion_r121179403
- [x] Add @nodejs team to forked repo - https://github.com/nodejs/docker-node/pull/431#issuecomment-307474085