### PR TITLE
Add i386 arch support

### DIFF
--- a/4.8/Dockerfile
+++ b/4.8/Dockerfile
@@ -29,7 +29,7 @@ RUN ARCH= && dpkgArch="$(dpkg --print-architecture)" \
     s390x) ARCH='s390x';; \
     arm64) ARCH='arm64';; \
     armhf) ARCH='armv7l';; \
-    i386) ARCH='i386';; \
+    i386) ARCH='x86';; \
     *) echo "unsupported architecture"; exit 1 ;; \
   esac \
   && curl -SLO "https://nodejs.org/dist/v$NODE_VERSION/node-v$NODE_VERSION-linux-$ARCH.tar.xz" \

--- a/4.8/Dockerfile
+++ b/4.8/Dockerfile
@@ -29,6 +29,7 @@ RUN ARCH= && dpkgArch="$(dpkg --print-architecture)" \
     s390x) ARCH='s390x';; \
     arm64) ARCH='arm64';; \
     armhf) ARCH='armv7l';; \
+    i386) ARCH='i386';; \
     *) echo "unsupported architecture"; exit 1 ;; \
   esac \
   && curl -SLO "https://nodejs.org/dist/v$NODE_VERSION/node-v$NODE_VERSION-linux-$ARCH.tar.xz" \

--- a/4.8/architectures
+++ b/4.8/architectures
@@ -3,3 +3,4 @@ amd64     default,alpine,onbuild,slim,stretch,wheezy
 ppc64le default,onbuild,slim,stretch
 arm64v8 default,onbuild,slim,stretch
 arm32v7 default,onbuild,slim,stretch
+i386 default,alpine,onbuild,slim,stretch,wheezy

--- a/4.8/architectures
+++ b/4.8/architectures
@@ -3,4 +3,4 @@ amd64     default,alpine,onbuild,slim,stretch,wheezy
 ppc64le default,onbuild,slim,stretch
 arm64v8 default,onbuild,slim,stretch
 arm32v7 default,onbuild,slim,stretch
-i386 default,alpine,onbuild,slim,stretch,wheezy
+i386 default,alpine,onbuild,slim,stretch

--- a/4.8/architectures
+++ b/4.8/architectures
@@ -3,4 +3,4 @@ amd64     default,alpine,onbuild,slim,stretch,wheezy
 ppc64le default,onbuild,slim,stretch
 arm64v8 default,onbuild,slim,stretch
 arm32v7 default,onbuild,slim,stretch
-i386 default,alpine,onbuild,slim,stretch
+i386 default,onbuild,slim,stretch

--- a/4.8/slim/Dockerfile
+++ b/4.8/slim/Dockerfile
@@ -30,7 +30,7 @@ RUN buildDeps='xz-utils' \
       s390x) ARCH='s390x';; \
       arm64) ARCH='arm64';; \
       armhf) ARCH='armv7l';; \
-      i386) ARCH='i386';; \
+      i386) ARCH='x86';; \
       *) echo "unsupported architecture"; exit 1 ;; \
     esac \
     && set -x \

--- a/4.8/slim/Dockerfile
+++ b/4.8/slim/Dockerfile
@@ -30,6 +30,7 @@ RUN buildDeps='xz-utils' \
       s390x) ARCH='s390x';; \
       arm64) ARCH='arm64';; \
       armhf) ARCH='armv7l';; \
+      i386) ARCH='i386';; \
       *) echo "unsupported architecture"; exit 1 ;; \
     esac \
     && set -x \

--- a/4.8/stretch/Dockerfile
+++ b/4.8/stretch/Dockerfile
@@ -29,7 +29,7 @@ RUN ARCH= && dpkgArch="$(dpkg --print-architecture)" \
     s390x) ARCH='s390x';; \
     arm64) ARCH='arm64';; \
     armhf) ARCH='armv7l';; \
-    i386) ARCH='i386';; \
+    i386) ARCH='x86';; \
     *) echo "unsupported architecture"; exit 1 ;; \
   esac \
   && curl -SLO "https://nodejs.org/dist/v$NODE_VERSION/node-v$NODE_VERSION-linux-$ARCH.tar.xz" \

--- a/4.8/stretch/Dockerfile
+++ b/4.8/stretch/Dockerfile
@@ -29,6 +29,7 @@ RUN ARCH= && dpkgArch="$(dpkg --print-architecture)" \
     s390x) ARCH='s390x';; \
     arm64) ARCH='arm64';; \
     armhf) ARCH='armv7l';; \
