### PR TITLE
Remove "jessie" from unsupported architectures

### DIFF
--- a/6/architectures
+++ b/6/architectures
@@ -1,7 +1,7 @@
 bashbrew-arch   variants
 arm32v7  jessie,onbuild,slim,stretch
-arm64v8  jessie,onbuild,slim,stretch
+arm64v8  onbuild,slim,stretch
 amd64    jessie,alpine,onbuild,slim,stretch
 i386     jessie,onbuild,slim,stretch
-ppc64le  jessie,onbuild,slim,stretch
-s390x    jessie,onbuild,slim,stretch
+ppc64le  onbuild,slim,stretch
+s390x    onbuild,slim,stretch

--- a/8/architectures
+++ b/8/architectures
@@ -1,8 +1,8 @@
 bashbrew-arch   variants
 arm32v6  alpine
 arm32v7  jessie,onbuild,slim,stretch
-arm64v8  jessie,alpine,onbuild,slim,stretch
+arm64v8  alpine,onbuild,slim,stretch
 amd64    jessie,alpine,onbuild,slim,stretch
 i386     jessie,alpine,onbuild,slim,stretch
-ppc64le  jessie,alpine,onbuild,slim,stretch
-s390x    jessie,alpine,onbuild,slim,stretch
+ppc64le  alpine,onbuild,slim,stretch
+s390x    alpine,onbuild,slim,stretch

--- a/architectures
+++ b/architectures
@@ -1,8 +1,8 @@
 bashbrew-arch   variants
 arm32v6  alpine
 arm32v7  jessie,onbuild,slim,stretch
-arm64v8  jessie,alpine,onbuild,slim,stretch
+arm64v8  alpine,onbuild,slim,stretch
 amd64    jessie,alpine,onbuild,slim,stretch
 i386     alpine
-ppc64le  jessie,alpine,onbuild,slim,stretch
-s390x    jessie,alpine,onbuild,slim,stretch
+ppc64le  alpine,onbuild,slim,stretch
+s390x    alpine,onbuild,slim,stretch


### PR DESCRIPTION
See https://wiki.debian.org/LTS for the list of supported "Debian Jessie" architectures (currently "i386, amd64, armel and armhf").

IMO, these `architectures` files appear to be very hard to keep current and accurate -- it took me some time to figure out whether this change was actually accurate given that these files are the _result_ of combining two bits of information.  On the one hand, you've got the list of architectures supported by Node.js (either in the binary releases in the case of Debian-based variants or for building from source in the case of Alpine-based variants) and on the other hand you've got the list of supported architectures for the base distribution each variant is building from.  Once you have those two bits of information, calculating the intersection of them is reasonably trivial (which intersection is all this file records).  Collecting and correlating those bits of information is certainly possible to do in an automated fashion (even arguably easy), but is pretty annoying to do by hand especially when multiple versions share the same definitions file.  Thus, I'd really recommend splitting this out and calculating the intersection programmatically instead, but IANTM so this is simply an outsider observation.

If you're looking for examples of doing this differently, there's some bits that have been extremely effective in keeping the maintenance burden of maintaining said lists low (due to only storing the mappings between different architecture names/strings and leaving the scraping/calculation to scripts, which is what they're good at), see https://github.com/docker-library/golang, https://github.com/docker-library/julia, https://github.com/docker-library/pypy (I'm sure we have others, but those are three that come to mind immediately).  An approach like that would also obviate the need for PRs like https://github.com/nodejs/docker-node/pull/823 (which has sat unresolved now since at least Jul 19, not to mention how long it might have been an active issue before I noticed it and filed the PR) since the correlation information would've automatically removed the impossible-to-build `i386` from the list as soon as it became impossible to satisfy the combination of Debian/Alpine support + Node.js released binaries support.  For example, `pypy` and `julia` both commonly will remove architecture support from release to release, but the mechanisms in those repositories make it such that we don't have any action on our part to compensate for those additions/removals (they happen automatically -- we simply maintain string mapping tables to convert between the different ways architecture is specified in different projects).