### PR TITLE
Fix "bash: yarn: command not found" error

### DIFF
--- a/Dockerfile-alpine.template
+++ b/Dockerfile-alpine.template
@@ -58,7 +58,6 @@ RUN apk add --no-cache --virtual .build-deps-yarn curl gnupg tar \
   && curl -fSLO --compressed "https://yarnpkg.com/downloads/$YARN_VERSION/yarn-v$YARN_VERSION.tar.gz" \
   && curl -fSLO --compressed "https://yarnpkg.com/downloads/$YARN_VERSION/yarn-v$YARN_VERSION.tar.gz.asc" \
   && gpg --batch --verify yarn-v$YARN_VERSION.tar.gz.asc yarn-v$YARN_VERSION.tar.gz \
-  && mkdir -p /opt/yarn \
   && tar -xzf yarn-v$YARN_VERSION.tar.gz -C /opt/ \
   && ln -s /opt/yarn-v$YARN_VERSION /opt/yarn \
   && ln -s /opt/yarn/bin/yarn /usr/local/bin/yarn \


### PR DESCRIPTION
Creating the folder and then trying to transform it in a link is not a solution to other issues.