+    i386) ARCH='i386';; \
     *) echo "unsupported architecture"; exit 1 ;; \
   esac \
   && curl -SLO "https://nodejs.org/dist/v$NODE_VERSION/node-v$NODE_VERSION-linux-$ARCH.tar.xz" \

--- a/6.11/Dockerfile
+++ b/6.11/Dockerfile
@@ -29,7 +29,7 @@ RUN ARCH= && dpkgArch="$(dpkg --print-architecture)" \
     s390x) ARCH='s390x';; \
     arm64) ARCH='arm64';; \
     armhf) ARCH='armv7l';; \
-    i386) ARCH='i386';; \
+    i386) ARCH='x86';; \
     *) echo "unsupported architecture"; exit 1 ;; \
   esac \
   && curl -SLO "https://nodejs.org/dist/v$NODE_VERSION/node-v$NODE_VERSION-linux-$ARCH.tar.xz" \

--- a/6.11/Dockerfile
+++ b/6.11/Dockerfile
@@ -29,6 +29,7 @@ RUN ARCH= && dpkgArch="$(dpkg --print-architecture)" \
     s390x) ARCH='s390x';; \
     arm64) ARCH='arm64';; \
     armhf) ARCH='armv7l';; \
+    i386) ARCH='i386';; \
     *) echo "unsupported architecture"; exit 1 ;; \
   esac \
   && curl -SLO "https://nodejs.org/dist/v$NODE_VERSION/node-v$NODE_VERSION-linux-$ARCH.tar.xz" \

--- a/6.11/architectures
+++ b/6.11/architectures
@@ -4,3 +4,4 @@ ppc64le default,onbuild,slim,stretch
 s390x default,onbuild,slim,stretch
 arm64v8 default,onbuild,slim,stretch
 arm32v7 default,onbuild,slim,stretch
+i386 default,alpine,onbuild,slim,stretch,wheezy

--- a/6.11/architectures
+++ b/6.11/architectures
@@ -4,4 +4,4 @@ ppc64le default,onbuild,slim,stretch
 s390x default,onbuild,slim,stretch
 arm64v8 default,onbuild,slim,stretch
 arm32v7 default,onbuild,slim,stretch
-i386 default,alpine,onbuild,slim,stretch
+i386 default,onbuild,slim,stretch

--- a/6.11/architectures
+++ b/6.11/architectures
@@ -4,4 +4,4 @@ ppc64le default,onbuild,slim,stretch
 s390x default,onbuild,slim,stretch
 arm64v8 default,onbuild,slim,stretch
 arm32v7 default,onbuild,slim,stretch
-i386 default,alpine,onbuild,slim,stretch,wheezy
+i386 default,alpine,onbuild,slim,stretch

--- a/6.11/slim/Dockerfile
+++ b/6.11/slim/Dockerfile
@@ -30,7 +30,7 @@ RUN buildDeps='xz-utils' \
       s390x) ARCH='s390x';; \
       arm64) ARCH='arm64';; \
       armhf) ARCH='armv7l';; \
-      i386) ARCH='i386';; \
+      i386) ARCH='x86';; \
       *) echo "unsupported architecture"; exit 1 ;; \
     esac \
     && set -x \

--- a/6.11/slim/Dockerfile
+++ b/6.11/slim/Dockerfile
@@ -30,6 +30,7 @@ RUN buildDeps='xz-utils' \
       s390x) ARCH='s390x';; \
       arm64) ARCH='arm64';; \
       armhf) ARCH='armv7l';; \
+      i386) ARCH='i386';; \
       *) echo "unsupported architecture"; exit 1 ;; \
     esac \
     && set -x \

--- a/6.11/stretch/Dockerfile
+++ b/6.11/stretch/Dockerfile
@@ -29,7 +29,7 @@ RUN ARCH= && dpkgArch="$(dpkg --print-architecture)" \
     s390x) ARCH='s390x';; \
     arm64) ARCH='arm64';; \
     armhf) ARCH='armv7l';; \
-    i386) ARCH='i386';; \
+    i386) ARCH='x86';; \
     *) echo "unsupported architecture"; exit 1 ;; \
   esac \
   && curl -SLO "https://nodejs.org/dist/v$NODE_VERSION/node-v$NODE_VERSION-linux-$ARCH.tar.xz" \

