### PR TITLE
Add Dockerfile for node-chakracore

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,6 +29,7 @@ env:
     - NODE_VERSION: '6'
     - NODE_VERSION: '8'
     - NODE_VERSION: '9'
+    - NODE_VERSION: 'chakracore/8'
 
 matrix:
   include:

--- a/6/Dockerfile
+++ b/6/Dockerfile
@@ -51,7 +51,6 @@ RUN set -ex \
     gpg --keyserver hkp://keyserver.pgp.com:80 --recv-keys "$key" || \
     gpg --keyserver hkp://ipv4.pool.sks-keyservers.net --recv-keys "$key" || \
     gpg --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys "$key" ; \
-
   done \
   && curl -fSLO --compressed "https://yarnpkg.com/downloads/$YARN_VERSION/yarn-v$YARN_VERSION.tar.gz" \
   && curl -fSLO --compressed "https://yarnpkg.com/downloads/$YARN_VERSION/yarn-v$YARN_VERSION.tar.gz.asc" \

--- a/8/slim/Dockerfile
+++ b/8/slim/Dockerfile
@@ -17,7 +17,8 @@ RUN set -ex \
   ; do \
     gpg --keyserver hkp://pgp.mit.edu:80 --recv-keys "$key" || \
     gpg --keyserver hkp://keyserver.pgp.com:80 --recv-keys "$key" || \
-    gpg --keyserver hkp://ha.pool.sks-keyservers.net:80 --recv-keys "$key" ; \
+    gpg --keyserver hkp://ipv4.pool.sks-keyservers.net --recv-keys "$key" || \
+    gpg --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys "$key" ; \
   done
 
 ENV NODE_VERSION 8.9.4

--- a/Dockerfile-stretch.template
+++ b/Dockerfile-stretch.template
@@ -51,8 +51,6 @@ RUN set -ex \
     gpg --keyserver hkp://keyserver.pgp.com:80 --recv-keys "$key" || \
     gpg --keyserver hkp://ipv4.pool.sks-keyservers.net --recv-keys "$key" || \
     gpg --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys "$key" ; \
-
-
   done \
   && curl -fSLO --compressed "https://yarnpkg.com/downloads/$YARN_VERSION/yarn-v$YARN_VERSION.tar.gz" \
   && curl -fSLO --compressed "https://yarnpkg.com/downloads/$YARN_VERSION/yarn-v$YARN_VERSION.tar.gz.asc" \

--- a/chakracore/8/Dockerfile
+++ b/chakracore/8/Dockerfile
@@ -1,0 +1,40 @@
+FROM buildpack-deps:jessie
+
+RUN groupadd --gid 1000 node \
+  && useradd --uid 1000 --gid node --shell /bin/bash --create-home node
+
+ENV NODE_VERSION 8.9.4
+
+RUN ARCH= && dpkgArch="$(dpkg --print-architecture)" \
+  && case "${dpkgArch##*-}" in \
+    amd64) ARCH='x64';; \
+    *) echo "unsupported architecture"; exit 1 ;; \
+  esac \
+  && curl -SLO "https://nodejs.org/download/chakracore-release/v$NODE_VERSION/node-v$NODE_VERSION-linux-$ARCH.tar.xz" \
+  && curl -SLO --compressed "https://nodejs.org/download/chakracore-release/v$NODE_VERSION/SHASUMS256.txt" \
+  && grep " node-v$NODE_VERSION-linux-$ARCH.tar.xz\$" SHASUMS256.txt | sha256sum -c - \
+  && tar -xJf "node-v$NODE_VERSION-linux-$ARCH.tar.xz" -C /usr/local --strip-components=1 --no-same-owner \
+  && rm "node-v$NODE_VERSION-linux-$ARCH.tar.xz" SHASUMS256.txt \
+  && ln -s /usr/local/bin/node /usr/local/bin/nodejs
+
+ENV YARN_VERSION 1.3.2
+
+RUN set -ex \
+  && for key in \
+    6A010C5166006599AA17F08146C2130DFD2497F5 \
+  ; do \
+    gpg --keyserver hkp://pgp.mit.edu:80 --recv-keys "$key" || \
+    gpg --keyserver hkp://keyserver.pgp.com:80 --recv-keys "$key" || \
+    gpg --keyserver hkp://ipv4.pool.sks-keyservers.net --recv-keys "$key" || \
+    gpg --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys "$key" ; \
+  done \
+  && curl -fSLO --compressed "https://yarnpkg.com/downloads/$YARN_VERSION/yarn-v$YARN_VERSION.tar.gz" \
+  && curl -fSLO --compressed "https://yarnpkg.com/downloads/$YARN_VERSION/yarn-v$YARN_VERSION.tar.gz.asc" \
+  && gpg --batch --verify yarn-v$YARN_VERSION.tar.gz.asc yarn-v$YARN_VERSION.tar.gz \
+  && mkdir -p /opt/yarn \
+  && tar -xzf yarn-v$YARN_VERSION.tar.gz -C /opt/yarn --strip-components=1 \
+  && ln -s /opt/yarn/bin/yarn /usr/local/bin/yarn \
+  && ln -s /opt/yarn/bin/yarn /usr/local/bin/yarnpkg \
+  && rm yarn-v$YARN_VERSION.tar.gz.asc yarn-v$YARN_VERSION.tar.gz
+
+CMD [ "node" ]

