### PR TITLE
documentation: additional typo fix

### DIFF
--- a/docs/BestPractices.md
+++ b/docs/BestPractices.md
@@ -10,7 +10,7 @@
 - [CMD](#cmd)
 - [Docker Run](#docker-run)
 - [Security](#security)
-- [node-gyp in apline variant](#node-gyp-alpine)
+- [node-gyp in alpine variant](#node-gyp-alpine)
 
 ## Environment Variables
 


### PR DESCRIPTION
realized there was another minor typo apline should be alpine