### PR TITLE
Update architectures files (generated)

### DIFF
--- a/11/architectures
+++ b/11/architectures
@@ -1,7 +1,7 @@
 bashbrew-arch   variants
-amd64    jessie,jessie-slim,alpine,stretch,stretch-slim
+amd64    alpine,stretch,stretch-slim
 arm32v6  alpine
-arm32v7  jessie,jessie-slim,stretch,stretch-slim
+arm32v7  stretch,stretch-slim
 arm64v8  alpine,stretch,stretch-slim
 i386     alpine
 ppc64le  alpine,stretch,stretch-slim

--- a/6/architectures
+++ b/6/architectures
@@ -1,7 +1,8 @@
 bashbrew-arch   variants
-arm32v7  jessie,jessie-slim,onbuild,stretch,stretch-slim
-arm64v8  stretch
 amd64    jessie,jessie-slim,alpine,onbuild,stretch,stretch-slim
-i386     jessie,jessie-slim,onbuild,stretch,stretch-slim
-ppc64le  stretch
-s390x    stretch
+arm32v6  alpine
+arm32v7  jessie,jessie-slim,onbuild,stretch,stretch-slim
+arm64v8  alpine,onbuild,stretch,stretch-slim
+i386     jessie,jessie-slim,alpine,onbuild,stretch,stretch-slim
+ppc64le  alpine,onbuild,stretch,stretch-slim
+s390x    alpine,onbuild,stretch,stretch-slim

--- a/8/architectures
+++ b/8/architectures
@@ -1,8 +1,8 @@
 bashbrew-arch   variants
+amd64    jessie,jessie-slim,alpine,onbuild,stretch,stretch-slim
 arm32v6  alpine
 arm32v7  jessie,jessie-slim,onbuild,stretch,stretch-slim
 arm64v8  alpine,onbuild,stretch,stretch-slim
-amd64    jessie,jessie-slim,alpine,onbuild,stretch,stretch-slim
 i386     jessie,jessie-slim,alpine,onbuild,stretch,stretch-slim
 ppc64le  alpine,onbuild,stretch,stretch-slim
 s390x    alpine,onbuild,stretch,stretch-slim

--- a/architectures
+++ b/architectures
@@ -1,8 +1,8 @@
 bashbrew-arch   variants
-arm32v6  alpine
-arm32v7  jessie,jessie-slim,onbuild,stretch,stretch-slim
-arm64v8  alpine,onbuild,stretch,stretch-slim
 amd64    jessie,jessie-slim,alpine,onbuild,stretch,stretch-slim
-i386     alpine
-ppc64le  alpine,onbuild,stretch,stretch-slim
-s390x    alpine,onbuild,stretch,stretch-slim
+arm32v6  jessie,jessie-slim,alpine,onbuild,stretch,stretch-slim
+arm32v7  jessie,jessie-slim,alpine,onbuild,stretch,stretch-slim
+arm64v8  jessie,jessie-slim,alpine,onbuild,stretch,stretch-slim
+i386     jessie,jessie-slim,alpine,onbuild,stretch,stretch-slim
+ppc64le  jessie,jessie-slim,alpine,onbuild,stretch,stretch-slim
+s390x    jessie,jessie-slim,alpine,onbuild,stretch,stretch-slim


### PR DESCRIPTION
The contents of these files were generated by cross-referencing the available artifacts on https://nodejs.org/dist/ vs the supported architectures of the base image of each variant.

Closes #985

I would again echo my distaste for the overly-complex and confusing structure of these files that I articulated in https://github.com/nodejs/docker-node/pull/863.  IMO it would _much_ cleaner and simpler to maintain a list of mappings from "bashbrew architecture" string to "node architecture" string (which is a trivial list of 7 simple mappings) and generate the rest of the missing information based on detection (checking the release folder and then cross-referencing it with the supported architectures of the base image, which is exactly what my script did to generate these based on that list of 7 mappings).

Here's a useful `diff` to more easily see the _actual_ effect of this change (comparing the downstream effect):

```diff
$ diff -u <(bashbrew cat https://github.com/docker-library/official-images/raw/master/library/node) <(bashbrew cat <(./generate-stackbrew-library.sh))
--- /dev/fd/63	2019-02-19 16:36:39.546281014 -0800
+++ /dev/fd/62	2019-02-19 16:36:39.550280903 -0800
@@ -42,11 +42,12 @@
 Directory: 6/jessie-slim
 
 Tags: 6.16.0-alpine, 6.16-alpine, 6-alpine, boron-alpine
+Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
 GitCommit: daa131d713cf42ae181292471766879f750b5230
 Directory: 6/alpine
 
 Tags: 6.16.0-onbuild, 6.16-onbuild, 6-onbuild, boron-onbuild
-Architectures: amd64, arm32v7, i386
+Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: daa131d713cf42ae181292471766879f750b5230
 Directory: 6/onbuild
 
@@ -56,12 +57,12 @@
 Directory: 6/stretch
 
 Tags: 6.16.0-stretch-slim, 6.16-stretch-slim, 6-stretch-slim, boron-stretch-slim, 6.16.0-slim, 6.16-slim, 6-slim, boron-slim
-Architectures: amd64, arm32v7, i386
+Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: daa131d713cf42ae181292471766879f750b5230
 Directory: 6/stretch-slim
 
 Tags: 11.10.0-alpine, 11.10-alpine, 11-alpine, current-alpine, alpine
-Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
+Architectures: amd64, arm32v6, arm64v8, ppc64le, s390x
 GitCommit: 7b643da4aeb3d77f1c26c9f6fadd32b04f8d7bc9
 Directory: 11/alpine
 
@@ -86,7 +87,7 @@
 Directory: 10/jessie-slim
 
 Tags: 10.15.1-alpine, 10.15-alpine, 10-alpine, dubnium-alpine, lts-alpine
-Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
+Architectures: amd64, arm32v6, arm64v8, ppc64le, s390x
 GitCommit: 90043cdde5057865b94fec447ce193fb46b69e18
 Directory: 10/alpine
 
@@ -96,7 +97,7 @@
 Directory: 10/stretch
 
 Tags: 10.15.1-stretch-slim, 10.15-stretch-slim, 10-stretch-slim, dubnium-stretch-slim, lts-stretch-slim, 10.15.1-slim, 10.15-slim, 10-slim, dubnium-slim, lts-slim
-Architectures: amd64, arm32v7
+Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
 GitCommit: 90043cdde5057865b94fec447ce193fb46b69e18
 Directory: 10/stretch-slim
 
```

I'm happy to share the script I wrote to generate these with appropriate values, but I'd honestly really prefer if this could be solved in a way in this repository directly that makes these files actually maintainable without doing this full hacky generation like what I've done here.

If you want a good example of a fairly-static list of supported architectures per release version, see https://github.com/docker-library/golang (especially the `release-architectures` files in each version folder).

If you want an example of a dynamic list of supported architectures per release version (where architectures can shift to come and go), see https://github.com/docker-library/pypy instead.