### PR TITLE
Support arm32v7 architecture

### DIFF
--- a/4.8/Dockerfile
+++ b/4.8/Dockerfile
@@ -29,6 +29,7 @@ RUN ARCH= && dpkgArch="$(dpkg --print-architecture)" \
     ppc64el) ARCH='ppc64le';; \
     s390x) ARCH='s390x';; \
     arm64) ARCH='arm64';; \
+    armhf) ARCH='armv7l';; \
     *) echo "unsupported architecture"; exit 1 ;; \
   esac \
   && curl -SLO "https://nodejs.org/dist/v$NODE_VERSION/node-v$NODE_VERSION-linux-$ARCH.tar.xz" \

--- a/4.8/architectures
+++ b/4.8/architectures
@@ -2,3 +2,4 @@ bashbrew-arch   variants
 amd64     default,alpine,onbuild,slim,stretch,wheezy
 ppc64le default,onbuild,slim,stretch
 arm64v8 default,onbuild,slim,stretch
+arm32v7 default,onbuild,slim,stretch

--- a/4.8/slim/Dockerfile
+++ b/4.8/slim/Dockerfile
@@ -30,6 +30,7 @@ RUN buildDeps='xz-utils' \
       ppc64el) ARCH='ppc64le';; \
       s390x) ARCH='s390x';; \
       arm64) ARCH='arm64';; \
+      armhf) ARCH='armv7l';; \
       *) echo "unsupported architecture"; exit 1 ;; \
     esac \
     && set -x \

--- a/4.8/stretch/Dockerfile
+++ b/4.8/stretch/Dockerfile
@@ -29,6 +29,7 @@ RUN ARCH= && dpkgArch="$(dpkg --print-architecture)" \
     ppc64el) ARCH='ppc64le';; \
     s390x) ARCH='s390x';; \
     arm64) ARCH='arm64';; \
+    armhf) ARCH='armv7l';; \
     *) echo "unsupported architecture"; exit 1 ;; \
   esac \
   && curl -SLO "https://nodejs.org/dist/v$NODE_VERSION/node-v$NODE_VERSION-linux-$ARCH.tar.xz" \

--- a/6.11/Dockerfile
+++ b/6.11/Dockerfile
@@ -29,6 +29,7 @@ RUN ARCH= && dpkgArch="$(dpkg --print-architecture)" \
     ppc64el) ARCH='ppc64le';; \
     s390x) ARCH='s390x';; \
     arm64) ARCH='arm64';; \
+    armhf) ARCH='armv7l';; \
     *) echo "unsupported architecture"; exit 1 ;; \
   esac \
   && curl -SLO "https://nodejs.org/dist/v$NODE_VERSION/node-v$NODE_VERSION-linux-$ARCH.tar.xz" \

--- a/6.11/slim/Dockerfile
+++ b/6.11/slim/Dockerfile
@@ -30,6 +30,7 @@ RUN buildDeps='xz-utils' \
       ppc64el) ARCH='ppc64le';; \
       s390x) ARCH='s390x';; \
       arm64) ARCH='arm64';; \
+      armhf) ARCH='armv7l';; \
       *) echo "unsupported architecture"; exit 1 ;; \
     esac \
     && set -x \

--- a/6.11/stretch/Dockerfile
+++ b/6.11/stretch/Dockerfile
@@ -29,6 +29,7 @@ RUN ARCH= && dpkgArch="$(dpkg --print-architecture)" \
     ppc64el) ARCH='ppc64le';; \
     s390x) ARCH='s390x';; \
     arm64) ARCH='arm64';; \
+    armhf) ARCH='armv7l';; \
     *) echo "unsupported architecture"; exit 1 ;; \
   esac \
   && curl -SLO "https://nodejs.org/dist/v$NODE_VERSION/node-v$NODE_VERSION-linux-$ARCH.tar.xz" \

--- a/7.10/Dockerfile
+++ b/7.10/Dockerfile
@@ -29,6 +29,7 @@ RUN ARCH= && dpkgArch="$(dpkg --print-architecture)" \
     ppc64el) ARCH='ppc64le';; \
     s390x) ARCH='s390x';; \
     arm64) ARCH='arm64';; \
