### PR TITLE
Add multi-arch node:alpine

### DIFF
--- a/architectures
+++ b/architectures
@@ -1,6 +1,6 @@
 bashbrew-arch   variants
 amd64     default,alpine,onbuild,slim,stretch,wheezy
-ppc64le default,onbuild,slim,stretch
-s390x default,onbuild,slim,stretch
-arm64v8 default,onbuild,slim,stretch
-arm32v7 default,onbuild,slim,stretch
+ppc64le default,alpine,onbuild,slim,stretch
+s390x default,alpine,onbuild,slim,stretch
+arm64v8 default,alpine,onbuild,slim,stretch
+arm32v7 default,alpine,onbuild,slim,stretch


### PR DESCRIPTION
Let's start making a multi-arch `node:alpine` image.

Node itself is already multi-arch:
```
$ docker run --rm mplatform/mquery node
Image: node
 * Manifest List: Yes
 * Supported platforms:
   - linux/amd64
   - linux/arm/v7
   - linux/arm64/v8
   - linux/ppc64le
   - linux/s390x
```

Now alpine is also available:

```
$ docker run --rm mplatform/mquery alpine
Image: alpine
 * Manifest List: Yes
 * Supported platforms:
   - linux/amd64
   - linux/arm/v6
   - linux/arm64/v8
   - linux/386
   - linux/ppc64le
   - linux/s390x
```

I don't know if the change in the `architecture` file is enough (probably not :-) ), but it's a first start.
Is something else missing that has to be changed in this repo?
