### PR TITLE
Fixed the permissions for global npm modules

### DIFF
--- a/4.8/Dockerfile
+++ b/4.8/Dockerfile
@@ -37,7 +37,10 @@ RUN ARCH= && dpkgArch="$(dpkg --print-architecture)" \
   && grep " node-v$NODE_VERSION-linux-$ARCH.tar.xz\$" SHASUMS256.txt | sha256sum -c - \
   && tar -xJf "node-v$NODE_VERSION-linux-$ARCH.tar.xz" -C /usr/local --strip-components=1 \
   && rm "node-v$NODE_VERSION-linux-$ARCH.tar.xz" SHASUMS256.txt.asc SHASUMS256.txt \
-  && ln -s /usr/local/bin/node /usr/local/bin/nodejs
+  && ln -s /usr/local/bin/node /usr/local/bin/nodejs \
+  && chown node:node $(npm config get prefix)/lib/node_modules \
+  && chown node:node $(npm config get prefix)/bin \
+  && chown node:node $(npm config get prefix)/share
 
 ENV YARN_VERSION 0.24.4
 

--- a/4.8/alpine/Dockerfile
+++ b/4.8/alpine/Dockerfile
@@ -44,7 +44,10 @@ RUN addgroup -g 1000 node \
     && apk del .build-deps \
     && cd .. \
     && rm -Rf "node-v$NODE_VERSION" \
-    && rm "node-v$NODE_VERSION.tar.xz" SHASUMS256.txt.asc SHASUMS256.txt
+    && rm "node-v$NODE_VERSION.tar.xz" SHASUMS256.txt.asc SHASUMS256.txt \
+    && chown node:node $(npm config get prefix)/lib/node_modules \
+    && chown node:node $(npm config get prefix)/bin \
+    && chown node:node $(npm config get prefix)/share
 
 ENV YARN_VERSION 0.24.4
 

--- a/4.8/slim/Dockerfile
+++ b/4.8/slim/Dockerfile
@@ -42,7 +42,10 @@ RUN buildDeps='xz-utils' \
     && tar -xJf "node-v$NODE_VERSION-linux-$ARCH.tar.xz" -C /usr/local --strip-components=1 \
     && rm "node-v$NODE_VERSION-linux-$ARCH.tar.xz" SHASUMS256.txt.asc SHASUMS256.txt \
     && apt-get purge -y --auto-remove $buildDeps \
-    && ln -s /usr/local/bin/node /usr/local/bin/nodejs
+    && ln -s /usr/local/bin/node /usr/local/bin/nodejs \
+    && chown node:node $(npm config get prefix)/lib/node_modules \
+    && chown node:node $(npm config get prefix)/bin \
+    && chown node:node $(npm config get prefix)/share
 
 ENV YARN_VERSION 0.24.4
 

--- a/4.8/stretch/Dockerfile
+++ b/4.8/stretch/Dockerfile
@@ -37,7 +37,10 @@ RUN ARCH= && dpkgArch="$(dpkg --print-architecture)" \
   && grep " node-v$NODE_VERSION-linux-$ARCH.tar.xz\$" SHASUMS256.txt | sha256sum -c - \
   && tar -xJf "node-v$NODE_VERSION-linux-$ARCH.tar.xz" -C /usr/local --strip-components=1 \
   && rm "node-v$NODE_VERSION-linux-$ARCH.tar.xz" SHASUMS256.txt.asc SHASUMS256.txt \
-  && ln -s /usr/local/bin/node /usr/local/bin/nodejs
+  && ln -s /usr/local/bin/node /usr/local/bin/nodejs \
+  && chown node:node $(npm config get prefix)/lib/node_modules \
+  && chown node:node $(npm config get prefix)/bin \
+  && chown node:node $(npm config get prefix)/share
 
 ENV YARN_VERSION 0.24.4
 

