### PR TITLE
Upgrade to yarn v1.10.1 and alpine:3.8

### DIFF
--- a/10/alpine/Dockerfile
+++ b/10/alpine/Dockerfile
@@ -46,7 +46,7 @@ RUN addgroup -g 1000 node \
     && rm -Rf "node-v$NODE_VERSION" \
     && rm "node-v$NODE_VERSION.tar.xz" SHASUMS256.txt.asc SHASUMS256.txt
 
-ENV YARN_VERSION 1.9.4
+ENV YARN_VERSION 1.10.1
 
 RUN apk add --no-cache --virtual .build-deps-yarn curl gnupg tar \
   && for key in \

--- a/10/jessie/Dockerfile
+++ b/10/jessie/Dockerfile
@@ -41,7 +41,7 @@ RUN ARCH= && dpkgArch="$(dpkg --print-architecture)" \
   && rm "node-v$NODE_VERSION-linux-$ARCH.tar.xz" SHASUMS256.txt.asc SHASUMS256.txt \
   && ln -s /usr/local/bin/node /usr/local/bin/nodejs
 
-ENV YARN_VERSION 1.9.4
+ENV YARN_VERSION 1.10.1
 
 RUN set -ex \
   && for key in \

--- a/10/slim/Dockerfile
+++ b/10/slim/Dockerfile
@@ -46,7 +46,7 @@ RUN buildDeps='xz-utils' \
     && apt-get purge -y --auto-remove $buildDeps \
     && ln -s /usr/local/bin/node /usr/local/bin/nodejs
 
-ENV YARN_VERSION 1.9.4
+ENV YARN_VERSION 1.10.1
 
 RUN set -ex \
   && for key in \

--- a/10/stretch/Dockerfile
+++ b/10/stretch/Dockerfile
@@ -41,7 +41,7 @@ RUN ARCH= && dpkgArch="$(dpkg --print-architecture)" \
   && rm "node-v$NODE_VERSION-linux-$ARCH.tar.xz" SHASUMS256.txt.asc SHASUMS256.txt \
   && ln -s /usr/local/bin/node /usr/local/bin/nodejs
 
-ENV YARN_VERSION 1.9.4
+ENV YARN_VERSION 1.10.1
 
 RUN set -ex \
   && for key in \

--- a/6/alpine/Dockerfile
+++ b/6/alpine/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.4
+FROM alpine:3.8
 
 ENV NODE_VERSION 6.14.4
 
@@ -46,7 +46,7 @@ RUN addgroup -g 1000 node \
     && rm -Rf "node-v$NODE_VERSION" \
     && rm "node-v$NODE_VERSION.tar.xz" SHASUMS256.txt.asc SHASUMS256.txt
 
-ENV YARN_VERSION 1.6.0
+ENV YARN_VERSION 1.10.1
 
 RUN apk add --no-cache --virtual .build-deps-yarn curl gnupg tar \
   && for key in \

--- a/6/jessie/Dockerfile
+++ b/6/jessie/Dockerfile
@@ -41,7 +41,7 @@ RUN ARCH= && dpkgArch="$(dpkg --print-architecture)" \
   && rm "node-v$NODE_VERSION-linux-$ARCH.tar.xz" SHASUMS256.txt.asc SHASUMS256.txt \
   && ln -s /usr/local/bin/node /usr/local/bin/nodejs
 
-ENV YARN_VERSION 1.6.0
+ENV YARN_VERSION 1.10.1
 
 RUN set -ex \
   && for key in \

--- a/6/slim/Dockerfile
+++ b/6/slim/Dockerfile
@@ -46,7 +46,7 @@ RUN buildDeps='xz-utils' \
     && apt-get purge -y --auto-remove $buildDeps \
     && ln -s /usr/local/bin/node /usr/local/bin/nodejs
 
-ENV YARN_VERSION 1.6.0
+ENV YARN_VERSION 1.10.1
 
 RUN set -ex \
   && for key in \

