### PR TITLE
Use LTS version of Node.js for doctoc

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,6 +37,8 @@ jobs:
       env:
         - TEST: Doc Toc Check
       language: node_js
+      node_js:
+        - lts/*
       install: npm i -g doctoc
       script:
         - cp README.md README.md.tmp &&
@@ -166,3 +168,4 @@ jobs:
       env:
         - NODE_VERSION: "chakracore/8"
         - VARIANT: "default"
+

--- a/.travis.yml
+++ b/.travis.yml
@@ -168,4 +168,3 @@ jobs:
       env:
         - NODE_VERSION: "chakracore/8"
         - VARIANT: "default"
-

--- a/travis.yml.template
+++ b/travis.yml.template
@@ -35,6 +35,8 @@ jobs:
       env:
         - TEST: Doc Toc Check
       language: node_js
+      node_js:
+        - lts/*
       install: npm i -g doctoc
       script:
         - cp README.md README.md.tmp &&


### PR DESCRIPTION
nvm defaults to v0.10