### PR TITLE
for node 8 lts, update to latest yarn 1.7.0 stable

### DIFF
--- a/8/alpine/Dockerfile
+++ b/8/alpine/Dockerfile
@@ -45,7 +45,7 @@ RUN addgroup -g 1000 node \
     && rm -Rf "node-v$NODE_VERSION" \
     && rm "node-v$NODE_VERSION.tar.xz" SHASUMS256.txt.asc SHASUMS256.txt
 
-ENV YARN_VERSION 1.6.0
+ENV YARN_VERSION 1.7.0
 
 RUN apk add --no-cache --virtual .build-deps-yarn curl gnupg tar \
   && for key in \

--- a/8/jessie/Dockerfile
+++ b/8/jessie/Dockerfile
@@ -40,7 +40,7 @@ RUN ARCH= && dpkgArch="$(dpkg --print-architecture)" \
   && rm "node-v$NODE_VERSION-linux-$ARCH.tar.xz" SHASUMS256.txt.asc SHASUMS256.txt \
   && ln -s /usr/local/bin/node /usr/local/bin/nodejs
 
-ENV YARN_VERSION 1.6.0
+ENV YARN_VERSION 1.7.0
 
 RUN set -ex \
   && for key in \

--- a/8/slim/Dockerfile
+++ b/8/slim/Dockerfile
@@ -45,7 +45,7 @@ RUN buildDeps='xz-utils' \
     && apt-get purge -y --auto-remove $buildDeps \
     && ln -s /usr/local/bin/node /usr/local/bin/nodejs
 
-ENV YARN_VERSION 1.6.0
+ENV YARN_VERSION 1.7.0
 
 RUN set -ex \
   && for key in \

--- a/8/stretch/Dockerfile
+++ b/8/stretch/Dockerfile
@@ -40,7 +40,7 @@ RUN ARCH= && dpkgArch="$(dpkg --print-architecture)" \
   && rm "node-v$NODE_VERSION-linux-$ARCH.tar.xz" SHASUMS256.txt.asc SHASUMS256.txt \
   && ln -s /usr/local/bin/node /usr/local/bin/nodejs
 
-ENV YARN_VERSION 1.6.0
+ENV YARN_VERSION 1.7.0
 
 RUN set -ex \
   && for key in \


### PR DESCRIPTION
Yarn 1.7.0 stable was released https://github.com/yarnpkg/yarn/releases/tag/v1.7.0

This PR updates the node 8 LTS images to have yarn 1.7.0 instead of 1.6.0.

cc @ilikebits @corbin-coleman @jose-bigio

Signed-off-by: Andrew Hsu <andrewhsu@docker.com>