+    armhf) ARCH='armv7l';; \
     *) echo "unsupported architecture"; exit 1 ;; \
   esac \
   && curl -SLO "https://nodejs.org/dist/v$NODE_VERSION/node-v$NODE_VERSION-linux-$ARCH.tar.xz" \

--- a/7.10/slim/Dockerfile
+++ b/7.10/slim/Dockerfile
@@ -30,6 +30,7 @@ RUN buildDeps='xz-utils' \
       ppc64el) ARCH='ppc64le';; \
       s390x) ARCH='s390x';; \
       arm64) ARCH='arm64';; \
+      armhf) ARCH='armv7l';; \
       *) echo "unsupported architecture"; exit 1 ;; \
     esac \
     && set -x \

--- a/7.10/stretch/Dockerfile
+++ b/7.10/stretch/Dockerfile
@@ -29,6 +29,7 @@ RUN ARCH= && dpkgArch="$(dpkg --print-architecture)" \
     ppc64el) ARCH='ppc64le';; \
     s390x) ARCH='s390x';; \
     arm64) ARCH='arm64';; \
+    armhf) ARCH='armv7l';; \
     *) echo "unsupported architecture"; exit 1 ;; \
   esac \
   && curl -SLO "https://nodejs.org/dist/v$NODE_VERSION/node-v$NODE_VERSION-linux-$ARCH.tar.xz" \

--- a/8.4/Dockerfile
+++ b/8.4/Dockerfile
@@ -29,6 +29,7 @@ RUN ARCH= && dpkgArch="$(dpkg --print-architecture)" \
     ppc64el) ARCH='ppc64le';; \
     s390x) ARCH='s390x';; \
     arm64) ARCH='arm64';; \
+    armhf) ARCH='armv7l';; \
     *) echo "unsupported architecture"; exit 1 ;; \
   esac \
   && curl -SLO "https://nodejs.org/dist/v$NODE_VERSION/node-v$NODE_VERSION-linux-$ARCH.tar.xz" \

--- a/8.4/slim/Dockerfile
+++ b/8.4/slim/Dockerfile
@@ -30,6 +30,7 @@ RUN buildDeps='xz-utils' \
       ppc64el) ARCH='ppc64le';; \
       s390x) ARCH='s390x';; \
       arm64) ARCH='arm64';; \
+      armhf) ARCH='armv7l';; \
       *) echo "unsupported architecture"; exit 1 ;; \
     esac \
     && set -x \

--- a/8.4/stretch/Dockerfile
+++ b/8.4/stretch/Dockerfile
@@ -29,6 +29,7 @@ RUN ARCH= && dpkgArch="$(dpkg --print-architecture)" \
     ppc64el) ARCH='ppc64le';; \
     s390x) ARCH='s390x';; \
     arm64) ARCH='arm64';; \
+    armhf) ARCH='armv7l';; \
     *) echo "unsupported architecture"; exit 1 ;; \
   esac \
   && curl -SLO "https://nodejs.org/dist/v$NODE_VERSION/node-v$NODE_VERSION-linux-$ARCH.tar.xz" \

--- a/Dockerfile-slim.template
+++ b/Dockerfile-slim.template
@@ -30,6 +30,7 @@ RUN buildDeps='xz-utils' \
       ppc64el) ARCH='ppc64le';; \
       s390x) ARCH='s390x';; \
       arm64) ARCH='arm64';; \
+      armhf) ARCH='armv7l';; \
       *) echo "unsupported architecture"; exit 1 ;; \
     esac \
     && set -x \

--- a/Dockerfile-stretch.template
+++ b/Dockerfile-stretch.template
@@ -29,6 +29,7 @@ RUN ARCH= && dpkgArch="$(dpkg --print-architecture)" \
     ppc64el) ARCH='ppc64le';; \
     s390x) ARCH='s390x';; \
     arm64) ARCH='arm64';; \
+    armhf) ARCH='armv7l';; \
     *) echo "unsupported architecture"; exit 1 ;; \
   esac \
   && curl -SLO "https://nodejs.org/dist/v$NODE_VERSION/node-v$NODE_VERSION-linux-$ARCH.tar.xz" \

--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -29,6 +29,7 @@ RUN ARCH= && dpkgArch="$(dpkg --print-architecture)" \
     ppc64el) ARCH='ppc64le';; \
     s390x) ARCH='s390x';; \
     arm64) ARCH='arm64';; \
