### PR TITLE
Remove i386 support from binary-release-based 10 variants

### DIFF
--- a/8/architectures
+++ b/8/architectures
@@ -3,6 +3,6 @@ arm32v6  alpine
 arm32v7  jessie,onbuild,slim,stretch
 arm64v8  jessie,alpine,onbuild,slim,stretch
 amd64    jessie,alpine,onbuild,slim,stretch
-i386     alpine
+i386     jessie,alpine,onbuild,slim,stretch
 ppc64le  jessie,alpine,onbuild,slim,stretch
 s390x    jessie,alpine,onbuild,slim,stretch


### PR DESCRIPTION
This copies the current `architectures` file into `8/` and then removes `i386` from all but Alpine (where it's built from source).

The justification here is that https://nodejs.org/dist/v10.6.0/node-v10.6.0-linux-x86.tar.xz is a 404 (appears 32bit builds are no longer generated).