### PR TITLE
Fix update.sh for empty patch version issue

### DIFF
--- a/update.sh
+++ b/update.sh
@@ -40,7 +40,7 @@ function update_node_version {
 		fi
 
 		sed -E -i.bak 's/^FROM (.*)/FROM '"$fromprefix"'\1/' "$dockerfile" && rm "$dockerfile".bak
-		sed -E -i.bak 's/^(ENV NODE_VERSION |FROM .*node:).*/\1'"$version.$fullVersion"'/' "$dockerfile" && rm "$dockerfile".bak
+		sed -E -i.bak 's/^(ENV NODE_VERSION |FROM .*node:).*/\1'"$version.${fullVersion:-0}"'/' "$dockerfile" && rm "$dockerfile".bak
 		sed -E -i.bak 's/^(ENV YARN_VERSION ).*/\1'"$yarnVersion"'/' "$dockerfile" && rm "$dockerfile".bak
 		if [[ "${version/.*/}" -ge 8 || "$arch" = "ppc64le" || "$arch" = "s390x" || "$arch" = "arm64" || "$arch" = "arm32v7" ]]; then
 			sed -E -i.bak 's/FROM (.*)alpine:3.4/FROM \1alpine:3.6/' "$dockerfile"


### PR DESCRIPTION
This problem didn't appear everytime, I'm not sure what's the reason why yet, but when it appears, and when last number in the nodejs version = 0, the origin `update.sh` will cause `v6.12.0` become `v6.12.` and `v9.1.0` become `v9.1.` in the Dockerfiles, which is weird and not correct.

This patch will make the latest version (`$fullVersion` in the script) `0` when it's empty.