### PR TITLE
[WIP] Temporarily allow markdown-link-check fails on Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,10 @@ stages:
     if: branch = master AND type IN (push)
 
 jobs:
+  allow_failures:
+    script:
+      - find . -name "*.md" -exec markdown-link-check {} \;
+
   include:
     - stage: Test
       env:

--- a/travis.yml.template
+++ b/travis.yml.template
@@ -15,6 +15,10 @@ stages:
     if: branch = master AND type IN (push)
 
 jobs:
+  allow_failures:
+    script:
+      - find . -name "*.md" -exec markdown-link-check {} \;
+
   include:
     - stage: Test
       env:


### PR DESCRIPTION
This task strangely got no response on Travis CI in recent few builds, which caused the CI build failed, so use allow_failure to tolerance it.