### PR TITLE
fix node 10 tags

### DIFF
--- a/generate-stackbrew-library.sh
+++ b/generate-stackbrew-library.sh
@@ -12,9 +12,13 @@ array_6='6 boron';
 # shellcheck disable=SC2034
 array_8='8 carbon';
 # shellcheck disable=SC2034
-array_9='9 latest';
+array_9='9';
 # shellcheck disable=SC2034
-array_chakracore_8='chakracore-8 chakracore';
+array_10='10 latest';
+# shellcheck disable=SC2034
+array_chakracore_8='chakracore-8';
+# shellcheck disable=SC2034
+array_chakracore_10='chakracore-10 chakracore';
 
 cd "$(cd "${0%/*}" && pwd -P)";
 


### PR DESCRIPTION
Gives the following stackbrew diff:

```diff
@@ -1,34 +1,34 @@
-# this file is generated via https://github.com/nodejs/docker-node/blob/e839bbbb50d4969cfe68f95136354b0a6221ca7b/generate-stackbrew-library.sh
+# this file is generated via https://github.com/nodejs/docker-node/blob/a17e3f48d012804a98e961691d836bc721728e8e/generate-stackbrew-library.sh
 
 Maintainers: The Node.js Docker Team <https://github.com/nodejs/docker-node> (@nodejs)
 GitRepo: https://github.com/nodejs/docker-node.git
 
-Tags: 9.11.1, 9.11, 9, latest
+Tags: 9.11.1, 9.11, 9
 Architectures: amd64, ppc64le, s390x, arm64v8, arm32v7, i386
 GitCommit: 9023f588717d236a92d91a8483ff0582484c22d1
 Directory: 9
 
-Tags: 9.11.1-alpine, 9.11-alpine, 9-alpine, alpine
+Tags: 9.11.1-alpine, 9.11-alpine, 9-alpine
 Architectures: amd64, ppc64le, s390x, arm64v8, arm32v6, i386
 GitCommit: 9023f588717d236a92d91a8483ff0582484c22d1
 Directory: 9/alpine
 
-Tags: 9.11.1-onbuild, 9.11-onbuild, 9-onbuild, onbuild
+Tags: 9.11.1-onbuild, 9.11-onbuild, 9-onbuild
 Architectures: amd64, ppc64le, s390x, arm64v8, arm32v7, i386
 GitCommit: 9023f588717d236a92d91a8483ff0582484c22d1
 Directory: 9/onbuild
 
-Tags: 9.11.1-slim, 9.11-slim, 9-slim, slim
+Tags: 9.11.1-slim, 9.11-slim, 9-slim
 Architectures: amd64, ppc64le, s390x, arm64v8, arm32v7, i386
 GitCommit: 9023f588717d236a92d91a8483ff0582484c22d1
 Directory: 9/slim
 
-Tags: 9.11.1-stretch, 9.11-stretch, 9-stretch, stretch
+Tags: 9.11.1-stretch, 9.11-stretch, 9-stretch
 Architectures: amd64, ppc64le, s390x, arm64v8, arm32v7, i386
 GitCommit: 9023f588717d236a92d91a8483ff0582484c22d1
 Directory: 9/stretch
 
-Tags: 9.11.1-wheezy, 9.11-wheezy, 9-wheezy, wheezy
+Tags: 9.11.1-wheezy, 9.11-wheezy, 9-wheezy
 Architectures: amd64
 GitCommit: 9023f588717d236a92d91a8483ff0582484c22d1
 Directory: 9/wheezy
@@ -123,37 +123,37 @@ Architectures: amd64
 GitCommit: f56c21260109ad432ec3ea5ba96dbd3b9daa4ea7
 Directory: 4/wheezy
 
-Tags: 10.0.0, 10.0
+Tags: 10.0.0, 10.0, 10, latest
 Architectures: amd64, ppc64le, s390x, arm64v8, arm32v7, i386
 GitCommit: 80814e984e9faa5e9195f9a61632e1898f6633d9
 Directory: 10
 
-Tags: 10.0.0-alpine, 10.0-alpine
+Tags: 10.0.0-alpine, 10.0-alpine, 10-alpine, alpine
 Architectures: amd64, ppc64le, s390x, arm64v8, arm32v6, i386
 GitCommit: 80814e984e9faa5e9195f9a61632e1898f6633d9
 Directory: 10/alpine
 
-Tags: 10.0.0-slim, 10.0-slim
+Tags: 10.0.0-slim, 10.0-slim, 10-slim, slim
 Architectures: amd64, ppc64le, s390x, arm64v8, arm32v7, i386
 GitCommit: 80814e984e9faa5e9195f9a61632e1898f6633d9
 Directory: 10/slim
 
-Tags: 10.0.0-stretch, 10.0-stretch
+Tags: 10.0.0-stretch, 10.0-stretch, 10-stretch, stretch
 Architectures: amd64, ppc64le, s390x, arm64v8, arm32v7, i386
 GitCommit: 80814e984e9faa5e9195f9a61632e1898f6633d9
 Directory: 10/stretch
 
-Tags: 10.0.0-wheezy, 10.0-wheezy
+Tags: 10.0.0-wheezy, 10.0-wheezy, 10-wheezy, wheezy
 Architectures: amd64
 GitCommit: 80814e984e9faa5e9195f9a61632e1898f6633d9
 Directory: 10/wheezy
 
-Tags: chakracore-8.11.1, chakracore-8.11, chakracore-8, chakracore
+Tags: chakracore-8.11.1, chakracore-8.11, chakracore-8
 Architectures: amd64
 GitCommit: eca9e8f34ca78bdba691e1d5ead82840e2673705
 Directory: chakracore/8
 
-Tags: chakracore-10.0.0, chakracore-10.0
+Tags: chakracore-10.0.0, chakracore-10.0, chakracore-10, chakracore
 Architectures: amd64
 GitCommit: f713f15abe3ff05635326ba9716b7755c9d5f1aa
 Directory: chakracore/10
```