### PR TITLE
Remove manual ShellCheck installation on Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,12 +36,6 @@ jobs:
       env:
         - TEST: Shell Check
       script: shellcheck *.sh
-      addons:
-        apt:
-          sources:
-            - debian-sid
-          packages:
-            - shellcheck
 
     - stage: Deploy
       script: ./generate-stackbrew-pr.sh


### PR DESCRIPTION
Travis CI started to provide ShellCheck directly for a while, we can save both time and resources to manually install it now!