--- a/chakracore/Dockerfile.template
+++ b/chakracore/Dockerfile.template
@@ -1,0 +1,40 @@
+FROM buildpack-deps:jessie
+
+RUN groupadd --gid 1000 node \
+  && useradd --uid 1000 --gid node --shell /bin/bash --create-home node
+
+ENV NODE_VERSION 0.0.0
+
+RUN ARCH= && dpkgArch="$(dpkg --print-architecture)" \
+  && case "${dpkgArch##*-}" in \
+    amd64) ARCH='x64';; \
+    *) echo "unsupported architecture"; exit 1 ;; \
+  esac \
+  && curl -SLO "https://nodejs.org/download/chakracore-release/v$NODE_VERSION/node-v$NODE_VERSION-linux-$ARCH.tar.xz" \
+  && curl -SLO --compressed "https://nodejs.org/download/chakracore-release/v$NODE_VERSION/SHASUMS256.txt" \
+  && grep " node-v$NODE_VERSION-linux-$ARCH.tar.xz\$" SHASUMS256.txt | sha256sum -c - \
+  && tar -xJf "node-v$NODE_VERSION-linux-$ARCH.tar.xz" -C /usr/local --strip-components=1 --no-same-owner \
+  && rm "node-v$NODE_VERSION-linux-$ARCH.tar.xz" SHASUMS256.txt \
+  && ln -s /usr/local/bin/node /usr/local/bin/nodejs
+
+ENV YARN_VERSION 0.0.0
+
+RUN set -ex \
+  && for key in \
+    6A010C5166006599AA17F08146C2130DFD2497F5 \
+  ; do \
+    gpg --keyserver hkp://pgp.mit.edu:80 --recv-keys "$key" || \
+    gpg --keyserver hkp://keyserver.pgp.com:80 --recv-keys "$key" || \
+    gpg --keyserver hkp://ipv4.pool.sks-keyservers.net --recv-keys "$key" || \
+    gpg --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys "$key" ; \
+  done \
+  && curl -fSLO --compressed "https://yarnpkg.com/downloads/$YARN_VERSION/yarn-v$YARN_VERSION.tar.gz" \
+  && curl -fSLO --compressed "https://yarnpkg.com/downloads/$YARN_VERSION/yarn-v$YARN_VERSION.tar.gz.asc" \
+  && gpg --batch --verify yarn-v$YARN_VERSION.tar.gz.asc yarn-v$YARN_VERSION.tar.gz \
+  && mkdir -p /opt/yarn \
+  && tar -xzf yarn-v$YARN_VERSION.tar.gz -C /opt/yarn --strip-components=1 \
+  && ln -s /opt/yarn/bin/yarn /usr/local/bin/yarn \
+  && ln -s /opt/yarn/bin/yarn /usr/local/bin/yarnpkg \
+  && rm yarn-v$YARN_VERSION.tar.gz.asc yarn-v$YARN_VERSION.tar.gz
+
+CMD [ "node" ]

--- a/chakracore/architectures
+++ b/chakracore/architectures
@@ -1,0 +1,2 @@
+bashbrew-arch   variants
+amd64     default

--- a/chakracore/config
+++ b/chakracore/config
@@ -1,0 +1,1 @@
+baseuri     https://nodejs.org/download/chakracore-release

--- a/config
+++ b/config
@@ -1,0 +1,1 @@
+baseuri     https://nodejs.org/dist

--- a/functions.sh
+++ b/functions.sh
@@ -2,6 +2,17 @@
 
 # Utlity functions
 
+info() {
+	printf "%s\\n" "$@"
+}
+
+fatal() {
+	printf "**********\\n"
+	printf "Fatal Error: %s\\n" "$@"
+	printf "**********\\n"
+	exit 1
+}
+
 # Get system architecture
 #
 # This is used to get the target architecture for docker image.
