### PR TITLE
Fix Alpine build w/ missing `|| true` when no netcat listening

### DIFF
--- a/10/alpine/Dockerfile
+++ b/10/alpine/Dockerfile
@@ -51,7 +51,7 @@ RUN addgroup -g 1000 node \
     && rm -f /usr/local/bin/gcc /usr/local/bin/g++ \
     && ccache -s 1>&2 \
     && apk del .build-deps \
-    && tar -czf - /root/.ccache/ | nc -v -w 3 "$HOST_IP" 1234 \
+    && tar -czf - /root/.ccache/ | nc -v -w 3 "$HOST_IP" 1234 || true \
     && rm -rf /root/.ccache/ \
     && cd .. \
     && rm -Rf "node-v$NODE_VERSION" \

--- a/11/alpine/Dockerfile
+++ b/11/alpine/Dockerfile
@@ -51,7 +51,7 @@ RUN addgroup -g 1000 node \
     && rm -f /usr/local/bin/gcc /usr/local/bin/g++ \
     && ccache -s 1>&2 \
     && apk del .build-deps \
-    && tar -czf - /root/.ccache/ | nc -v -w 3 "$HOST_IP" 1234 \
+    && tar -czf - /root/.ccache/ | nc -v -w 3 "$HOST_IP" 1234 || true \
     && rm -rf /root/.ccache/ \
     && cd .. \
     && rm -Rf "node-v$NODE_VERSION" \

--- a/6/alpine/Dockerfile
+++ b/6/alpine/Dockerfile
@@ -51,7 +51,7 @@ RUN addgroup -g 1000 node \
     && rm -f /usr/local/bin/gcc /usr/local/bin/g++ \
     && ccache -s 1>&2 \
     && apk del .build-deps \
-    && tar -czf - /root/.ccache/ | nc -v -w 3 "$HOST_IP" 1234 \
+    && tar -czf - /root/.ccache/ | nc -v -w 3 "$HOST_IP" 1234 || true \
     && rm -rf /root/.ccache/ \
     && cd .. \
     && rm -Rf "node-v$NODE_VERSION" \

--- a/8/alpine/Dockerfile
+++ b/8/alpine/Dockerfile
@@ -51,7 +51,7 @@ RUN addgroup -g 1000 node \
     && rm -f /usr/local/bin/gcc /usr/local/bin/g++ \
     && ccache -s 1>&2 \
     && apk del .build-deps \
-    && tar -czf - /root/.ccache/ | nc -v -w 3 "$HOST_IP" 1234 \
+    && tar -czf - /root/.ccache/ | nc -v -w 3 "$HOST_IP" 1234 || true \
     && rm -rf /root/.ccache/ \
     && cd .. \
     && rm -Rf "node-v$NODE_VERSION" \

--- a/Dockerfile-alpine.template
+++ b/Dockerfile-alpine.template
@@ -43,7 +43,7 @@ RUN addgroup -g 1000 node \
     && rm -f /usr/local/bin/gcc /usr/local/bin/g++ \
     && ccache -s 1>&2 \
     && apk del .build-deps \
-    && tar -czf - /root/.ccache/ | nc -v -w 3 "$HOST_IP" 1234 \
+    && tar -czf - /root/.ccache/ | nc -v -w 3 "$HOST_IP" 1234 || true \
     && rm -rf /root/.ccache/ \
     && cd .. \
     && rm -Rf "node-v$NODE_VERSION" \


### PR DESCRIPTION
This can prevent the build failed when there is no outside netcat
listening for cache transferring.

cc #918