### PR TITLE
Support Linux on ppc64le

### DIFF
--- a/Dockerfile-slim.template
+++ b/Dockerfile-slim.template
@@ -24,15 +24,21 @@ ENV NPM_CONFIG_LOGLEVEL info
 ENV NODE_VERSION 0.0.0
 
 RUN buildDeps='xz-utils' \
+    && ARCH= && dpkgArch="$(dpkg --print-architecture)" \
+    && case "${dpkgArch##*-}" in \
+      amd64) ARCH='x64';; \
+      ppc64el) ARCH='ppc64le';; \
+      *) echo "unsupported architecture"; exit 1 ;; \
+    esac \
     && set -x \
     && apt-get update && apt-get install -y $buildDeps --no-install-recommends \
     && rm -rf /var/lib/apt/lists/* \
-    && curl -SLO "https://nodejs.org/dist/v$NODE_VERSION/node-v$NODE_VERSION-linux-x64.tar.xz" \
+    && curl -SLO "https://nodejs.org/dist/v$NODE_VERSION/node-v$NODE_VERSION-linux-$ARCH.tar.xz" \
     && curl -SLO --compressed "https://nodejs.org/dist/v$NODE_VERSION/SHASUMS256.txt.asc" \
     && gpg --batch --decrypt --output SHASUMS256.txt SHASUMS256.txt.asc \
-    && grep " node-v$NODE_VERSION-linux-x64.tar.xz\$" SHASUMS256.txt | sha256sum -c - \
-    && tar -xJf "node-v$NODE_VERSION-linux-x64.tar.xz" -C /usr/local --strip-components=1 \
-    && rm "node-v$NODE_VERSION-linux-x64.tar.xz" SHASUMS256.txt.asc SHASUMS256.txt \
+    && grep " node-v$NODE_VERSION-linux-$ARCH.tar.xz\$" SHASUMS256.txt | sha256sum -c - \
+    && tar -xJf "node-v$NODE_VERSION-linux-$ARCH.tar.xz" -C /usr/local --strip-components=1 \
+    && rm "node-v$NODE_VERSION-linux-$ARCH.tar.xz" SHASUMS256.txt.asc SHASUMS256.txt \
     && apt-get purge -y --auto-remove $buildDeps \
     && ln -s /usr/local/bin/node /usr/local/bin/nodejs
 

--- a/Dockerfile-wheezy.template
+++ b/Dockerfile-wheezy.template
@@ -23,12 +23,18 @@ RUN set -ex \
 ENV NPM_CONFIG_LOGLEVEL info
 ENV NODE_VERSION 0.0.0
 
-RUN curl -SLO "https://nodejs.org/dist/v$NODE_VERSION/node-v$NODE_VERSION-linux-x64.tar.xz" \
+RUN ARCH= && dpkgArch="$(dpkg --print-architecture)" \
+  && case "${dpkgArch##*-}" in \
+    amd64) ARCH='x64';; \
+    ppc64el) ARCH='ppc64le';; \
+    *) echo "unsupported architecture"; exit 1 ;; \
+  esac \
+  && curl -SLO "https://nodejs.org/dist/v$NODE_VERSION/node-v$NODE_VERSION-linux-$ARCH.tar.xz" \
   && curl -SLO --compressed "https://nodejs.org/dist/v$NODE_VERSION/SHASUMS256.txt.asc" \
   && gpg --batch --decrypt --output SHASUMS256.txt SHASUMS256.txt.asc \
-  && grep " node-v$NODE_VERSION-linux-x64.tar.xz\$" SHASUMS256.txt | sha256sum -c - \
-  && tar -xJf "node-v$NODE_VERSION-linux-x64.tar.xz" -C /usr/local --strip-components=1 \
-  && rm "node-v$NODE_VERSION-linux-x64.tar.xz" SHASUMS256.txt.asc SHASUMS256.txt \
+  && grep " node-v$NODE_VERSION-linux-$ARCH.tar.xz\$" SHASUMS256.txt | sha256sum -c - \
+  && tar -xJf "node-v$NODE_VERSION-linux-$ARCH.tar.xz" -C /usr/local --strip-components=1 \
+  && rm "node-v$NODE_VERSION-linux-$ARCH.tar.xz" SHASUMS256.txt.asc SHASUMS256.txt \
   && ln -s /usr/local/bin/node /usr/local/bin/nodejs
 
 ENV YARN_VERSION 0.0.0

--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -23,12 +23,18 @@ RUN set -ex \
 ENV NPM_CONFIG_LOGLEVEL info
 ENV NODE_VERSION 0.0.0
 
-RUN curl -SLO "https://nodejs.org/dist/v$NODE_VERSION/node-v$NODE_VERSION-linux-x64.tar.xz" \
+RUN ARCH= && dpkgArch="$(dpkg --print-architecture)" \
+  && case "${dpkgArch##*-}" in \
+    amd64) ARCH='x64';; \
+    ppc64el) ARCH='ppc64le';; \
+    *) echo "unsupported architecture"; exit 1 ;; \
+  esac \
+  && curl -SLO "https://nodejs.org/dist/v$NODE_VERSION/node-v$NODE_VERSION-linux-$ARCH.tar.xz" \
   && curl -SLO --compressed "https://nodejs.org/dist/v$NODE_VERSION/SHASUMS256.txt.asc" \
   && gpg --batch --decrypt --output SHASUMS256.txt SHASUMS256.txt.asc \
-  && grep " node-v$NODE_VERSION-linux-x64.tar.xz\$" SHASUMS256.txt | sha256sum -c - \
-  && tar -xJf "node-v$NODE_VERSION-linux-x64.tar.xz" -C /usr/local --strip-components=1 \
-  && rm "node-v$NODE_VERSION-linux-x64.tar.xz" SHASUMS256.txt.asc SHASUMS256.txt \
+  && grep " node-v$NODE_VERSION-linux-$ARCH.tar.xz\$" SHASUMS256.txt | sha256sum -c - \
+  && tar -xJf "node-v$NODE_VERSION-linux-$ARCH.tar.xz" -C /usr/local --strip-components=1 \
+  && rm "node-v$NODE_VERSION-linux-$ARCH.tar.xz" SHASUMS256.txt.asc SHASUMS256.txt \
   && ln -s /usr/local/bin/node /usr/local/bin/nodejs
 
 ENV YARN_VERSION 0.0.0

--- a/README.md
+++ b/README.md
@@ -137,7 +137,10 @@ $ docker run node npm --loglevel=warn ...
 
 The `node` images come in many flavors, each designed for a specific use case.
 All of the images contain pre-installed versions of `node`,
-[`npm`](https://www.npmjs.com/), and [`yarn`](https://yarnpkg.com).
+[`npm`](https://www.npmjs.com/), and [`yarn`](https://yarnpkg.com). For each
+supported architecutre, the supported variants are different. In the file:
+[architectures](./architectures), it lists all supported variants for all of
+the architecures that we support now.
 
 ## `node:<version>`
 

--- a/architectures
+++ b/architectures
@@ -1,0 +1,3 @@
+bashbrew-arch   variants
+x64     alpine,onbuild,slim,wheezy
+ppc64le onbuild,slim

--- a/functions.sh
+++ b/functions.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+
+# Utlity functions
+
+# Get system architecture
+#
+# This is used to get the target architecture for docker image.
+# For crossing building, we need a way to specify the target
+# architecutre manually.
+function get_arch() {
+	local arch
+	case $(uname -m) in
+	x86_64)
+		arch="x64"
+		;;
+	ppc64le)
+		arch="ppc64le"
+		;;
+	s390x)
+		arch="s390x"
+		;;
+	*)
+		echo "$0 does not support architecture $arch ... aborting"
+		exit 1
+		;;
+	esac
+
+	echo "$arch"
+}
+
+# Get corresponding variants based on the architecture.
+# All supported variants of each supported architecutre are listed in a
+# file - 'architectures'. Its format is:
+#   <architecutre 1> <supported variant 1 >,<supported variant 2>...
+#   <architecutre 2> <supported variant 1 >,<supported variant 2>...
+function get_variants() {
+	local arch
+	arch=$(get_arch)
+	local variants
+	variants=$(grep "$arch" architectures | sed -E 's/'"$arch"'\s*//' | sed -E 's/,/ /g')
+	echo "$variants"
+}

