### PR TITLE
Rebase {8,9}/alpine from alpine:3.7

### DIFF
--- a/8/alpine/Dockerfile
+++ b/8/alpine/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.6
+FROM alpine:3.7
 
 ENV NODE_VERSION 8.11.1
 

--- a/9/alpine/Dockerfile
+++ b/9/alpine/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.6
+FROM alpine:3.7
 
 ENV NODE_VERSION 9.11.1
 


### PR DESCRIPTION
node 8.x is the LTS version, but Alpine 3.6 is getting
long in the tooth. For the image consumers who want to install
newer versions of other software packages, it's better to switch to the
latest stable Alpine version.