+    armhf) ARCH='armv7l';; \
     *) echo "unsupported architecture"; exit 1 ;; \
   esac \
   && curl -SLO "https://nodejs.org/dist/v$NODE_VERSION/node-v$NODE_VERSION-linux-$ARCH.tar.xz" \

--- a/architectures
+++ b/architectures
@@ -3,3 +3,4 @@ amd64     default,alpine,onbuild,slim,stretch,wheezy
 ppc64le default,onbuild,slim,stretch
 s390x default,onbuild,slim,stretch
 arm64v8 default,onbuild,slim,stretch
+arm32v7 default,onbuild,slim,stretch

--- a/functions.sh
+++ b/functions.sh
@@ -20,7 +20,10 @@ function get_arch() {
 		arch="s390x"
 		;;
 	aarch64)
-	        arch="arm64"
+	    arch="arm64"
+		;;
+	armv7l)
+	    arch="armhf"
 		;;
 	*)
 		echo "$0 does not support architecture $arch ... aborting"

--- a/functions.sh
+++ b/functions.sh
@@ -23,7 +23,7 @@ function get_arch() {
 	    arch="arm64"
 		;;
 	armv7l)
-	    arch="armhf"
+	    arch="arm32v7"
 		;;
 	*)
 		echo "$0 does not support architecture $arch ... aborting"

--- a/functions.sh
+++ b/functions.sh
@@ -20,10 +20,10 @@ function get_arch() {
 		arch="s390x"
 		;;
 	aarch64)
-	    arch="arm64"
+		arch="arm64"
 		;;
 	armv7l)
-	    arch="arm32v7"
+		arch="arm32v7"
 		;;
 	*)
 		echo "$0 does not support architecture $arch ... aborting"

--- a/update.sh
+++ b/update.sh
@@ -42,7 +42,7 @@ function update_node_version {
 		sed -E -i.bak 's/^FROM (.*)/FROM '"$fromprefix"'\1/' "$dockerfile" && rm "$dockerfile".bak
 		sed -E -i.bak 's/^(ENV NODE_VERSION |FROM .*node:).*/\1'"$version.$fullVersion"'/' "$dockerfile" && rm "$dockerfile".bak
 		sed -E -i.bak 's/^(ENV YARN_VERSION ).*/\1'"$yarnVersion"'/' "$dockerfile" && rm "$dockerfile".bak
-		if [[ "${version/.*/}" -ge 8 || "$arch" = "ppc64le" || "$arch" = "s390x" || "$arch" = "arm64" ]]; then
+		if [[ "${version/.*/}" -ge 8 || "$arch" = "ppc64le" || "$arch" = "s390x" || "$arch" = "arm64" || "$arch" = "armhf" ]]; then
 			sed -E -i.bak 's/FROM (.*)alpine:3.4/FROM \1alpine:3.6/' "$dockerfile"
 			rm "$dockerfile.bak"
 		fi

--- a/update.sh
+++ b/update.sh
@@ -42,7 +42,7 @@ function update_node_version {
 		sed -E -i.bak 's/^FROM (.*)/FROM '"$fromprefix"'\1/' "$dockerfile" && rm "$dockerfile".bak
 		sed -E -i.bak 's/^(ENV NODE_VERSION |FROM .*node:).*/\1'"$version.$fullVersion"'/' "$dockerfile" && rm "$dockerfile".bak
 		sed -E -i.bak 's/^(ENV YARN_VERSION ).*/\1'"$yarnVersion"'/' "$dockerfile" && rm "$dockerfile".bak
-		if [[ "${version/.*/}" -ge 8 || "$arch" = "ppc64le" || "$arch" = "s390x" || "$arch" = "arm64" || "$arch" = "armhf" ]]; then
+		if [[ "${version/.*/}" -ge 8 || "$arch" = "ppc64le" || "$arch" = "s390x" || "$arch" = "arm64" || "$arch" = "arm32v7" ]]; then
 			sed -E -i.bak 's/FROM (.*)alpine:3.4/FROM \1alpine:3.6/' "$dockerfile"
 			rm "$dockerfile.bak"
 		fi


### PR DESCRIPTION
- Support arm32v7 in all versions and the following
variants: default, stretch, slim and onbuild
- Generate proper architectures for the stackbrew
- Update update.sh in order to be used on arm32v7