### PR TITLE
Support arm64 architecture 

### DIFF
--- a/4.8/Dockerfile
+++ b/4.8/Dockerfile
@@ -28,6 +28,7 @@ RUN ARCH= && dpkgArch="$(dpkg --print-architecture)" \
     amd64) ARCH='x64';; \
     ppc64el) ARCH='ppc64le';; \
     s390x) ARCH='s390x';; \
+    arm64) ARCH='arm64';; \
     *) echo "unsupported architecture"; exit 1 ;; \
   esac \
   && curl -SLO "https://nodejs.org/dist/v$NODE_VERSION/node-v$NODE_VERSION-linux-$ARCH.tar.xz" \

--- a/4.8/stretch/Dockerfile
+++ b/4.8/stretch/Dockerfile
@@ -28,6 +28,7 @@ RUN ARCH= && dpkgArch="$(dpkg --print-architecture)" \
     amd64) ARCH='x64';; \
     ppc64el) ARCH='ppc64le';; \
     s390x) ARCH='s390x';; \
+    arm64) ARCH='arm64';; \
     *) echo "unsupported architecture"; exit 1 ;; \
   esac \
   && curl -SLO "https://nodejs.org/dist/v$NODE_VERSION/node-v$NODE_VERSION-linux-$ARCH.tar.xz" \

--- a/6.11/Dockerfile
+++ b/6.11/Dockerfile
@@ -28,6 +28,7 @@ RUN ARCH= && dpkgArch="$(dpkg --print-architecture)" \
     amd64) ARCH='x64';; \
     ppc64el) ARCH='ppc64le';; \
     s390x) ARCH='s390x';; \
+    arm64) ARCH='arm64';; \
     *) echo "unsupported architecture"; exit 1 ;; \
   esac \
   && curl -SLO "https://nodejs.org/dist/v$NODE_VERSION/node-v$NODE_VERSION-linux-$ARCH.tar.xz" \

--- a/6.11/stretch/Dockerfile
+++ b/6.11/stretch/Dockerfile
@@ -28,6 +28,7 @@ RUN ARCH= && dpkgArch="$(dpkg --print-architecture)" \
     amd64) ARCH='x64';; \
     ppc64el) ARCH='ppc64le';; \
     s390x) ARCH='s390x';; \
+    arm64) ARCH='arm64';; \
     *) echo "unsupported architecture"; exit 1 ;; \
   esac \
   && curl -SLO "https://nodejs.org/dist/v$NODE_VERSION/node-v$NODE_VERSION-linux-$ARCH.tar.xz" \

--- a/7.10/Dockerfile
+++ b/7.10/Dockerfile
@@ -28,6 +28,7 @@ RUN ARCH= && dpkgArch="$(dpkg --print-architecture)" \
     amd64) ARCH='x64';; \
     ppc64el) ARCH='ppc64le';; \
     s390x) ARCH='s390x';; \
+    arm64) ARCH='arm64';; \
     *) echo "unsupported architecture"; exit 1 ;; \
   esac \
   && curl -SLO "https://nodejs.org/dist/v$NODE_VERSION/node-v$NODE_VERSION-linux-$ARCH.tar.xz" \

--- a/7.10/stretch/Dockerfile
+++ b/7.10/stretch/Dockerfile
@@ -28,6 +28,7 @@ RUN ARCH= && dpkgArch="$(dpkg --print-architecture)" \
     amd64) ARCH='x64';; \
     ppc64el) ARCH='ppc64le';; \
     s390x) ARCH='s390x';; \
+    arm64) ARCH='arm64';; \
     *) echo "unsupported architecture"; exit 1 ;; \
   esac \
   && curl -SLO "https://nodejs.org/dist/v$NODE_VERSION/node-v$NODE_VERSION-linux-$ARCH.tar.xz" \

--- a/8.2/Dockerfile
+++ b/8.2/Dockerfile
@@ -28,6 +28,7 @@ RUN ARCH= && dpkgArch="$(dpkg --print-architecture)" \
     amd64) ARCH='x64';; \
     ppc64el) ARCH='ppc64le';; \
     s390x) ARCH='s390x';; \
+    arm64) ARCH='arm64';; \
     *) echo "unsupported architecture"; exit 1 ;; \
   esac \
   && curl -SLO "https://nodejs.org/dist/v$NODE_VERSION/node-v$NODE_VERSION-linux-$ARCH.tar.xz" \

