### PR TITLE
Change baseimage for node:slim to stretch release

### DIFF
--- a/Dockerfile-slim.template
+++ b/Dockerfile-slim.template
@@ -1,10 +1,12 @@
-FROM debian:jessie-slim
+FROM debian:stretch-slim
 
 RUN groupadd --gid 1000 node \
   && useradd --uid 1000 --gid node --shell /bin/bash --create-home node
 
 # gpg keys listed at https://github.com/nodejs/node#release-team
 RUN set -ex \
+  && apt-get update && apt-get install -y gpg dirmngr --no-install-recommends \
+  && rm -rf /var/lib/apt/lists/* \
   && for key in \
     "${NODE_KEYS[@]}"
   ; do \


### PR DESCRIPTION
Fixes: https://github.com/nodejs/docker-node/issues/821