### PR TITLE
For 10.x, upgrade yarn to v1.10.1

### DIFF
--- a/10/alpine/Dockerfile
+++ b/10/alpine/Dockerfile
@@ -46,7 +46,7 @@ RUN addgroup -g 1000 node \
     && rm -Rf "node-v$NODE_VERSION" \
     && rm "node-v$NODE_VERSION.tar.xz" SHASUMS256.txt.asc SHASUMS256.txt
 
-ENV YARN_VERSION 1.9.4
+ENV YARN_VERSION 1.10.1
 
 RUN apk add --no-cache --virtual .build-deps-yarn curl gnupg tar \
   && for key in \

--- a/10/jessie/Dockerfile
+++ b/10/jessie/Dockerfile
@@ -41,7 +41,7 @@ RUN ARCH= && dpkgArch="$(dpkg --print-architecture)" \
   && rm "node-v$NODE_VERSION-linux-$ARCH.tar.xz" SHASUMS256.txt.asc SHASUMS256.txt \
   && ln -s /usr/local/bin/node /usr/local/bin/nodejs
 
-ENV YARN_VERSION 1.9.4
+ENV YARN_VERSION 1.10.1
 
 RUN set -ex \
   && for key in \

--- a/10/slim/Dockerfile
+++ b/10/slim/Dockerfile
@@ -46,7 +46,7 @@ RUN buildDeps='xz-utils' \
     && apt-get purge -y --auto-remove $buildDeps \
     && ln -s /usr/local/bin/node /usr/local/bin/nodejs
 
-ENV YARN_VERSION 1.9.4
+ENV YARN_VERSION 1.10.1
 
 RUN set -ex \
   && for key in \

--- a/10/stretch/Dockerfile
+++ b/10/stretch/Dockerfile
@@ -41,7 +41,7 @@ RUN ARCH= && dpkgArch="$(dpkg --print-architecture)" \
   && rm "node-v$NODE_VERSION-linux-$ARCH.tar.xz" SHASUMS256.txt.asc SHASUMS256.txt \
   && ln -s /usr/local/bin/node /usr/local/bin/nodejs
 
-ENV YARN_VERSION 1.9.4
+ENV YARN_VERSION 1.10.1
 
 RUN set -ex \
   && for key in \


### PR DESCRIPTION
https://github.com/yarnpkg/yarn/releases

yarn 1.10.1 is marked as stable, and has some nice improvements such as including checksums in yarn.lock