### PR TITLE
upgrade Alpine Linux images to use version 3.8

### DIFF
--- a/10/alpine/Dockerfile
+++ b/10/alpine/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.7
+FROM alpine:3.8
 
 ENV NODE_VERSION 10.6.0
 

--- a/6/alpine/Dockerfile
+++ b/6/alpine/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.4
+FROM alpine:3.8
 
 ENV NODE_VERSION 6.14.3
 

--- a/8/alpine/Dockerfile
+++ b/8/alpine/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.6
+FROM alpine:3.8
 
 ENV NODE_VERSION 8.11.3
 


### PR DESCRIPTION
This patch set upgrades the Node 6, 8, and 10 Docker images to be based off of Alpine 3.8. The Node 6 image is based off of Alpine 3.4 and that release is no longer supported as of 2018-05-01 according to https://wiki.alpinelinux.org/wiki/Alpine_Linux:Releases.

If this patch set cannot be merged in, then I suggest as an alternative creating Alpine images with the Alpine version number (like node:6-alpine3.8)