### PR TITLE
Bump Alpine base image version to v3.8

### DIFF
--- a/config
+++ b/config
@@ -1,3 +1,3 @@
 baseuri     https://nodejs.org/dist
 default_variant jessie
-alpine_version  3.7
+alpine_version  3.8


### PR DESCRIPTION
Alpine Linux v3.8 Docker image released.