### PR TITLE
Update Node 10 Alpine version

### DIFF
--- a/10/alpine/Dockerfile
+++ b/10/alpine/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.8
+FROM alpine:3.9
 
 ENV NODE_VERSION 10.15.1
 


### PR DESCRIPTION
Closes #998 

Given Node 10 is the current LTS, it makes sense to move to Alpine 3.9.  Node 11 images are already using 3.9 as well.