### PR TITLE
Replace onbuild with alpine in Dockerfile example

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ See: http://nodejs.org
 ## Create a `Dockerfile` in your Node.js app project
 
 ```dockerfile
-FROM node:4-onbuild
+FROM node:alpine
 # replace this with your application's default port
 EXPOSE 8888
 ```


### PR DESCRIPTION
Since onbuild is deprecated it should not be in the Dockerfile example.