### PR TITLE
Update Dockerfile example in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,8 @@ See: http://nodejs.org
 ## Create a `Dockerfile` in your Node.js app project
 
 ```dockerfile
-FROM node:4-onbuild
+# specify the node base image with your desired version node:<version>
+FROM node:6
 # replace this with your application's default port
 EXPOSE 8888
 ```


### PR DESCRIPTION
As onbuild is deprecated - update the first Dockerfile example in the README to use node:6 (current LTS) as a base image. In addition this change adds a comment to the Dockerfile how to specify versions.