--- a/generate-stackbrew-library.sh
+++ b/generate-stackbrew-library.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 set -e
+. functions.sh
 
 hash git 2>/dev/null || { echo >&2 "git not found, exiting."; }
 
@@ -57,7 +58,9 @@ for version in "${versions[@]}"; do
 	echo "Directory: ${version}"
 	echo
 
-	variants=$(echo "$version"/*/ | xargs -n1 basename)
+        # Get supported variants according to the target architecture.
+        # See details in function.sh
+	variants=$(get_variants | tr ' ' '\n')
 	for variant in $variants; do
 		# Skip non-docker directories
 		[ -f "$version/$variant/Dockerfile" ] || continue

--- a/test-build.sh
+++ b/test-build.sh
@@ -5,6 +5,8 @@
 set -uo pipefail
 IFS=$'\n\t'
 
+. functions.sh
+
 info() {
   printf "%s\n" "$@"
 }
@@ -43,7 +45,9 @@ for version in "${versions[@]}"; do
   fi
   info "Test of $tag succeeded."
 
-  variants=$(echo "$version"/*/ | xargs -n1 basename)
+  # Get supported variants according to the target architecture.
+  # See details in function.sh
+  variants=$(get_variants | tr ' ' '\n')
 
   for variant in $variants; do
     # Skip non-docker directories

