### PR TITLE
Use default Docker version on Travis CI instead of manual install

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,10 +7,6 @@ language: generic
 
 services:
     - docker
-addons:
-  apt:
-    packages:
-      - docker-ce
 
 script: ./test-build.sh $NODE_VERSION $VARIANT
 

--- a/travis.yml.template
+++ b/travis.yml.template
@@ -5,10 +5,6 @@ language: generic
 
 services:
     - docker
-addons:
-  apt:
-    packages:
-      - docker-ce
 
 script: ./test-build.sh $NODE_VERSION $VARIANT
 


### PR DESCRIPTION
We don't need the latest Docker, instead, let's make the CI faster and less chance to fail.