--- a/4.8/wheezy/Dockerfile
+++ b/4.8/wheezy/Dockerfile
@@ -35,7 +35,10 @@ RUN ARCH= && dpkgArch="$(dpkg --print-architecture)" \
   && grep " node-v$NODE_VERSION-linux-$ARCH.tar.xz\$" SHASUMS256.txt | sha256sum -c - \
   && tar -xJf "node-v$NODE_VERSION-linux-$ARCH.tar.xz" -C /usr/local --strip-components=1 \
   && rm "node-v$NODE_VERSION-linux-$ARCH.tar.xz" SHASUMS256.txt.asc SHASUMS256.txt \
-  && ln -s /usr/local/bin/node /usr/local/bin/nodejs
+  && ln -s /usr/local/bin/node /usr/local/bin/nodejs \
+  && chown node:node $(npm config get prefix)/lib/node_modules \
+  && chown node:node $(npm config get prefix)/bin \
+  && chown node:node $(npm config get prefix)/share
 
 ENV YARN_VERSION 0.24.4
 

--- a/6.11/Dockerfile
+++ b/6.11/Dockerfile
@@ -37,7 +37,10 @@ RUN ARCH= && dpkgArch="$(dpkg --print-architecture)" \
   && grep " node-v$NODE_VERSION-linux-$ARCH.tar.xz\$" SHASUMS256.txt | sha256sum -c - \
   && tar -xJf "node-v$NODE_VERSION-linux-$ARCH.tar.xz" -C /usr/local --strip-components=1 \
   && rm "node-v$NODE_VERSION-linux-$ARCH.tar.xz" SHASUMS256.txt.asc SHASUMS256.txt \
-  && ln -s /usr/local/bin/node /usr/local/bin/nodejs
+  && ln -s /usr/local/bin/node /usr/local/bin/nodejs \
+  && chown node:node $(npm config get prefix)/lib/node_modules \
+  && chown node:node $(npm config get prefix)/bin \
+  && chown node:node $(npm config get prefix)/share
 
 ENV YARN_VERSION 0.27.5
 

--- a/6.11/alpine/Dockerfile
+++ b/6.11/alpine/Dockerfile
@@ -44,7 +44,10 @@ RUN addgroup -g 1000 node \
     && apk del .build-deps \
     && cd .. \
     && rm -Rf "node-v$NODE_VERSION" \
-    && rm "node-v$NODE_VERSION.tar.xz" SHASUMS256.txt.asc SHASUMS256.txt
+    && rm "node-v$NODE_VERSION.tar.xz" SHASUMS256.txt.asc SHASUMS256.txt \
+    && chown node:node $(npm config get prefix)/lib/node_modules \
+    && chown node:node $(npm config get prefix)/bin \
+    && chown node:node $(npm config get prefix)/share
 
 ENV YARN_VERSION 0.27.5
 

--- a/6.11/slim/Dockerfile
+++ b/6.11/slim/Dockerfile
@@ -42,7 +42,10 @@ RUN buildDeps='xz-utils' \
     && tar -xJf "node-v$NODE_VERSION-linux-$ARCH.tar.xz" -C /usr/local --strip-components=1 \
     && rm "node-v$NODE_VERSION-linux-$ARCH.tar.xz" SHASUMS256.txt.asc SHASUMS256.txt \
     && apt-get purge -y --auto-remove $buildDeps \
-    && ln -s /usr/local/bin/node /usr/local/bin/nodejs
+    && ln -s /usr/local/bin/node /usr/local/bin/nodejs \
+    && chown node:node $(npm config get prefix)/lib/node_modules \
+    && chown node:node $(npm config get prefix)/bin \
+    && chown node:node $(npm config get prefix)/share
 
 ENV YARN_VERSION 0.27.5
 

--- a/6.11/stretch/Dockerfile
+++ b/6.11/stretch/Dockerfile
@@ -37,7 +37,10 @@ RUN ARCH= && dpkgArch="$(dpkg --print-architecture)" \
   && grep " node-v$NODE_VERSION-linux-$ARCH.tar.xz\$" SHASUMS256.txt | sha256sum -c - \
   && tar -xJf "node-v$NODE_VERSION-linux-$ARCH.tar.xz" -C /usr/local --strip-components=1 \
   && rm "node-v$NODE_VERSION-linux-$ARCH.tar.xz" SHASUMS256.txt.asc SHASUMS256.txt \