--- a/6/stretch/Dockerfile
+++ b/6/stretch/Dockerfile
@@ -41,7 +41,7 @@ RUN ARCH= && dpkgArch="$(dpkg --print-architecture)" \
   && rm "node-v$NODE_VERSION-linux-$ARCH.tar.xz" SHASUMS256.txt.asc SHASUMS256.txt \
   && ln -s /usr/local/bin/node /usr/local/bin/nodejs
 
-ENV YARN_VERSION 1.6.0
+ENV YARN_VERSION 1.10.1
 
 RUN set -ex \
   && for key in \

--- a/8/alpine/Dockerfile
+++ b/8/alpine/Dockerfile
@@ -46,7 +46,7 @@ RUN addgroup -g 1000 node \
     && rm -Rf "node-v$NODE_VERSION" \
     && rm "node-v$NODE_VERSION.tar.xz" SHASUMS256.txt.asc SHASUMS256.txt
 
-ENV YARN_VERSION 1.9.4
+ENV YARN_VERSION 1.10.1
 
 RUN apk add --no-cache --virtual .build-deps-yarn curl gnupg tar \
   && for key in \

--- a/8/jessie/Dockerfile
+++ b/8/jessie/Dockerfile
@@ -41,7 +41,7 @@ RUN ARCH= && dpkgArch="$(dpkg --print-architecture)" \
   && rm "node-v$NODE_VERSION-linux-$ARCH.tar.xz" SHASUMS256.txt.asc SHASUMS256.txt \
   && ln -s /usr/local/bin/node /usr/local/bin/nodejs
 
-ENV YARN_VERSION 1.9.4
+ENV YARN_VERSION 1.10.1
 
 RUN set -ex \
   && for key in \

--- a/8/slim/Dockerfile
+++ b/8/slim/Dockerfile
@@ -46,7 +46,7 @@ RUN buildDeps='xz-utils' \
     && apt-get purge -y --auto-remove $buildDeps \
     && ln -s /usr/local/bin/node /usr/local/bin/nodejs
 
-ENV YARN_VERSION 1.9.4
+ENV YARN_VERSION 1.10.1
 
 RUN set -ex \
   && for key in \

--- a/8/stretch/Dockerfile
+++ b/8/stretch/Dockerfile
@@ -41,7 +41,7 @@ RUN ARCH= && dpkgArch="$(dpkg --print-architecture)" \
   && rm "node-v$NODE_VERSION-linux-$ARCH.tar.xz" SHASUMS256.txt.asc SHASUMS256.txt \
   && ln -s /usr/local/bin/node /usr/local/bin/nodejs
 
-ENV YARN_VERSION 1.9.4
+ENV YARN_VERSION 1.10.1
 
 RUN set -ex \
   && for key in \

--- a/chakracore/10/Dockerfile
+++ b/chakracore/10/Dockerfile
@@ -17,7 +17,7 @@ RUN ARCH= && dpkgArch="$(dpkg --print-architecture)" \
   && rm "node-v$NODE_VERSION-linux-$ARCH.tar.xz" SHASUMS256.txt \
   && ln -s /usr/local/bin/node /usr/local/bin/nodejs
 
-ENV YARN_VERSION 1.7.0
+ENV YARN_VERSION 1.10.1
 
 RUN set -ex \
   && for key in \

--- a/chakracore/8/Dockerfile
+++ b/chakracore/8/Dockerfile
@@ -17,7 +17,7 @@ RUN ARCH= && dpkgArch="$(dpkg --print-architecture)" \
   && rm "node-v$NODE_VERSION-linux-$ARCH.tar.xz" SHASUMS256.txt \
   && ln -s /usr/local/bin/node /usr/local/bin/nodejs
 
-ENV YARN_VERSION 1.6.0
+ENV YARN_VERSION 1.10.1
 
 RUN set -ex \
   && for key in \


### PR DESCRIPTION
I just ran the `update.sh` script.
Yarn has integrity check since v1.10.0 and it's pretty useful for security purposes.