### PR TITLE
documentation: fix typo in recommended multistage Dockerfile

### DIFF
--- a/docs/BestPractices.md
+++ b/docs/BestPractices.md
@@ -173,7 +173,7 @@ And Here's a multistage build example
 FROM node:alpine as builder
 
 ## Install build toolchain, install node deps and compile native add-ons
-RUN apk add --no-cache --virtual .gyp python make g++ \
+RUN apk add --no-cache --virtual .gyp python make g++
 RUN npm install [ your npm dependencies here ]
 
 FROM node:alpine as app


### PR DESCRIPTION
I think the slash at the end of the line is typo which causes the second RUN to be on the same line as the previous RUN, which causes an error.