### PR TITLE
fix: update to alpine-3.8.1

### DIFF
--- a/10/alpine/Dockerfile
+++ b/10/alpine/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.8
+FROM alpine:3.8.1
 
 ENV NODE_VERSION 10.11.0
 

--- a/8/alpine/Dockerfile
+++ b/8/alpine/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.8
+FROM alpine:3.8.1
 
 ENV NODE_VERSION 8.12.0
 


### PR DESCRIPTION
Closes #868 

## Tasks

- [x] Update 8.x
- [x] Update 10.x
- [ ] Update 6.x - ❗️ Not sure if I should? It was set to 3.4 but I see the others are 3.8.0 so wondering if that's on purpose