### PR TITLE
Fixed the stackbrew PR causing invalid stackbrew library entries

### DIFF
--- a/generate-stackbrew-pr.sh
+++ b/generate-stackbrew-pr.sh
@@ -28,7 +28,7 @@ REPO_NAME="official-images"
 ORIGIN_SLUG="$GITHUB_USERNAME/$REPO_NAME"
 UPSTREAM_SLUG="docker-library/$REPO_NAME"
 DOCKER_SLUG="nodejs/docker-node"
-gitpath="$REPO_NAME"
+gitpath="../$REPO_NAME"
 
 function updated() {
 	local versions


### PR DESCRIPTION
Clones the official-images repo in the parent repo instead of the current one to avoid the clone folder being picked up by the stackbrew-library script.