### PR TITLE
Use `xargs` instead of `find -exec` for tests to return exit status

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,7 +29,7 @@ jobs:
       install:
         - npm i -g markdown-link-check
       script:
-        - find . -name "*.md" -exec markdown-link-check {} \;
+        - find . -name "*.md" | xargs -n 1 markdown-link-check
 
     - stage: Test
       env:

--- a/travis.yml.template
+++ b/travis.yml.template
@@ -27,7 +27,7 @@ jobs:
       install:
         - npm i -g markdown-link-check
       script:
-        - find . -name "*.md" -exec markdown-link-check {} \;
+        - find . -name "*.md" | xargs -n 1 markdown-link-check
 
     - stage: Test
       env:


### PR DESCRIPTION
`find -exec` will not return the exit status of the callee program but `xargs` will, we need the second one to fail the CI when something going wrong.