--- a/6.11/stretch/Dockerfile
+++ b/6.11/stretch/Dockerfile
@@ -29,6 +29,7 @@ RUN ARCH= && dpkgArch="$(dpkg --print-architecture)" \
     s390x) ARCH='s390x';; \
     arm64) ARCH='arm64';; \
     armhf) ARCH='armv7l';; \
+    i386) ARCH='i386';; \
     *) echo "unsupported architecture"; exit 1 ;; \
   esac \
   && curl -SLO "https://nodejs.org/dist/v$NODE_VERSION/node-v$NODE_VERSION-linux-$ARCH.tar.xz" \

--- a/8.9/Dockerfile
+++ b/8.9/Dockerfile
@@ -29,7 +29,7 @@ RUN ARCH= && dpkgArch="$(dpkg --print-architecture)" \
     s390x) ARCH='s390x';; \
     arm64) ARCH='arm64';; \
     armhf) ARCH='armv7l';; \
-    i386) ARCH='i386';; \
+    i386) ARCH='x86';; \
     *) echo "unsupported architecture"; exit 1 ;; \
   esac \
   && curl -SLO "https://nodejs.org/dist/v$NODE_VERSION/node-v$NODE_VERSION-linux-$ARCH.tar.xz" \

--- a/8.9/Dockerfile
+++ b/8.9/Dockerfile
@@ -29,6 +29,7 @@ RUN ARCH= && dpkgArch="$(dpkg --print-architecture)" \
     s390x) ARCH='s390x';; \
     arm64) ARCH='arm64';; \
     armhf) ARCH='armv7l';; \
+    i386) ARCH='i386';; \
     *) echo "unsupported architecture"; exit 1 ;; \
   esac \
   && curl -SLO "https://nodejs.org/dist/v$NODE_VERSION/node-v$NODE_VERSION-linux-$ARCH.tar.xz" \

--- a/8.9/slim/Dockerfile
+++ b/8.9/slim/Dockerfile
@@ -30,7 +30,7 @@ RUN buildDeps='xz-utils' \
       s390x) ARCH='s390x';; \
       arm64) ARCH='arm64';; \
       armhf) ARCH='armv7l';; \
-      i386) ARCH='i386';; \
+      i386) ARCH='x86';; \
       *) echo "unsupported architecture"; exit 1 ;; \
     esac \
     && set -x \

--- a/8.9/slim/Dockerfile
+++ b/8.9/slim/Dockerfile
@@ -30,6 +30,7 @@ RUN buildDeps='xz-utils' \
       s390x) ARCH='s390x';; \
       arm64) ARCH='arm64';; \
       armhf) ARCH='armv7l';; \
+      i386) ARCH='i386';; \
       *) echo "unsupported architecture"; exit 1 ;; \
     esac \
     && set -x \

--- a/8.9/stretch/Dockerfile
+++ b/8.9/stretch/Dockerfile
@@ -29,7 +29,7 @@ RUN ARCH= && dpkgArch="$(dpkg --print-architecture)" \
     s390x) ARCH='s390x';; \
     arm64) ARCH='arm64';; \
     armhf) ARCH='armv7l';; \
-    i386) ARCH='i386';; \
+    i386) ARCH='x86';; \
     *) echo "unsupported architecture"; exit 1 ;; \
   esac \
   && curl -SLO "https://nodejs.org/dist/v$NODE_VERSION/node-v$NODE_VERSION-linux-$ARCH.tar.xz" \

--- a/8.9/stretch/Dockerfile
+++ b/8.9/stretch/Dockerfile
@@ -29,6 +29,7 @@ RUN ARCH= && dpkgArch="$(dpkg --print-architecture)" \
     s390x) ARCH='s390x';; \
     arm64) ARCH='arm64';; \
     armhf) ARCH='armv7l';; \
+    i386) ARCH='i386';; \
     *) echo "unsupported architecture"; exit 1 ;; \
   esac \
   && curl -SLO "https://nodejs.org/dist/v$NODE_VERSION/node-v$NODE_VERSION-linux-$ARCH.tar.xz" \

--- a/9.0/Dockerfile
+++ b/9.0/Dockerfile
@@ -29,7 +29,7 @@ RUN ARCH= && dpkgArch="$(dpkg --print-architecture)" \
     s390x) ARCH='s390x';; \
     arm64) ARCH='arm64';; \
     armhf) ARCH='armv7l';; \
