### PR TITLE
Correct mistaken Yarn update policy.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,7 +8,7 @@ New **Node.js** releases are released as soon as possible.
 
 New **NPM** releases are not tracked. We simply use the NPM version bundled in the corresponding Node.js release.
 
-**Yarn** is updated to the latest version only when there is a new Node.js SemVer-minor release, and it's updated only in the branch with the new release, preferably in the same PR. The `update.sh` script does this automatically when invoked with a specific branch, e.g. `./update.sh 6.10`.
+**Yarn** is updated to the latest version only when there is a new Node.js SemVer PATCH release, and it's updated only in the branch with the new release, preferably in the same PR. The `update.sh` script does this automatically when invoked with a specific branch, e.g. `./update.sh 6.10`.
 
 ## Adding dependencies to the base images
 


### PR DESCRIPTION
The intention was always to update on SemVer PATCH releases (which makes the most sense), not MINOR. I messed that up in #393, apologies for which.