### PR TITLE
documentation fix: init flag is included in docker only after 1.13 not 1.3

### DIFF
--- a/docs/BestPractices.md
+++ b/docs/BestPractices.md
@@ -19,7 +19,7 @@ Run with `NODE_ENV` set to `production`. This is the way you would pass in secre
 ```
 ## Handling Kernel Signals
 
-Node.js was not designed to run as PID 1 which leads to unexpected behaviour when running inside of Docker. For example, a Node.js process running as PID 1 will not respond to `SIGTERM` (`CTRL-C`) and similar signals. As of Docker 1.3, you can use the `--init` flag to wrap your Node.js process with a [lightweight init system](https://github.com/krallin/tini) that properly handles running as PID 1.
+Node.js was not designed to run as PID 1 which leads to unexpected behaviour when running inside of Docker. For example, a Node.js process running as PID 1 will not respond to `SIGTERM` (`CTRL-C`) and similar signals. As of Docker 1.13, you can use the `--init` flag to wrap your Node.js process with a [lightweight init system](https://github.com/krallin/tini) that properly handles running as PID 1.
 
 ```
 docker run -it --init node


### PR DESCRIPTION
see https://docs.docker.com/release-notes/docker-engine/#1130-2017-01-18