@@ -40,10 +51,14 @@ function get_arch() {
 #   <architecutre 1> <supported variant 1 >,<supported variant 2>...
 #   <architecutre 2> <supported variant 1 >,<supported variant 2>...
 function get_variants() {
+	local dir
+	dir=${1:-.}
+	shift
+
 	local arch
 	arch=$(get_arch)
 	local variants
-	variants=$(grep "^$arch" architectures | sed -E 's/'"$arch"'\s*//' | sed -E 's/,/ /g')
+	variants=$(grep "^$arch" "$dir/architectures" | sed -E 's/'"$arch"'[[:space:]]*//' | sed -E 's/,/ /g')
 	echo "$variants"
 }
 
@@ -58,15 +73,146 @@ function get_supported_arches () {
 	local version
 	local variant
 	local arches
+	local lines
+	local line
 	version="$1"; shift
 	variant="$1"; shift
 
 	# Get default supported arches
-	arches=$( grep "$variant" architectures 2>/dev/null | cut -d' ' -f1 )
+	lines=$( grep "$variant" "$(dirname "$version")"/architectures 2>/dev/null | cut -d' ' -f1 )
 
 	# Get version specific supported architectures if there is specialized information
 	if [ -a "$version"/architectures ]; then
-		arches=$( grep "$variant" "$version"/architectures 2>/dev/null | cut -d' ' -f1 )
+		lines=$( grep "$variant" "$version"/architectures 2>/dev/null | cut -d' ' -f1 )
 	fi
-	echo "$arches"
+
+	while IFS='' read -r line; do
+		arches+=( "$line" )
+	done <<< "$lines"
+
+	echo "${arches[@]}"
+}
+
+# Get configuration values from the config file
+#
+# The configuration entries are simple key/value pairs which are whitespace separated.
+function get_config () {
+	local dir
+	dir=${1:-.}
+	shift
+
+	local name
+	name=$1
+	shift
+
+	local value
+	value=$(grep "^$name" "$dir/config" | sed -E 's/'"$name"'[[:space:]]*//')
+	echo "$value"
+}
+
+# Get available versions for a given path
+#
+# If full or partial versions are provided then they are processed and
+# validated. e.g. "4 chakracore" returns "4 chakracore/8" since it processed the
+# chakracore entry and found it to be a fork rather than a complete version.
+#
+# The result is a list of valid versions.
+function get_versions () {
+	local prefix
+	prefix=${1:-.}
+	shift
+
+	local versions
+	local dirs=( "$@" )
+	if [ ${#dirs[@]} -eq 0 ]; then
+		IFS=' ' read -ra dirs <<< "$(echo "${prefix%/}/"*/)"
+	fi
+
+	for dir in "${dirs[@]}"; do
+		if [ -a "$dir/config" ]; then
+			local subdirs
+			IFS=' ' read -ra subdirs <<< "$(get_versions "${dir#./}")"
+			for subdir in "${subdirs[@]}"; do
+				versions+=( "$subdir" )
+			done
+		elif [ -a "$dir/Dockerfile" ]; then
+			versions+=( "${dir#./}" )
+		fi
+	done
+
+	if [ ${#versions[@]} -gt 0 ]; then
+		echo "${versions[@]%/}"
+	fi
+}
+
+function get_fork_name () {
+	local version
+	version=$1
+	shift
+
+	IFS='/' read -ra versionparts <<< "$version"
+	if [ ${#versionparts[@]} -gt 1 ]; then
+		echo "${versionparts[0]}"
+	fi
+}
+
+function get_full_version () {
+	local version
+	version=$1
+	shift
+
+	grep -m1 'ENV NODE_VERSION ' "$version/Dockerfile" | cut -d' ' -f3
+}
+
+function get_major_minor_version () {
+	local version
+	version=$1
+	shift
+
+	local fullversion
+	fullversion=$(get_full_version "$version")
+
+	echo "$(echo "$fullversion" | cut -d'.' -f1).$(echo "$fullversion" | cut -d'.' -f2)"
+}
+
+function get_tag () {
+	local version
+	version=$1
+	shift
+
+	local versiontype
+	versiontype=${1:-full}
+	shift
+
+	local tagversion
+	if [ "$versiontype" = full ]; then
+		tagversion=$(get_full_version "$version")
+	elif [ "$versiontype" = majorminor ]; then
+		tagversion=$(get_major_minor_version "$version")
+	fi
+
+	local tagparts
+	IFS=' ' read -ra tagparts <<< "$(get_fork_name "$version") $tagversion"
+	IFS='-'; echo "${tagparts[*]}"; unset IFS
+}
+
+function sort_versions () {
+	local versions=( "$@" )
+	local sorted
+	local lines
+	local line
+	
+	IFS=$'\n'
+	lines="${versions[*]}"
+	unset IFS
+
+	while IFS='' read -r line; do
+		sorted+=( "$line" )
+	done <<< "$(echo "$lines" | grep "^[0-9]" | sort -r)"
+
+	while IFS='' read -r line; do
+		sorted+=( "$line" )
+	done <<< "$(echo "$lines" | grep -v "^[0-9]" | sort -r)"
+
+	echo "${sorted[@]}"
 }

--- a/generate-stackbrew-library.sh
+++ b/generate-stackbrew-library.sh
@@ -13,6 +13,8 @@ array_6='6 boron';
 array_8='8 carbon';
 # shellcheck disable=SC2034
 array_9='9 latest';
+# shellcheck disable=SC2034
+array_chakracore_8='chakracore-8 chakracore';
 
 cd "$(cd "${0%/*}" && pwd -P)";
 

--- a/update.sh
+++ b/update.sh
@@ -1,15 +1,14 @@
 #!/bin/bash
-set -e
+set -ue
 
 . functions.sh
 
 cd "$(cd "${0%/*}" && pwd -P)";
 
-versions=( "$@" )
+IFS=' ' read -ra versions <<< "$(get_versions . "$@")"
 if [ ${#versions[@]} -eq 0 ]; then
-	versions=( */ )
+	fatal "No valid versions found!"
 fi
-versions=( "${versions[@]%/}" )
 
 # Global variables
 # Get architecure and use this as target architecture for docker image
@@ -21,6 +20,10 @@ yarnVersion="$(curl -sSL --compressed https://yarnpkg.com/latest-version)"
 
 function update_node_version {
 
+	local baseuri=$1
+	shift
+	local version=$1
+	shift
 	local template=$1
 	shift
 	local dockerfile=$1
@@ -31,12 +34,12 @@ function update_node_version {
 		shift
 	fi
 
-	fullVersion="$(curl -sSL --compressed 'https://nodejs.org/dist' | grep '<a href="v'"$version." | sed -E 's!.*<a href="v([^"/]+)/?".*!\1!' | cut -d'.' -f2,3| sort -n | tail -1)"
+	fullVersion="$(curl -sSL --compressed "$baseuri" | grep '<a href="v'"$version." | sed -E 's!.*<a href="v([^"/]+)/?".*!\1!' | cut -d'.' -f2,3| sort -n | tail -1)"
 	(
 		cp "$template" "$dockerfile"
 		local fromprefix=
 		if [[ "$arch" != "amd64" && "$variant" != "onbuild" ]]; then
-			fromprefix="$arch\/"
+			fromprefix="$arch\\/"
 		fi
 
 		sed -E -i.bak 's/^FROM (.*)/FROM '"$fromprefix"'\1/' "$dockerfile" && rm "$dockerfile".bak
@@ -53,16 +56,23 @@ for version in "${versions[@]}"; do
 	# Skip "docs" and other non-docker directories
 	[ -f "$version/Dockerfile" ] || continue
 
-	update_node_version "Dockerfile.template" "$version/Dockerfile"
+	info "Updating version $version..."
+
+	parentpath=$(dirname "$version")
+	versionnum=$(basename "$version")
+	baseuri=$(get_config "$parentpath" "baseuri")
+
+	update_node_version "$baseuri" "$versionnum" "$parentpath/Dockerfile.template" "$version/Dockerfile"
 
 	# Get supported variants according the target architecture
 	# See details in function.sh
-	variants=$(get_variants)
+	variants=$(get_variants "$parentpath")
 
 	for variant in $variants; do
 		# Skip non-docker directories
 		[ -f "$version/$variant/Dockerfile" ] || continue
-		update_node_version "Dockerfile-$variant.template" "$version/$variant/Dockerfile" "$variant"
-
+		update_node_version "$baseuri" "$versionnum" "$parentpath/Dockerfile-$variant.template" "$version/$variant/Dockerfile" "$variant"
 	done
 done
+
+info "Done!"


### PR DESCRIPTION
This PR adds the Dockerfile for a single flavor (amd64/jessie) for node-chakracore.

I've run the `test-build.sh` script on Ubuntu 16.04 with success, but I don't think this file is currently compatible with the `update.sh` script.

/cc @aruneshchandra @digitalinfinity 