-  && ln -s /usr/local/bin/node /usr/local/bin/nodejs
+  && ln -s /usr/local/bin/node /usr/local/bin/nodejs \
+  && chown node:node $(npm config get prefix)/lib/node_modules \
+  && chown node:node $(npm config get prefix)/bin \
+  && chown node:node $(npm config get prefix)/share
 
 ENV YARN_VERSION 0.27.5
 

--- a/6.11/wheezy/Dockerfile
+++ b/6.11/wheezy/Dockerfile
@@ -35,7 +35,10 @@ RUN ARCH= && dpkgArch="$(dpkg --print-architecture)" \
   && grep " node-v$NODE_VERSION-linux-$ARCH.tar.xz\$" SHASUMS256.txt | sha256sum -c - \
   && tar -xJf "node-v$NODE_VERSION-linux-$ARCH.tar.xz" -C /usr/local --strip-components=1 \
   && rm "node-v$NODE_VERSION-linux-$ARCH.tar.xz" SHASUMS256.txt.asc SHASUMS256.txt \
-  && ln -s /usr/local/bin/node /usr/local/bin/nodejs
+  && ln -s /usr/local/bin/node /usr/local/bin/nodejs \
+  && chown node:node $(npm config get prefix)/lib/node_modules \
+  && chown node:node $(npm config get prefix)/bin \
+  && chown node:node $(npm config get prefix)/share
 
 ENV YARN_VERSION 0.27.5
 

--- a/7.10/Dockerfile
+++ b/7.10/Dockerfile
@@ -37,7 +37,10 @@ RUN ARCH= && dpkgArch="$(dpkg --print-architecture)" \
   && grep " node-v$NODE_VERSION-linux-$ARCH.tar.xz\$" SHASUMS256.txt | sha256sum -c - \
   && tar -xJf "node-v$NODE_VERSION-linux-$ARCH.tar.xz" -C /usr/local --strip-components=1 \
   && rm "node-v$NODE_VERSION-linux-$ARCH.tar.xz" SHASUMS256.txt.asc SHASUMS256.txt \
-  && ln -s /usr/local/bin/node /usr/local/bin/nodejs
+  && ln -s /usr/local/bin/node /usr/local/bin/nodejs \
+  && chown node:node $(npm config get prefix)/lib/node_modules \
+  && chown node:node $(npm config get prefix)/bin \
+  && chown node:node $(npm config get prefix)/share
 
 ENV YARN_VERSION 0.24.4
 

--- a/7.10/alpine/Dockerfile
+++ b/7.10/alpine/Dockerfile
@@ -44,7 +44,10 @@ RUN addgroup -g 1000 node \
     && apk del .build-deps \
     && cd .. \
     && rm -Rf "node-v$NODE_VERSION" \
-    && rm "node-v$NODE_VERSION.tar.xz" SHASUMS256.txt.asc SHASUMS256.txt
+    && rm "node-v$NODE_VERSION.tar.xz" SHASUMS256.txt.asc SHASUMS256.txt \
+    && chown node:node $(npm config get prefix)/lib/node_modules \
+    && chown node:node $(npm config get prefix)/bin \
+    && chown node:node $(npm config get prefix)/share
 
 ENV YARN_VERSION 0.24.4
 

--- a/7.10/slim/Dockerfile
+++ b/7.10/slim/Dockerfile
@@ -42,7 +42,10 @@ RUN buildDeps='xz-utils' \
     && tar -xJf "node-v$NODE_VERSION-linux-$ARCH.tar.xz" -C /usr/local --strip-components=1 \
     && rm "node-v$NODE_VERSION-linux-$ARCH.tar.xz" SHASUMS256.txt.asc SHASUMS256.txt \
     && apt-get purge -y --auto-remove $buildDeps \