--- a/update.sh
+++ b/update.sh
@@ -1,6 +1,8 @@
 #!/bin/bash
 set -e
 
+. functions.sh
+
 cd "$(cd "${0%/*}" && pwd -P)";
 
 versions=( "$@" )
@@ -9,22 +11,39 @@ if [ ${#versions[@]} -eq 0 ]; then
 fi
 versions=( "${versions[@]%/}" )
 
-
-template=
-dockerfile=
+# Global variables
+# Get architecure and use this as target architecture for docker image
+# See details in function.sh
+# TODO: Should be able to specify target architecture manually
+arch=$(get_arch)
 
 yarnVersion="$(curl -sSL --compressed https://yarnpkg.com/latest-version)"
 
 function update_node_version {
+
+	local template=$1
+	shift
+	local dockerfile=$1
+	shift
+	local variant=
+	if [[ $# -eq 1 ]]; then
+		variant=$1
+		shift
+	fi
+
 	fullVersion="$(curl -sSL --compressed 'https://nodejs.org/dist' | grep '<a href="v'"$version." | sed -E 's!.*<a href="v([^"/]+)/?".*!\1!' | cut -f 3 -d . | sort -n | tail -1)"
 	(
-		cp $template $dockerfile
-		sed -E -i.bak 's/^(ENV NODE_VERSION |FROM node:).*/\1'"$version.$fullVersion"'/' "$dockerfile"
-		rm "$dockerfile.bak"
-		sed -E -i.bak 's/^(ENV YARN_VERSION ).*/\1'"$yarnVersion"'/' "$dockerfile"
-		rm "$dockerfile.bak"
-		if [[ "${version/.*/}" -ge 8 ]]; then
-			sed -E -i.bak 's/FROM alpine:3.4/FROM alpine:3.6/' "$dockerfile"
+		cp "$template" "$dockerfile"
+		local fromprefix=
+		if [[ "$arch" != "x64" && "$variant" != "onbuild" ]]; then
+			fromprefix="$arch\/"
+		fi
+
+		sed -E -i.bak 's/^FROM (.*)/FROM '"$fromprefix"'\1/' "$dockerfile" && rm "$dockerfile".bak
+		sed -E -i.bak 's/^(ENV NODE_VERSION |FROM .*node:).*/\1'"$version.$fullVersion"'/' "$dockerfile" && rm "$dockerfile".bak
+		sed -E -i.bak 's/^(ENV YARN_VERSION ).*/\1'"$yarnVersion"'/' "$dockerfile" && rm "$dockerfile".bak
+		if [[ "${version/.*/}" -ge 8 || "$arch" = "ppc64le" ]]; then
+			sed -E -i.bak 's/FROM (.*)alpine:3.4/FROM \1alpine:3.6/' "$dockerfile"
 			rm "$dockerfile.bak"
 		fi
 	)
@@ -34,21 +53,16 @@ for version in "${versions[@]}"; do
 	# Skip "docs" and other non-docker directories
 	[ -f "$version/Dockerfile" ] || continue
 
-	template="Dockerfile.template"
-	dockerfile="$version/Dockerfile"
+	update_node_version "Dockerfile.template" "$version/Dockerfile"
 
-	update_node_version
-
-	variants=$(echo "$version"/*/ | xargs -n1 basename)
+        # Get supported variants according the target architecture
+        # See details in function.sh
+	variants=$(get_variants)
 
 	for variant in $variants; do
 		# Skip non-docker directories
 		[ -f "$version/$variant/Dockerfile" ] || continue
-
-		template="Dockerfile-$variant.template"
-		dockerfile="$version/$variant/Dockerfile"
-
-		update_node_version
+		update_node_version "Dockerfile-$variant.template" "$version/$variant/Dockerfile" "$variant"
 
 	done
 done


### PR DESCRIPTION
- Add an architectures file to list supported architectures and
  variants.
- Use `dpkg --print-architecture` or `apk --print-arch` in Dockerfile
  to get current architecture.
- Add a functions.sh to put utility functions, including
  - get_arch: get the current running architecture.
  - get_variants: get corresponding supported variants based on the
    running architecture.
- Modify update.sh and generate-stackbrew-library.sh to detect
  running architecture

Signed-off-by: Yihong Wang <yh.wang@ibm.com>