-    i386) ARCH='i386';; \
+    i386) ARCH='x86';; \
     *) echo "unsupported architecture"; exit 1 ;; \
   esac \
   && curl -SLO "https://nodejs.org/dist/v$NODE_VERSION/node-v$NODE_VERSION-linux-$ARCH.tar.xz" \

--- a/9.0/Dockerfile
+++ b/9.0/Dockerfile
@@ -29,6 +29,7 @@ RUN ARCH= && dpkgArch="$(dpkg --print-architecture)" \
     s390x) ARCH='s390x';; \
     arm64) ARCH='arm64';; \
     armhf) ARCH='armv7l';; \
+    i386) ARCH='i386';; \
     *) echo "unsupported architecture"; exit 1 ;; \
   esac \
   && curl -SLO "https://nodejs.org/dist/v$NODE_VERSION/node-v$NODE_VERSION-linux-$ARCH.tar.xz" \

--- a/9.0/slim/Dockerfile
+++ b/9.0/slim/Dockerfile
@@ -30,7 +30,7 @@ RUN buildDeps='xz-utils' \
       s390x) ARCH='s390x';; \
       arm64) ARCH='arm64';; \
       armhf) ARCH='armv7l';; \
-      i386) ARCH='i386';; \
+      i386) ARCH='x86';; \
       *) echo "unsupported architecture"; exit 1 ;; \
     esac \
     && set -x \

--- a/9.0/slim/Dockerfile
+++ b/9.0/slim/Dockerfile
@@ -30,6 +30,7 @@ RUN buildDeps='xz-utils' \
       s390x) ARCH='s390x';; \
       arm64) ARCH='arm64';; \
       armhf) ARCH='armv7l';; \
+      i386) ARCH='i386';; \
       *) echo "unsupported architecture"; exit 1 ;; \
     esac \
     && set -x \

--- a/9.0/stretch/Dockerfile
+++ b/9.0/stretch/Dockerfile
@@ -29,7 +29,7 @@ RUN ARCH= && dpkgArch="$(dpkg --print-architecture)" \
     s390x) ARCH='s390x';; \
     arm64) ARCH='arm64';; \
     armhf) ARCH='armv7l';; \
-    i386) ARCH='i386';; \
+    i386) ARCH='x86';; \
     *) echo "unsupported architecture"; exit 1 ;; \
   esac \
   && curl -SLO "https://nodejs.org/dist/v$NODE_VERSION/node-v$NODE_VERSION-linux-$ARCH.tar.xz" \

--- a/9.0/stretch/Dockerfile
+++ b/9.0/stretch/Dockerfile
@@ -29,6 +29,7 @@ RUN ARCH= && dpkgArch="$(dpkg --print-architecture)" \
     s390x) ARCH='s390x';; \
     arm64) ARCH='arm64';; \
     armhf) ARCH='armv7l';; \
+    i386) ARCH='i386';; \
     *) echo "unsupported architecture"; exit 1 ;; \
   esac \
   && curl -SLO "https://nodejs.org/dist/v$NODE_VERSION/node-v$NODE_VERSION-linux-$ARCH.tar.xz" \

--- a/Dockerfile-slim.template
+++ b/Dockerfile-slim.template
@@ -30,7 +30,7 @@ RUN buildDeps='xz-utils' \
       s390x) ARCH='s390x';; \
       arm64) ARCH='arm64';; \
       armhf) ARCH='armv7l';; \
-      i386) ARCH='i386';; \
+      i386) ARCH='x86';; \
       *) echo "unsupported architecture"; exit 1 ;; \
     esac \
     && set -x \

--- a/Dockerfile-slim.template
+++ b/Dockerfile-slim.template
@@ -30,6 +30,7 @@ RUN buildDeps='xz-utils' \
       s390x) ARCH='s390x';; \
       arm64) ARCH='arm64';; \
       armhf) ARCH='armv7l';; \
+      i386) ARCH='i386';; \
       *) echo "unsupported architecture"; exit 1 ;; \
     esac \
     && set -x \

--- a/Dockerfile-stretch.template
+++ b/Dockerfile-stretch.template
@@ -29,7 +29,7 @@ RUN ARCH= && dpkgArch="$(dpkg --print-architecture)" \
     s390x) ARCH='s390x';; \
     arm64) ARCH='arm64';; \
     armhf) ARCH='armv7l';; \
