### PR TITLE
Update node.js v10 images

### DIFF
--- a/10/alpine/Dockerfile
+++ b/10/alpine/Dockerfile
@@ -1,6 +1,6 @@
-FROM alpine:3.7
+FROM alpine:3.8
 
-ENV NODE_VERSION 10.6.0
+ENV NODE_VERSION 10.7.0
 
 RUN addgroup -g 1000 node \
     && adduser -u 1000 -G node -s /bin/sh -D node \

--- a/10/jessie/Dockerfile
+++ b/10/jessie/Dockerfile
@@ -21,7 +21,7 @@ RUN set -ex \
     gpg --keyserver hkp://pgp.mit.edu:80 --recv-keys "$key" ; \
   done
 
-ENV NODE_VERSION 10.6.0
+ENV NODE_VERSION 10.7.0
 
 RUN ARCH= && dpkgArch="$(dpkg --print-architecture)" \
   && case "${dpkgArch##*-}" in \

--- a/10/slim/Dockerfile
+++ b/10/slim/Dockerfile
@@ -21,7 +21,7 @@ RUN set -ex \
     gpg --keyserver hkp://pgp.mit.edu:80 --recv-keys "$key" ; \
   done
 
-ENV NODE_VERSION 10.6.0
+ENV NODE_VERSION 10.7.0
 
 RUN buildDeps='xz-utils' \
     && ARCH= && dpkgArch="$(dpkg --print-architecture)" \

--- a/10/stretch/Dockerfile
+++ b/10/stretch/Dockerfile
@@ -21,7 +21,7 @@ RUN set -ex \
     gpg --keyserver hkp://pgp.mit.edu:80 --recv-keys "$key" ; \
   done
 
-ENV NODE_VERSION 10.6.0
+ENV NODE_VERSION 10.7.0
 
 RUN ARCH= && dpkgArch="$(dpkg --print-architecture)" \
   && case "${dpkgArch##*-}" in \


### PR DESCRIPTION
- Update node.js v10.x to v10.7.0
- For Alpine based image, update Alpine from v3.7 to v3.8

Ref:
- https://github.com/nodejs/node/releases/tag/v10.7.0
- https://github.com/nodejs/node/blob/master/doc/changelogs/CHANGELOG_V10.md#10.7.0
