### PR TITLE
Use npm instead to install yarn

### DIFF
--- a/docs/BestPractices.md
+++ b/docs/BestPractices.md
@@ -45,6 +45,8 @@ RUN curl -fSLO --compressed "https://yarnpkg.com/downloads/$YARN_VERSION/yarn-v$
     && rm yarn-v$YARN_VERSION.tar.gz
 ```
 
+or instead use npm, simply include `RUN npm i -g yarn`
+
 ## Handling Kernel Signals
 
 Node.js was not designed to run as PID 1 which leads to unexpected behaviour when running inside of Docker. For example, a Node.js process running as PID 1 will not respond to `SIGTERM` (`CTRL-C`) and similar signals. As of Docker 1.13, you can use the `--init` flag to wrap your Node.js process with a [lightweight init system](https://github.com/krallin/tini) that properly handles running as PID 1.


### PR DESCRIPTION
Seems a lot less verbose to just use npm to upgrade to yarn.