--- a/8.2/stretch/Dockerfile
+++ b/8.2/stretch/Dockerfile
@@ -28,6 +28,7 @@ RUN ARCH= && dpkgArch="$(dpkg --print-architecture)" \
     amd64) ARCH='x64';; \
     ppc64el) ARCH='ppc64le';; \
     s390x) ARCH='s390x';; \
+    arm64) ARCH='arm64';; \
     *) echo "unsupported architecture"; exit 1 ;; \
   esac \
   && curl -SLO "https://nodejs.org/dist/v$NODE_VERSION/node-v$NODE_VERSION-linux-$ARCH.tar.xz" \

--- a/Dockerfile-stretch.template
+++ b/Dockerfile-stretch.template
@@ -28,6 +28,7 @@ RUN ARCH= && dpkgArch="$(dpkg --print-architecture)" \
     amd64) ARCH='x64';; \
     ppc64el) ARCH='ppc64le';; \
     s390x) ARCH='s390x';; \
+    arm64) ARCH='arm64';; \
     *) echo "unsupported architecture"; exit 1 ;; \
   esac \
   && curl -SLO "https://nodejs.org/dist/v$NODE_VERSION/node-v$NODE_VERSION-linux-$ARCH.tar.xz" \

--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -28,6 +28,7 @@ RUN ARCH= && dpkgArch="$(dpkg --print-architecture)" \
     amd64) ARCH='x64';; \
     ppc64el) ARCH='ppc64le';; \
     s390x) ARCH='s390x';; \
+    arm64) ARCH='arm64';; \
     *) echo "unsupported architecture"; exit 1 ;; \
   esac \
   && curl -SLO "https://nodejs.org/dist/v$NODE_VERSION/node-v$NODE_VERSION-linux-$ARCH.tar.xz" \

--- a/architectures
+++ b/architectures
@@ -2,4 +2,4 @@ bashbrew-arch   variants
 amd64     default,alpine,onbuild,slim,stretch,wheezy
 ppc64le default,onbuild,slim,stretch
 s390x default,onbuild,slim,stretch
-arm64 default,onbuild,slim,stretch
+arm64v8 default,onbuild,slim,stretch

--- a/architectures
+++ b/architectures
@@ -2,3 +2,4 @@ bashbrew-arch   variants
 amd64     default,alpine,onbuild,slim,stretch,wheezy
 ppc64le default,onbuild,slim,stretch
 s390x default,onbuild,slim,stretch
+arm64 default,onbuild,slim,stretch

--- a/functions.sh
+++ b/functions.sh
@@ -19,6 +19,9 @@ function get_arch() {
 	s390x)
 		arch="s390x"
 		;;
+	aarch64)
+	        arch="arm64"
+		;;
 	*)
 		echo "$0 does not support architecture $arch ... aborting"
 		exit 1

--- a/update.sh
+++ b/update.sh
@@ -42,7 +42,7 @@ function update_node_version {
 		sed -E -i.bak 's/^FROM (.*)/FROM '"$fromprefix"'\1/' "$dockerfile" && rm "$dockerfile".bak
 		sed -E -i.bak 's/^(ENV NODE_VERSION |FROM .*node:).*/\1'"$version.$fullVersion"'/' "$dockerfile" && rm "$dockerfile".bak
 		sed -E -i.bak 's/^(ENV YARN_VERSION ).*/\1'"$yarnVersion"'/' "$dockerfile" && rm "$dockerfile".bak
-		if [[ "${version/.*/}" -ge 8 || "$arch" = "ppc64le" || "$arch" = "s390x" ]]; then
+		if [[ "${version/.*/}" -ge 8 || "$arch" = "ppc64le" || "$arch" = "s390x" || "$arch" = "arm64" ]]; then
 			sed -E -i.bak 's/FROM (.*)alpine:3.4/FROM \1alpine:3.6/' "$dockerfile"
 			rm "$dockerfile.bak"
 		fi


### PR DESCRIPTION
Support arm64 in all of the version and the following
variants: default, alpine, stretch, slim and onbuild
Generate proper architectures for the stackbrew
Update update.sh in order to be used on arm64
Signed-off-by: Zhao Longquan   zhaolongquan@huawei.com