-    && ln -s /usr/local/bin/node /usr/local/bin/nodejs
+    && ln -s /usr/local/bin/node /usr/local/bin/nodejs \
+    && chown node:node $(npm config get prefix)/lib/node_modules \
+    && chown node:node $(npm config get prefix)/bin \
+    && chown node:node $(npm config get prefix)/share
 
 ENV YARN_VERSION 0.24.4
 

--- a/7.10/stretch/Dockerfile
+++ b/7.10/stretch/Dockerfile
@@ -37,7 +37,10 @@ RUN ARCH= && dpkgArch="$(dpkg --print-architecture)" \
   && grep " node-v$NODE_VERSION-linux-$ARCH.tar.xz\$" SHASUMS256.txt | sha256sum -c - \
   && tar -xJf "node-v$NODE_VERSION-linux-$ARCH.tar.xz" -C /usr/local --strip-components=1 \
   && rm "node-v$NODE_VERSION-linux-$ARCH.tar.xz" SHASUMS256.txt.asc SHASUMS256.txt \
-  && ln -s /usr/local/bin/node /usr/local/bin/nodejs
+  && ln -s /usr/local/bin/node /usr/local/bin/nodejs \
+  && chown node:node $(npm config get prefix)/lib/node_modules \
+  && chown node:node $(npm config get prefix)/bin \
+  && chown node:node $(npm config get prefix)/share
 
 ENV YARN_VERSION 0.24.4
 

--- a/7.10/wheezy/Dockerfile
+++ b/7.10/wheezy/Dockerfile
@@ -35,7 +35,10 @@ RUN ARCH= && dpkgArch="$(dpkg --print-architecture)" \
   && grep " node-v$NODE_VERSION-linux-$ARCH.tar.xz\$" SHASUMS256.txt | sha256sum -c - \
   && tar -xJf "node-v$NODE_VERSION-linux-$ARCH.tar.xz" -C /usr/local --strip-components=1 \
   && rm "node-v$NODE_VERSION-linux-$ARCH.tar.xz" SHASUMS256.txt.asc SHASUMS256.txt \
-  && ln -s /usr/local/bin/node /usr/local/bin/nodejs
+  && ln -s /usr/local/bin/node /usr/local/bin/nodejs \
+  && chown node:node $(npm config get prefix)/lib/node_modules \
+  && chown node:node $(npm config get prefix)/bin \
+  && chown node:node $(npm config get prefix)/share
 
 ENV YARN_VERSION 0.24.4
 

--- a/8.4/Dockerfile
+++ b/8.4/Dockerfile
@@ -37,7 +37,10 @@ RUN ARCH= && dpkgArch="$(dpkg --print-architecture)" \
   && grep " node-v$NODE_VERSION-linux-$ARCH.tar.xz\$" SHASUMS256.txt | sha256sum -c - \
   && tar -xJf "node-v$NODE_VERSION-linux-$ARCH.tar.xz" -C /usr/local --strip-components=1 \
   && rm "node-v$NODE_VERSION-linux-$ARCH.tar.xz" SHASUMS256.txt.asc SHASUMS256.txt \
-  && ln -s /usr/local/bin/node /usr/local/bin/nodejs
+  && ln -s /usr/local/bin/node /usr/local/bin/nodejs \
+  && chown node:node $(npm config get prefix)/lib/node_modules \
+  && chown node:node $(npm config get prefix)/bin \
+  && chown node:node $(npm config get prefix)/share
 
 ENV YARN_VERSION 0.27.5
 

--- a/8.4/alpine/Dockerfile
+++ b/8.4/alpine/Dockerfile
@@ -44,7 +44,10 @@ RUN addgroup -g 1000 node \
     && apk del .build-deps \
     && cd .. \
     && rm -Rf "node-v$NODE_VERSION" \
-    && rm "node-v$NODE_VERSION.tar.xz" SHASUMS256.txt.asc SHASUMS256.txt
+    && rm "node-v$NODE_VERSION.tar.xz" SHASUMS256.txt.asc SHASUMS256.txt \
+    && chown node:node $(npm config get prefix)/lib/node_modules \
+    && chown node:node $(npm config get prefix)/bin \
+    && chown node:node $(npm config get prefix)/share
 
 ENV YARN_VERSION 0.27.5
 

