### PR TITLE
 Update Travis CI environment to Ubuntu Xenial

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@
 
 ---
 
-dist: trusty
+dist: xenial
 sudo: false
 
 language: generic

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@
 dist: xenial
 sudo: false
 
-language: generic
+language: minimal
 
 services:
   - docker

--- a/.travis.yml
+++ b/.travis.yml
@@ -86,7 +86,6 @@ jobs:
     - stage: Test
       env:
         - TEST: .travis.yml and travis.yml.template consistency
-      language: generic
       script:
         - ./update.sh
         - git diff --stat --exit-code .travis.yml

--- a/travis.yml.template
+++ b/travis.yml.template
@@ -84,7 +84,6 @@ jobs:
     - stage: Test
       env:
         - TEST: .travis.yml and travis.yml.template consistency
-      language: generic
       script:
         - ./update.sh
         - git diff --stat --exit-code .travis.yml

--- a/travis.yml.template
+++ b/travis.yml.template
@@ -3,7 +3,7 @@
 dist: xenial
 sudo: false
 
-language: generic
+language: minimal
 
 services:
   - docker

--- a/travis.yml.template
+++ b/travis.yml.template
@@ -1,6 +1,6 @@
 ---
 
-dist: trusty
+dist: xenial
 sudo: false
 
 language: generic


### PR DESCRIPTION
Same content as #905, but fix the wrong target branch in #905

------- 

Trusty is reaching EOL, Xenial environment is finally available, so let's move forward!

Ref: https://blog.travis-ci.com/2018-11-08-xenial-release