### PR TITLE
[DNM] Add windowsservercore with MSI installers

### DIFF
--- a/10/windowsservercore/Dockerfile
+++ b/10/windowsservercore/Dockerfile
@@ -1,0 +1,29 @@
+FROM microsoft/windowsservercore:1803
+
+SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
+
+ENV NODE_VERSION 10.7.0
+
+RUN [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12 ; \
+    Invoke-WebRequest $('https://nodejs.org/dist/v{0}/node-v{0}-x64.msi' -f $env:NODE_VERSION) -OutFile "$env:Temp\node.msi" -UseBasicParsing ; \
+    $sig = Get-AuthenticodeSignature -filepath "$env:Temp\node.msi" ; \
+    if ($sig.Status -ne 'Valid') { Write-Error 'Authenticode signature is not valid' } ; \
+    if (@( \
+      'db2f847aed75d4586000c83cad0607fdc12aa2bd' \
+      ) -notcontains $sig.SignerCertificate.Thumbprint) { Write-Error 'Unknown signer certificate' } ; \
+    Start-Process msiexec.exe -ArgumentList '/i', "$env:Temp\node.msi", '/quiet', '/norestart' -NoNewWindow -Wait; \
+    Remove-Item -Path "$env:Temp\node.msi"
+
+ENV YARN_VERSION 1.7.0
+
+RUN [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12 ; \
+    Invoke-WebRequest $('https://yarnpkg.com/downloads/{0}/yarn-{0}.msi' -f $env:YARN_VERSION) -OutFile "$env:Temp\yarn.msi" -UseBasicParsing ; \
+    $sig = Get-AuthenticodeSignature -filepath "$env:Temp\yarn.msi" ; \
+    if ($sig.Status -ne 'Valid') { Write-Error 'Authenticode signature is not valid' } ; \
+    if (@( \
+      'AF764E1EA56C762617BDC757C8B0F3780A0CF5F9' \
+      ) -notcontains $sig.SignerCertificate.Thumbprint) { Write-Error 'Unknown signer certificate' } ; \
+    Start-Process msiexec.exe -ArgumentList '/i', "$env:Temp\yarn.msi", '/quiet', '/norestart' -NoNewWindow -Wait; \
+    Remove-Item -Path "$env:Temp\yarn.msi"
+
+CMD [ "node.exe" ]

--- a/6/windowsservercore/Dockerfile
+++ b/6/windowsservercore/Dockerfile
@@ -1,0 +1,29 @@
+FROM microsoft/windowsservercore:1803
+
+SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
+
+ENV NODE_VERSION 6.14.3
+
+RUN [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12 ; \
+    Invoke-WebRequest $('https://nodejs.org/dist/v{0}/node-v{0}-x64.msi' -f $env:NODE_VERSION) -OutFile "$env:Temp\node.msi" -UseBasicParsing ; \
+    $sig = Get-AuthenticodeSignature -filepath "$env:Temp\node.msi" ; \
+    if ($sig.Status -ne 'Valid') { Write-Error 'Authenticode signature is not valid' } ; \
+    if (@( \
+      'db2f847aed75d4586000c83cad0607fdc12aa2bd' \
+      ) -notcontains $sig.SignerCertificate.Thumbprint) { Write-Error 'Unknown signer certificate' } ; \
+    Start-Process msiexec.exe -ArgumentList '/i', "$env:Temp\node.msi", '/quiet', '/norestart' -NoNewWindow -Wait; \
+    Remove-Item -Path "$env:Temp\node.msi"
+
+ENV YARN_VERSION 1.6.0
+
+RUN [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12 ; \
+    Invoke-WebRequest $('https://yarnpkg.com/downloads/{0}/yarn-{0}.msi' -f $env:YARN_VERSION) -OutFile "$env:Temp\yarn.msi" -UseBasicParsing ; \
+    $sig = Get-AuthenticodeSignature -filepath "$env:Temp\yarn.msi" ; \
+    if ($sig.Status -ne 'Valid') { Write-Error 'Authenticode signature is not valid' } ; \
+    if (@( \
+      'AF764E1EA56C762617BDC757C8B0F3780A0CF5F9' \
+      ) -notcontains $sig.SignerCertificate.Thumbprint) { Write-Error 'Unknown signer certificate' } ; \
+    Start-Process msiexec.exe -ArgumentList '/i', "$env:Temp\yarn.msi", '/quiet', '/norestart' -NoNewWindow -Wait; \
+    Remove-Item -Path "$env:Temp\yarn.msi"
+
+CMD [ "node.exe" ]

--- a/8/windowsservercore/Dockerfile
+++ b/8/windowsservercore/Dockerfile
@@ -1,0 +1,29 @@
+FROM microsoft/windowsservercore:1803
+
+SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
+
+ENV NODE_VERSION 8.11.3
+
+RUN [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12 ; \
+    Invoke-WebRequest $('https://nodejs.org/dist/v{0}/node-v{0}-x64.msi' -f $env:NODE_VERSION) -OutFile "$env:Temp\node.msi" -UseBasicParsing ; \
+    $sig = Get-AuthenticodeSignature -filepath "$env:Temp\node.msi" ; \
+    if ($sig.Status -ne 'Valid') { Write-Error 'Authenticode signature is not valid' } ; \
+    if (@( \
+      'db2f847aed75d4586000c83cad0607fdc12aa2bd' \
+      ) -notcontains $sig.SignerCertificate.Thumbprint) { Write-Error 'Unknown signer certificate' } ; \
+    Start-Process msiexec.exe -ArgumentList '/i', "$env:Temp\node.msi", '/quiet', '/norestart' -NoNewWindow -Wait; \
+    Remove-Item -Path "$env:Temp\node.msi"
+
+ENV YARN_VERSION 1.6.0
+
+RUN [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12 ; \
+    Invoke-WebRequest $('https://yarnpkg.com/downloads/{0}/yarn-{0}.msi' -f $env:YARN_VERSION) -OutFile "$env:Temp\yarn.msi" -UseBasicParsing ; \
+    $sig = Get-AuthenticodeSignature -filepath "$env:Temp\yarn.msi" ; \
+    if ($sig.Status -ne 'Valid') { Write-Error 'Authenticode signature is not valid' } ; \
+    if (@( \
+      'AF764E1EA56C762617BDC757C8B0F3780A0CF5F9' \
+      ) -notcontains $sig.SignerCertificate.Thumbprint) { Write-Error 'Unknown signer certificate' } ; \
+    Start-Process msiexec.exe -ArgumentList '/i', "$env:Temp\yarn.msi", '/quiet', '/norestart' -NoNewWindow -Wait; \
+    Remove-Item -Path "$env:Temp\yarn.msi"
+
+CMD [ "node.exe" ]

--- a/Dockerfile-windowsservercore.template
+++ b/Dockerfile-windowsservercore.template
@@ -1,0 +1,29 @@
+FROM microsoft/windowsservercore:1803
+
+SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
+
+ENV NODE_VERSION 0.0.0
+
+RUN [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12 ; \
+    Invoke-WebRequest $('https://nodejs.org/dist/v{0}/node-v{0}-x64.msi' -f $env:NODE_VERSION) -OutFile "$env:Temp\node.msi" -UseBasicParsing ; \
+    $sig = Get-AuthenticodeSignature -filepath "$env:Temp\node.msi" ; \
+    if ($sig.Status -ne 'Valid') { Write-Error 'Authenticode signature is not valid' } ; \
+    if (@( \
+      'db2f847aed75d4586000c83cad0607fdc12aa2bd' \
+      ) -notcontains $sig.SignerCertificate.Thumbprint) { Write-Error 'Unknown signer certificate' } ; \
+    Start-Process msiexec.exe -ArgumentList '/i', "$env:Temp\node.msi", '/quiet', '/norestart' -NoNewWindow -Wait; \
+    Remove-Item -Path "$env:Temp\node.msi"
+
+ENV YARN_VERSION 0.0.0
+
+RUN [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12 ; \
+    Invoke-WebRequest $('https://yarnpkg.com/downloads/{0}/yarn-{0}.msi' -f $env:YARN_VERSION) -OutFile "$env:Temp\yarn.msi" -UseBasicParsing ; \
+    $sig = Get-AuthenticodeSignature -filepath "$env:Temp\yarn.msi" ; \
+    if ($sig.Status -ne 'Valid') { Write-Error 'Authenticode signature is not valid' } ; \
+    if (@( \
+      'AF764E1EA56C762617BDC757C8B0F3780A0CF5F9' \
+      ) -notcontains $sig.SignerCertificate.Thumbprint) { Write-Error 'Unknown signer certificate' } ; \
+    Start-Process msiexec.exe -ArgumentList '/i', "$env:Temp\yarn.msi", '/quiet', '/norestart' -NoNewWindow -Wait; \
+    Remove-Item -Path "$env:Temp\yarn.msi"
+
+CMD [ "node.exe" ]

--- a/architectures
+++ b/architectures
@@ -6,3 +6,4 @@ amd64    jessie,alpine,onbuild,slim,stretch
 i386     jessie,alpine,onbuild,slim,stretch
 ppc64le  jessie,alpine,onbuild,slim,stretch
 s390x    jessie,alpine,onbuild,slim,stretch
+windows-amd64 windowsservercore


### PR DESCRIPTION
This doesn't replace the other Windows PRs like  #720, just showing an alternate using the MSI installers.

EX: 
1. `docker build .\8\windowsservercore\ -t nodejs:windowsservercore-8`
2. `docker run --rm -it nodejs:windowsservercore-8 powershell`
```
Windows PowerShell
Copyright (C) Microsoft Corporation. All rights reserved.

PS C:\> yarn --version
1.6.0
PS C:\> node --verson
C:\Program Files\nodejs\node.exe: bad option: --verson
PS C:\> node --version
v8.11.3
PS C:\> npm --version
5.6.0
PS C:\> whoami
user manager\containeradministrator
```

Pros:
- The GPG part isn't needed
- The MSIs setup perf counters and the Path automagially

Cons:
- This method won't work for nanoserver. I've opened up https://github.com/nodejs/build/issues/1413 to see if an APPX package can be built to support that.

/cc @LaurentGoderre @StefanScherer 