--- a/8.4/slim/Dockerfile
+++ b/8.4/slim/Dockerfile
@@ -42,7 +42,10 @@ RUN buildDeps='xz-utils' \
     && tar -xJf "node-v$NODE_VERSION-linux-$ARCH.tar.xz" -C /usr/local --strip-components=1 \
     && rm "node-v$NODE_VERSION-linux-$ARCH.tar.xz" SHASUMS256.txt.asc SHASUMS256.txt \
     && apt-get purge -y --auto-remove $buildDeps \
-    && ln -s /usr/local/bin/node /usr/local/bin/nodejs
+    && ln -s /usr/local/bin/node /usr/local/bin/nodejs \
+    && chown node:node $(npm config get prefix)/lib/node_modules \
+    && chown node:node $(npm config get prefix)/bin \
+    && chown node:node $(npm config get prefix)/share
 
 ENV YARN_VERSION 0.27.5
 

--- a/8.4/stretch/Dockerfile
+++ b/8.4/stretch/Dockerfile
@@ -37,7 +37,10 @@ RUN ARCH= && dpkgArch="$(dpkg --print-architecture)" \
   && grep " node-v$NODE_VERSION-linux-$ARCH.tar.xz\$" SHASUMS256.txt | sha256sum -c - \
   && tar -xJf "node-v$NODE_VERSION-linux-$ARCH.tar.xz" -C /usr/local --strip-components=1 \
   && rm "node-v$NODE_VERSION-linux-$ARCH.tar.xz" SHASUMS256.txt.asc SHASUMS256.txt \
-  && ln -s /usr/local/bin/node /usr/local/bin/nodejs
+  && ln -s /usr/local/bin/node /usr/local/bin/nodejs \
+  && chown node:node $(npm config get prefix)/lib/node_modules \
+  && chown node:node $(npm config get prefix)/bin \
+  && chown node:node $(npm config get prefix)/share
 
 ENV YARN_VERSION 0.27.5
 

--- a/8.4/wheezy/Dockerfile
+++ b/8.4/wheezy/Dockerfile
@@ -35,7 +35,10 @@ RUN ARCH= && dpkgArch="$(dpkg --print-architecture)" \
   && grep " node-v$NODE_VERSION-linux-$ARCH.tar.xz\$" SHASUMS256.txt | sha256sum -c - \
   && tar -xJf "node-v$NODE_VERSION-linux-$ARCH.tar.xz" -C /usr/local --strip-components=1 \
   && rm "node-v$NODE_VERSION-linux-$ARCH.tar.xz" SHASUMS256.txt.asc SHASUMS256.txt \
-  && ln -s /usr/local/bin/node /usr/local/bin/nodejs
+  && ln -s /usr/local/bin/node /usr/local/bin/nodejs \
+  && chown node:node $(npm config get prefix)/lib/node_modules \
+  && chown node:node $(npm config get prefix)/bin \
+  && chown node:node $(npm config get prefix)/share
 
 ENV YARN_VERSION 0.27.5
 

--- a/Dockerfile-alpine.template
+++ b/Dockerfile-alpine.template
@@ -44,7 +44,10 @@ RUN addgroup -g 1000 node \
     && apk del .build-deps \
     && cd .. \
     && rm -Rf "node-v$NODE_VERSION" \
-    && rm "node-v$NODE_VERSION.tar.xz" SHASUMS256.txt.asc SHASUMS256.txt
+    && rm "node-v$NODE_VERSION.tar.xz" SHASUMS256.txt.asc SHASUMS256.txt \
+    && chown node:node $(npm config get prefix)/lib/node_modules \
+    && chown node:node $(npm config get prefix)/bin \
+    && chown node:node $(npm config get prefix)/share
 
 ENV YARN_VERSION 0.0.0
 

