### PR TITLE
Update shfmt Docker image on Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -56,7 +56,7 @@ jobs:
       env:
         - TEST: shfmt check
       script:
-        - docker run -it --rm -v "$(pwd)":/sh -w /sh jamesmstone/shfmt@sha256:4eff05b54e87c11e8214848de3e5f4bb47a4241b99ac5c6554db5cc164015810 -i 2 -l -w -ci .
+        - docker run -it --rm -v "$(pwd)":/sh -w /sh peterdavehello/shfmt:2.5.0 -i 2 -l -w -ci .
         - git diff --color
         - git diff --stat=220 --color --exit-code
 

--- a/travis.yml.template
+++ b/travis.yml.template
@@ -54,7 +54,7 @@ jobs:
       env:
         - TEST: shfmt check
       script:
-        - docker run -it --rm -v "$(pwd)":/sh -w /sh jamesmstone/shfmt@sha256:4eff05b54e87c11e8214848de3e5f4bb47a4241b99ac5c6554db5cc164015810 -i 2 -l -w -ci .
+        - docker run -it --rm -v "$(pwd)":/sh -w /sh peterdavehello/shfmt:2.5.0 -i 2 -l -w -ci .
         - git diff --color
         - git diff --stat=220 --color --exit-code
 


### PR DESCRIPTION
Origin one is out of our control, and currently dated(v2.4.0).

After moved to v2.5.0, I'd like to enable `-sr` parameter to keep a space follow redirect operator.