-    i386) ARCH='i386';; \
+    i386) ARCH='x86';; \
     *) echo "unsupported architecture"; exit 1 ;; \
   esac \
   && curl -SLO "https://nodejs.org/dist/v$NODE_VERSION/node-v$NODE_VERSION-linux-$ARCH.tar.xz" \

--- a/Dockerfile-stretch.template
+++ b/Dockerfile-stretch.template
@@ -29,6 +29,7 @@ RUN ARCH= && dpkgArch="$(dpkg --print-architecture)" \
     s390x) ARCH='s390x';; \
     arm64) ARCH='arm64';; \
     armhf) ARCH='armv7l';; \
+    i386) ARCH='i386';; \
     *) echo "unsupported architecture"; exit 1 ;; \
   esac \
   && curl -SLO "https://nodejs.org/dist/v$NODE_VERSION/node-v$NODE_VERSION-linux-$ARCH.tar.xz" \

--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -29,7 +29,7 @@ RUN ARCH= && dpkgArch="$(dpkg --print-architecture)" \
     s390x) ARCH='s390x';; \
     arm64) ARCH='arm64';; \
     armhf) ARCH='armv7l';; \
-    i386) ARCH='i386';; \
+    i386) ARCH='x86';; \
     *) echo "unsupported architecture"; exit 1 ;; \
   esac \
   && curl -SLO "https://nodejs.org/dist/v$NODE_VERSION/node-v$NODE_VERSION-linux-$ARCH.tar.xz" \

--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -29,6 +29,7 @@ RUN ARCH= && dpkgArch="$(dpkg --print-architecture)" \
     s390x) ARCH='s390x';; \
     arm64) ARCH='arm64';; \
     armhf) ARCH='armv7l';; \
+    i386) ARCH='i386';; \
     *) echo "unsupported architecture"; exit 1 ;; \
   esac \
   && curl -SLO "https://nodejs.org/dist/v$NODE_VERSION/node-v$NODE_VERSION-linux-$ARCH.tar.xz" \

--- a/architectures
+++ b/architectures
@@ -5,4 +5,4 @@ s390x default,alpine,onbuild,slim,stretch
 arm64v8 default,alpine,onbuild,slim,stretch
 arm32v7 default,onbuild,slim,stretch
 arm32v6 alpine
-i386 default,alpine,onbuild,slim,stretch,wheezy
+i386 default,alpine,onbuild,slim,stretch

--- a/architectures
+++ b/architectures
@@ -5,3 +5,4 @@ s390x default,alpine,onbuild,slim,stretch
 arm64v8 default,alpine,onbuild,slim,stretch
 arm32v7 default,onbuild,slim,stretch
 arm32v6 alpine
+i386 default,alpine,onbuild,slim,stretch,wheezy


### PR DESCRIPTION
Fixes #574. I'm _pretty_ sure this is correct, but not 100%. Wheezy not included because of #567.

Diff for stackbrew:

<details>

