### PR TITLE
Fix image tests

### DIFF
--- a/test-build.sh
+++ b/test-build.sh
@@ -2,7 +2,7 @@
 #
 # Run a test build for all images.
 
-set -uo pipefail
+set -euo pipefail
 
 . functions.sh
 

--- a/test-image.sh
+++ b/test-image.sh
@@ -7,12 +7,12 @@ echo "Test for node succeeded."
 
 if ! npm --version >/dev/null; then
   echo "Test for npm failed!"
-  exit 2
+  exit 1
 fi
 echo "Test for npm succeeded."
 
 if ! yarn --version >/dev/null; then
   echo "Test of yarn failed!"
-  exit 3
+  exit 1
 fi
 echo "Test for yarn succeeded."


### PR DESCRIPTION
This closes #768

I did some local testing by breaking one of the images (e.g., remove the yarn symlinks) and ran `test-build.sh` and it seems to work. I can do follow up commits that deliberately break the yarn, npm or node tests to verify that things work as expected in travis-ci. If all looks good I can rebase and drop those commits.