--- a/Dockerfile-slim.template
+++ b/Dockerfile-slim.template
@@ -42,7 +42,10 @@ RUN buildDeps='xz-utils' \
     && tar -xJf "node-v$NODE_VERSION-linux-$ARCH.tar.xz" -C /usr/local --strip-components=1 \
     && rm "node-v$NODE_VERSION-linux-$ARCH.tar.xz" SHASUMS256.txt.asc SHASUMS256.txt \
     && apt-get purge -y --auto-remove $buildDeps \
-    && ln -s /usr/local/bin/node /usr/local/bin/nodejs
+    && ln -s /usr/local/bin/node /usr/local/bin/nodejs \
+    && chown node:node $(npm config get prefix)/lib/node_modules \
+    && chown node:node $(npm config get prefix)/bin \
+    && chown node:node $(npm config get prefix)/share
 
 ENV YARN_VERSION 0.0.0
 

--- a/Dockerfile-stretch.template
+++ b/Dockerfile-stretch.template
@@ -37,7 +37,10 @@ RUN ARCH= && dpkgArch="$(dpkg --print-architecture)" \
   && grep " node-v$NODE_VERSION-linux-$ARCH.tar.xz\$" SHASUMS256.txt | sha256sum -c - \
   && tar -xJf "node-v$NODE_VERSION-linux-$ARCH.tar.xz" -C /usr/local --strip-components=1 \
   && rm "node-v$NODE_VERSION-linux-$ARCH.tar.xz" SHASUMS256.txt.asc SHASUMS256.txt \
-  && ln -s /usr/local/bin/node /usr/local/bin/nodejs
+  && ln -s /usr/local/bin/node /usr/local/bin/nodejs \
+  && chown node:node $(npm config get prefix)/lib/node_modules \
+  && chown node:node $(npm config get prefix)/bin \
+  && chown node:node $(npm config get prefix)/share
 
 ENV YARN_VERSION 0.0.0
 

--- a/Dockerfile-wheezy.template
+++ b/Dockerfile-wheezy.template
@@ -35,7 +35,10 @@ RUN ARCH= && dpkgArch="$(dpkg --print-architecture)" \
   && grep " node-v$NODE_VERSION-linux-$ARCH.tar.xz\$" SHASUMS256.txt | sha256sum -c - \
   && tar -xJf "node-v$NODE_VERSION-linux-$ARCH.tar.xz" -C /usr/local --strip-components=1 \
   && rm "node-v$NODE_VERSION-linux-$ARCH.tar.xz" SHASUMS256.txt.asc SHASUMS256.txt \
-  && ln -s /usr/local/bin/node /usr/local/bin/nodejs
+  && ln -s /usr/local/bin/node /usr/local/bin/nodejs \
+  && chown node:node $(npm config get prefix)/lib/node_modules \
+  && chown node:node $(npm config get prefix)/bin \
+  && chown node:node $(npm config get prefix)/share
 
 ENV YARN_VERSION 0.0.0
 

--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -37,7 +37,10 @@ RUN ARCH= && dpkgArch="$(dpkg --print-architecture)" \
   && grep " node-v$NODE_VERSION-linux-$ARCH.tar.xz\$" SHASUMS256.txt | sha256sum -c - \
   && tar -xJf "node-v$NODE_VERSION-linux-$ARCH.tar.xz" -C /usr/local --strip-components=1 \
   && rm "node-v$NODE_VERSION-linux-$ARCH.tar.xz" SHASUMS256.txt.asc SHASUMS256.txt \
-  && ln -s /usr/local/bin/node /usr/local/bin/nodejs
+  && ln -s /usr/local/bin/node /usr/local/bin/nodejs \
+  && chown node:node $(npm config get prefix)/lib/node_modules \
+  && chown node:node $(npm config get prefix)/bin \
+  && chown node:node $(npm config get prefix)/share
 
 ENV YARN_VERSION 0.0.0
 


### PR DESCRIPTION
Based on the npm docks (https://docs.npmjs.com/getting-started/fixing-npm-permissions)

I tested this and it works when installing under `root` and with the `node` user.