```diff
diff --git i/library/node w/library/node
index 1c45afc..68efc55 100644
--- i/library/node
+++ w/library/node
@@ -4,122 +4,122 @@ Maintainers: The Node.js Docker Team <https://github.com/nodejs/docker-node> (@n
 GitRepo: https://github.com/nodejs/docker-node.git
 
 Tags: 9.0.0, 9.0, 9, latest
-Architectures: amd64, ppc64le, s390x, arm64v8, arm32v7
-GitCommit: 092306f6d035d53d7f087a1a671915aabc946c6f
+Architectures: amd64, ppc64le, s390x, arm64v8, arm32v7, i386
+GitCommit: d3557702c9f55d3180ad50788a05f153dc99ac1a
 Directory: 9.0
 
 Tags: 9.0.0-alpine, 9.0-alpine, 9-alpine, alpine
-Architectures: amd64, ppc64le, s390x, arm64v8, arm32v6
+Architectures: amd64, ppc64le, s390x, arm64v8, arm32v6, i386
 GitCommit: 092306f6d035d53d7f087a1a671915aabc946c6f
 Directory: 9.0/alpine
 
 Tags: 9.0.0-onbuild, 9.0-onbuild, 9-onbuild, onbuild
-Architectures: amd64, ppc64le, s390x, arm64v8, arm32v7
+Architectures: amd64, ppc64le, s390x, arm64v8, arm32v7, i386
 GitCommit: 092306f6d035d53d7f087a1a671915aabc946c6f
 Directory: 9.0/onbuild
 
 Tags: 9.0.0-slim, 9.0-slim, 9-slim, slim
-Architectures: amd64, ppc64le, s390x, arm64v8, arm32v7
-GitCommit: 092306f6d035d53d7f087a1a671915aabc946c6f
+Architectures: amd64, ppc64le, s390x, arm64v8, arm32v7, i386
+GitCommit: d3557702c9f55d3180ad50788a05f153dc99ac1a
 Directory: 9.0/slim
 
 Tags: 9.0.0-stretch, 9.0-stretch, 9-stretch, stretch
-Architectures: amd64, ppc64le, s390x, arm64v8, arm32v7
-GitCommit: 092306f6d035d53d7f087a1a671915aabc946c6f
+Architectures: amd64, ppc64le, s390x, arm64v8, arm32v7, i386
+GitCommit: d3557702c9f55d3180ad50788a05f153dc99ac1a
 Directory: 9.0/stretch
 
 Tags: 9.0.0-wheezy, 9.0-wheezy, 9-wheezy, wheezy
-Architectures: amd64
+Architectures: amd64, i386
 GitCommit: 092306f6d035d53d7f087a1a671915aabc946c6f
 Directory: 9.0/wheezy
 
 Tags: 8.9.0, 8.9, 8, carbon
-Architectures: amd64, ppc64le, s390x, arm64v8, arm32v7
-GitCommit: 39a5c8a3be7fff2ddc67a2e72919d0a3841b235f
+Architectures: amd64, ppc64le, s390x, arm64v8, arm32v7, i386
+GitCommit: d3557702c9f55d3180ad50788a05f153dc99ac1a
 Directory: 8.9
 
 Tags: 8.9.0-alpine, 8.9-alpine, 8-alpine, carbon-alpine
-Architectures: amd64, ppc64le, s390x, arm64v8, arm32v6
+Architectures: amd64, ppc64le, s390x, arm64v8, arm32v6, i386
 GitCommit: 39a5c8a3be7fff2ddc67a2e72919d0a3841b235f
 Directory: 8.9/alpine
 
 Tags: 8.9.0-onbuild, 8.9-onbuild, 8-onbuild, carbon-onbuild
-Architectures: amd64, ppc64le, s390x, arm64v8, arm32v7
+Architectures: amd64, ppc64le, s390x, arm64v8, arm32v7, i386
 GitCommit: 39a5c8a3be7fff2ddc67a2e72919d0a3841b235f
 Directory: 8.9/onbuild
 
 Tags: 8.9.0-slim, 8.9-slim, 8-slim, carbon-slim
-Architectures: amd64, ppc64le, s390x, arm64v8, arm32v7
-GitCommit: 39a5c8a3be7fff2ddc67a2e72919d0a3841b235f
+Architectures: amd64, ppc64le, s390x, arm64v8, arm32v7, i386
+GitCommit: d3557702c9f55d3180ad50788a05f153dc99ac1a
 Directory: 8.9/slim
 
 Tags: 8.9.0-stretch, 8.9-stretch, 8-stretch, carbon-stretch
-Architectures: amd64, ppc64le, s390x, arm64v8, arm32v7
-GitCommit: 39a5c8a3be7fff2ddc67a2e72919d0a3841b235f
+Architectures: amd64, ppc64le, s390x, arm64v8, arm32v7, i386
+GitCommit: d3557702c9f55d3180ad50788a05f153dc99ac1a
 Directory: 8.9/stretch
 
 Tags: 8.9.0-wheezy, 8.9-wheezy, 8-wheezy, carbon-wheezy
-Architectures: amd64
+Architectures: amd64, i386
 GitCommit: 39a5c8a3be7fff2ddc67a2e72919d0a3841b235f
 Directory: 8.9/wheezy
 
 Tags: 6.11.5, 6.11, 6, boron
-Architectures: amd64, ppc64le, s390x, arm64v8, arm32v7
-GitCommit: 222c645bfa57e415d57fc4ac2088262c8c3cef70
+Architectures: amd64, ppc64le, s390x, arm64v8, arm32v7, i386
+GitCommit: d3557702c9f55d3180ad50788a05f153dc99ac1a
 Directory: 6.11
 
 Tags: 6.11.5-alpine, 6.11-alpine, 6-alpine, boron-alpine
-Architectures: amd64
+Architectures: amd64, i386
 GitCommit: 94a739297fcd60ef969b478d4e581a6d8299a94d
 Directory: 6.11/alpine
 
 Tags: 6.11.5-onbuild, 6.11-onbuild, 6-onbuild, boron-onbuild
-Architectures: amd64, ppc64le, s390x, arm64v8, arm32v7
+Architectures: amd64, ppc64le, s390x, arm64v8, arm32v7, i386
 GitCommit: 7701eea6fe125530894b3e83f1e9d385e9ee509f
 Directory: 6.11/onbuild
 
 Tags: 6.11.5-slim, 6.11-slim, 6-slim, boron-slim
-Architectures: amd64, ppc64le, s390x, arm64v8, arm32v7
-GitCommit: 94a739297fcd60ef969b478d4e581a6d8299a94d
+Architectures: amd64, ppc64le, s390x, arm64v8, arm32v7, i386
+GitCommit: d3557702c9f55d3180ad50788a05f153dc99ac1a
 Directory: 6.11/slim
 
 Tags: 6.11.5-stretch, 6.11-stretch, 6-stretch, boron-stretch
-Architectures: amd64, ppc64le, s390x, arm64v8, arm32v7
-GitCommit: 94a739297fcd60ef969b478d4e581a6d8299a94d
+Architectures: amd64, ppc64le, s390x, arm64v8, arm32v7, i386
+GitCommit: d3557702c9f55d3180ad50788a05f153dc99ac1a
 Directory: 6.11/stretch
 
 Tags: 6.11.5-wheezy, 6.11-wheezy, 6-wheezy, boron-wheezy
-Architectures: amd64
+Architectures: amd64, i386
 GitCommit: 94a739297fcd60ef969b478d4e581a6d8299a94d
 Directory: 6.11/wheezy
 
 Tags: 4.8.5, 4.8, 4, argon
-Architectures: amd64, ppc64le, arm64v8, arm32v7
-GitCommit: 94a739297fcd60ef969b478d4e581a6d8299a94d
+Architectures: amd64, ppc64le, arm64v8, arm32v7, i386
+GitCommit: d3557702c9f55d3180ad50788a05f153dc99ac1a
 Directory: 4.8
 
 Tags: 4.8.5-alpine, 4.8-alpine, 4-alpine, argon-alpine
-Architectures: amd64
+Architectures: amd64, i386
 GitCommit: 94a739297fcd60ef969b478d4e581a6d8299a94d
 Directory: 4.8/alpine
 
 Tags: 4.8.5-onbuild, 4.8-onbuild, 4-onbuild, argon-onbuild
-Architectures: amd64, ppc64le, arm64v8, arm32v7
+Architectures: amd64, ppc64le, arm64v8, arm32v7, i386
 GitCommit: 7701eea6fe125530894b3e83f1e9d385e9ee509f
 Directory: 4.8/onbuild
 
 Tags: 4.8.5-slim, 4.8-slim, 4-slim, argon-slim
-Architectures: amd64, ppc64le, arm64v8, arm32v7
-GitCommit: 94a739297fcd60ef969b478d4e581a6d8299a94d
+Architectures: amd64, ppc64le, arm64v8, arm32v7, i386
+GitCommit: d3557702c9f55d3180ad50788a05f153dc99ac1a
 Directory: 4.8/slim
 
 Tags: 4.8.5-stretch, 4.8-stretch, 4-stretch, argon-stretch
-Architectures: amd64, ppc64le, arm64v8, arm32v7
-GitCommit: 94a739297fcd60ef969b478d4e581a6d8299a94d
+Architectures: amd64, ppc64le, arm64v8, arm32v7, i386
+GitCommit: d3557702c9f55d3180ad50788a05f153dc99ac1a
 Directory: 4.8/stretch
 
 Tags: 4.8.5-wheezy, 4.8-wheezy, 4-wheezy, argon-wheezy
-Architectures: amd64
+Architectures: amd64, i386
 GitCommit: 94a739297fcd60ef969b478d4e581a6d8299a94d
 Directory: 4.8/wheezy
```

</details>

/cc @tianon 