### PR TITLE
Travis improvements

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+dist: trusty
 sudo: required
 
 services:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,10 @@
 dist: trusty
 sudo: required
 
+language: node_js
+node_js:
+    - lts/*
+
 services:
     - docker
 
@@ -13,7 +17,6 @@ script:
     - if [ "true" = "${SHELLCHECK-}" ]; then shellcheck *.sh ; fi
     - if [ -n "${NODE_VERSION-}" ]; then ./test-build.sh $NODE_VERSION ; fi
     - if [ "true" = "${DOCTOCCHECK-}" ]; then
-         nvm install node &&
          npm i -g doctoc  &&
          cp README.md README.md.tmp &&
          doctoc --title='## Table of Contents' --github README.md &&

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,11 @@ sudo: required
 services:
     - docker
 
+addons:
+  apt:
+    packages:
+      - docker-ce
+
 script:
     - if [ "true" = "${SHELLCHECK-}" ]; then shellcheck *.sh ; fi
     - if [ -n "${NODE_VERSION-}" ]; then ./test-build.sh $NODE_VERSION ; fi


### PR DESCRIPTION
This adds a bunch of minor improvements to the travis-ci config:

- Install and use the latest version of docker (via the docker-ce package). 
- Explicitly set the distro to Trusty.
- Set the language to node_js and with the latest LTS version installed. Prior to this the image would default to the ruby language which always seemed weird to me. As a bonus this means we don't need to install node for the doc check