### PR TITLE
Support s390x architecture

### DIFF
--- a/4.8/architectures
+++ b/4.8/architectures
@@ -1,4 +1,3 @@
 bashbrew-arch   variants
 amd64     default,alpine,onbuild,slim,stretch,wheezy
 ppc64le default,onbuild,slim,stretch
-s390x default,onbuild,slim,stretch

--- a/Dockerfile-slim.template
+++ b/Dockerfile-slim.template
@@ -28,6 +28,7 @@ RUN buildDeps='xz-utils' \
     && case "${dpkgArch##*-}" in \
       amd64) ARCH='x64';; \
       ppc64el) ARCH='ppc64le';; \
+      s390x) ARCH='s390x';; \
       *) echo "unsupported architecture"; exit 1 ;; \
     esac \
     && set -x \

--- a/Dockerfile-stretch.template
+++ b/Dockerfile-stretch.template
@@ -27,6 +27,7 @@ RUN ARCH= && dpkgArch="$(dpkg --print-architecture)" \
   && case "${dpkgArch##*-}" in \
     amd64) ARCH='x64';; \
     ppc64el) ARCH='ppc64le';; \
+    s390x) ARCH='s390x';; \
     *) echo "unsupported architecture"; exit 1 ;; \
   esac \
   && curl -SLO "https://nodejs.org/dist/v$NODE_VERSION/node-v$NODE_VERSION-linux-$ARCH.tar.xz" \

--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -27,6 +27,7 @@ RUN ARCH= && dpkgArch="$(dpkg --print-architecture)" \
   && case "${dpkgArch##*-}" in \
     amd64) ARCH='x64';; \
     ppc64el) ARCH='ppc64le';; \
+    s390x) ARCH='s390x';; \
     *) echo "unsupported architecture"; exit 1 ;; \
   esac \
   && curl -SLO "https://nodejs.org/dist/v$NODE_VERSION/node-v$NODE_VERSION-linux-$ARCH.tar.xz" \

--- a/functions.sh
+++ b/functions.sh
@@ -37,7 +37,7 @@ function get_variants() {
 	local arch
 	arch=$(get_arch)
 	local variants
-	variants=$(grep "$arch" architectures | sed -E 's/'"$arch"'\s*//' | sed -E 's/,/ /g')
+	variants=$(grep "^$arch" architectures | sed -E 's/'"$arch"'\s*//' | sed -E 's/,/ /g')
 	echo "$variants"
 }
 

--- a/update.sh
+++ b/update.sh
@@ -42,7 +42,7 @@ function update_node_version {
 		sed -E -i.bak 's/^FROM (.*)/FROM '"$fromprefix"'\1/' "$dockerfile" && rm "$dockerfile".bak
 		sed -E -i.bak 's/^(ENV NODE_VERSION |FROM .*node:).*/\1'"$version.$fullVersion"'/' "$dockerfile" && rm "$dockerfile".bak
 		sed -E -i.bak 's/^(ENV YARN_VERSION ).*/\1'"$yarnVersion"'/' "$dockerfile" && rm "$dockerfile".bak
-		if [[ "${version/.*/}" -ge 8 || "$arch" = "ppc64le" ]]; then
+		if [[ "${version/.*/}" -ge 8 || "$arch" = "ppc64le" || "$arch" = "s390x" ]]; then
 			sed -E -i.bak 's/FROM (.*)alpine:3.4/FROM \1alpine:3.6/' "$dockerfile"
 			rm "$dockerfile.bak"
 		fi


### PR DESCRIPTION
- Support `s390x` in all of the version except 4.8 and the following
  variants: default, alpine, stretch, slim and onbuild
- Generate proper `architectures` for the stackbrew
- Update `update.sh` in order to be used on s390x
- `s390` is not supported in v4.8, therefore, add a local architectures
  under 4.8 and remove `s390x` there

Signed-off-by: Yihong Wang <yh.wang@ibm.com>