### PR TITLE
[WIP] Sort versions in function.sh/.travis.yml by `sort -Vr`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -102,6 +102,41 @@ jobs:
 
     - stage: Build
       before_script: *auto_skip
+      name: chakracore/10 on default
+      env:
+        - NODE_VERSION="chakracore/10"
+        - VARIANT="default"
+
+    - stage: Build
+      before_script: *auto_skip
+      name: chakracore/8 on default
+      env:
+        - NODE_VERSION="chakracore/8"
+        - VARIANT="default"
+
+    - stage: Build
+      before_script: *auto_skip
+      name: 11 on alpine
+      env:
+        - NODE_VERSION="11"
+        - VARIANT="alpine"
+
+    - stage: Build
+      before_script: *auto_skip
+      name: 11 on stretch
+      env:
+        - NODE_VERSION="11"
+        - VARIANT="stretch"
+
+    - stage: Build
+      before_script: *auto_skip
+      name: 11 on stretch-slim
+      env:
+        - NODE_VERSION="11"
+        - VARIANT="stretch-slim"
+
+    - stage: Build
+      before_script: *auto_skip
       name: 10 on jessie
       env:
         - NODE_VERSION="10"
@@ -133,69 +168,6 @@ jobs:
       name: 10 on stretch-slim
       env:
         - NODE_VERSION="10"
-        - VARIANT="stretch-slim"
-
-    - stage: Build
-      before_script: *auto_skip
-      name: 11 on alpine
-      env:
-        - NODE_VERSION="11"
-        - VARIANT="alpine"
-
-    - stage: Build
-      before_script: *auto_skip
-      name: 11 on stretch
-      env:
-        - NODE_VERSION="11"
-        - VARIANT="stretch"
-
-    - stage: Build
-      before_script: *auto_skip
-      name: 11 on stretch-slim
-      env:
-        - NODE_VERSION="11"
-        - VARIANT="stretch-slim"
-
-    - stage: Build
-      before_script: *auto_skip
-      name: 6 on jessie
-      env:
-        - NODE_VERSION="6"
-        - VARIANT="jessie"
-
-    - stage: Build
-      before_script: *auto_skip
-      name: 6 on jessie-slim
-      env:
-        - NODE_VERSION="6"
-        - VARIANT="jessie-slim"
-
-    - stage: Build
-      before_script: *auto_skip
-      name: 6 on alpine
-      env:
-        - NODE_VERSION="6"
-        - VARIANT="alpine"
-
-    - stage: Build
-      before_script: *auto_skip
-      name: 6 on onbuild
-      env:
-        - NODE_VERSION="6"
-        - VARIANT="onbuild"
-
-    - stage: Build
-      before_script: *auto_skip
-      name: 6 on stretch
-      env:
-        - NODE_VERSION="6"
-        - VARIANT="stretch"
-
-    - stage: Build
-      before_script: *auto_skip
-      name: 6 on stretch-slim
-      env:
-        - NODE_VERSION="6"
         - VARIANT="stretch-slim"
 
     - stage: Build
@@ -242,14 +214,42 @@ jobs:
 
     - stage: Build
       before_script: *auto_skip
-      name: chakracore/10 on default
+      name: 6 on jessie
       env:
-        - NODE_VERSION="chakracore/10"
-        - VARIANT="default"
+        - NODE_VERSION="6"
+        - VARIANT="jessie"
 
     - stage: Build
       before_script: *auto_skip
-      name: chakracore/8 on default
+      name: 6 on jessie-slim
       env:
-        - NODE_VERSION="chakracore/8"
-        - VARIANT="default"
+        - NODE_VERSION="6"
+        - VARIANT="jessie-slim"
+
+    - stage: Build
+      before_script: *auto_skip
+      name: 6 on alpine
+      env:
+        - NODE_VERSION="6"
+        - VARIANT="alpine"
+
+    - stage: Build
+      before_script: *auto_skip
+      name: 6 on onbuild
+      env:
+        - NODE_VERSION="6"
+        - VARIANT="onbuild"
+
+    - stage: Build
+      before_script: *auto_skip
+      name: 6 on stretch
+      env:
+        - NODE_VERSION="6"
+        - VARIANT="stretch"
+
+    - stage: Build
+      before_script: *auto_skip
+      name: 6 on stretch-slim
+      env:
+        - NODE_VERSION="6"
+        - VARIANT="stretch-slim"

--- a/functions.sh
+++ b/functions.sh
@@ -150,6 +150,7 @@ function get_versions() {
   default_variant=$(get_config "./" "default_variant")
   if [ ${#dirs[@]} -eq 0 ]; then
     IFS=' ' read -ra dirs <<< "$(echo "${prefix%/}/"*/)"
+    IFS=$'\n' dirs=($(sort -Vr <<< "${dirs[*]}"))
   fi
 
   for dir in "${dirs[@]}"; do


### PR DESCRIPTION
As we can skip the non-related builds now, this can potentially speed up
the CI builds. Since the larger major versions will be updated more
frequently(under development), the lower versions going to enter their
maintenance stage, which has fewer updates, put the versions has more
updates to appear earlier will make their builds start earlier, and
finish their builds earlier.

This might not help if we compare the chakracore builds with the others,
however, chakracore has only two builds, and it still has its version
ordering inside chakracore builds (10 -> 8 in this case), so it'll still
help compares to builds without ordering.