### PR TITLE
Adjust $TRAVIS_COMMIT_RANGE for git

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,7 @@ addons:
       - docker-ce
 
 before_install:
+  - export TRAVIS_COMMIT_RANGE="${TRAVIS_COMMIT_RANGE/.../..}"
   - source functions.sh && images_updated $TRAVIS_COMMIT_RANGE || tests_updated $TRAVIS_COMMIT_RANGE || travis_terminate
 
 script: ./test-build.sh $NODE_VERSION $VARIANT


### PR DESCRIPTION
Git uses `..` but Travis CI uses `...`, cc #747