### PR TITLE
Update Travis CI deploy(auto PR) job

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -95,6 +95,12 @@ jobs:
         - git diff --stat --exit-code .travis.yml
 
     - stage: Deploy
+      before_script:
+        - |
+          if ! git diff --name-only "$TRAVIS_COMMIT_RANGE" -- | grep -Eq "Dockerfile$"; then
+            echo "Skip deployment as none of the Dockerfiles has been changed."
+            exit
+          fi
       script:
         - ./generate-stackbrew-pr.sh "$TRAVIS_COMMIT_RANGE"
 

--- a/travis.yml.template
+++ b/travis.yml.template
@@ -93,6 +93,12 @@ jobs:
         - git diff --stat --exit-code .travis.yml
 
     - stage: Deploy
+      before_script:
+        - |
+          if ! git diff --name-only "$TRAVIS_COMMIT_RANGE" -- | grep -Eq "Dockerfile$"; then
+            echo "Skip deployment as none of the Dockerfiles has been changed."
+            exit
+          fi
       script:
         - ./generate-stackbrew-pr.sh "$TRAVIS_COMMIT_RANGE"
 


### PR DESCRIPTION
I think we can use the similar logic of image build test to skip the job earlier. I also clean up a part of the script I think we didn't need.