### PR TITLE
Add exit signal handling benefit to CMD section

### DIFF
--- a/docs/BestPractices.md
+++ b/docs/BestPractices.md
@@ -95,7 +95,7 @@ By default, any Docker Container may consume as much of the hardware such as CPU
 
 ## CMD
 
-When creating an image, you can bypass the `package.json`'s `start` command and bake it directly into the image itself. This reduces the number of processes running inside of your container.
+When creating an image, you can bypass the `package.json`'s `start` command and bake it directly into the image itself. First off this reduces the number of processes running inside of your container. Secondly it causes exit signals such as `SIGTERM` and `SIGINT` to be received by the Node.js process instead of npm swallowing them.
 
 ```Dockerfile
 CMD ["node","index.js"]


### PR DESCRIPTION
It took me a while to figure out why process handlers in my Node app were not received and following the best practices solved it for no apparent reason. More information in [this npm issue](https://github.com/npm/npm/issues/4603#issuecomment-170175517), TL;DR: npm does not pass on exit signals to its children.

Hopefully adding this information will save other people time debugging. :)