### PR TITLE
Update node.js v6, v8, v10 & v11 for security release

### DIFF
--- a/10/alpine/Dockerfile
+++ b/10/alpine/Dockerfile
@@ -1,6 +1,6 @@
 FROM alpine:3.8
 
-ENV NODE_VERSION 10.15.1
+ENV NODE_VERSION 10.15.2
 
 RUN addgroup -g 1000 node \
     && adduser -u 1000 -G node -s /bin/sh -D node \

--- a/10/jessie-slim/Dockerfile
+++ b/10/jessie-slim/Dockerfile
@@ -3,7 +3,7 @@ FROM debian:jessie-slim
 RUN groupadd --gid 1000 node \
   && useradd --uid 1000 --gid node --shell /bin/bash --create-home node
 
-ENV NODE_VERSION 10.15.1
+ENV NODE_VERSION 10.15.2
 
 RUN buildDeps='xz-utils' \
     && ARCH= && dpkgArch="$(dpkg --print-architecture)" \

--- a/10/jessie/Dockerfile
+++ b/10/jessie/Dockerfile
@@ -3,7 +3,7 @@ FROM buildpack-deps:jessie
 RUN groupadd --gid 1000 node \
   && useradd --uid 1000 --gid node --shell /bin/bash --create-home node
 
-ENV NODE_VERSION 10.15.1
+ENV NODE_VERSION 10.15.2
 
 RUN ARCH= && dpkgArch="$(dpkg --print-architecture)" \
   && case "${dpkgArch##*-}" in \

--- a/10/stretch-slim/Dockerfile
+++ b/10/stretch-slim/Dockerfile
@@ -3,7 +3,7 @@ FROM debian:stretch-slim
 RUN groupadd --gid 1000 node \
   && useradd --uid 1000 --gid node --shell /bin/bash --create-home node
 
-ENV NODE_VERSION 10.15.1
+ENV NODE_VERSION 10.15.2
 
 RUN buildDeps='xz-utils' \
     && ARCH= && dpkgArch="$(dpkg --print-architecture)" \

--- a/10/stretch/Dockerfile
+++ b/10/stretch/Dockerfile
@@ -3,7 +3,7 @@ FROM buildpack-deps:stretch
 RUN groupadd --gid 1000 node \
   && useradd --uid 1000 --gid node --shell /bin/bash --create-home node
 
-ENV NODE_VERSION 10.15.1
+ENV NODE_VERSION 10.15.2
 
 RUN ARCH= && dpkgArch="$(dpkg --print-architecture)" \
   && case "${dpkgArch##*-}" in \

--- a/11/alpine/Dockerfile
+++ b/11/alpine/Dockerfile
@@ -1,6 +1,6 @@
 FROM alpine:3.9
 
-ENV NODE_VERSION 11.10.0
+ENV NODE_VERSION 11.10.1
 
 RUN addgroup -g 1000 node \
     && adduser -u 1000 -G node -s /bin/sh -D node \

--- a/11/stretch-slim/Dockerfile
+++ b/11/stretch-slim/Dockerfile
@@ -3,7 +3,7 @@ FROM debian:stretch-slim
 RUN groupadd --gid 1000 node \
   && useradd --uid 1000 --gid node --shell /bin/bash --create-home node
 
-ENV NODE_VERSION 11.10.0
+ENV NODE_VERSION 11.10.1
 
 RUN buildDeps='xz-utils' \
     && ARCH= && dpkgArch="$(dpkg --print-architecture)" \

--- a/11/stretch/Dockerfile
+++ b/11/stretch/Dockerfile
@@ -3,7 +3,7 @@ FROM buildpack-deps:stretch
 RUN groupadd --gid 1000 node \
   && useradd --uid 1000 --gid node --shell /bin/bash --create-home node
 
-ENV NODE_VERSION 11.10.0
+ENV NODE_VERSION 11.10.1
 
 RUN ARCH= && dpkgArch="$(dpkg --print-architecture)" \
   && case "${dpkgArch##*-}" in \

--- a/6/alpine/Dockerfile
+++ b/6/alpine/Dockerfile
@@ -1,6 +1,6 @@
 FROM alpine:3.8
 
-ENV NODE_VERSION 6.16.0
+ENV NODE_VERSION 6.17.0
 
 RUN addgroup -g 1000 node \
     && adduser -u 1000 -G node -s /bin/sh -D node \

--- a/6/jessie-slim/Dockerfile
+++ b/6/jessie-slim/Dockerfile
@@ -3,7 +3,7 @@ FROM debian:jessie-slim
 RUN groupadd --gid 1000 node \
   && useradd --uid 1000 --gid node --shell /bin/bash --create-home node
 
-ENV NODE_VERSION 6.16.0
+ENV NODE_VERSION 6.17.0
 
 RUN buildDeps='xz-utils' \
     && ARCH= && dpkgArch="$(dpkg --print-architecture)" \

--- a/6/jessie/Dockerfile
+++ b/6/jessie/Dockerfile
@@ -3,7 +3,7 @@ FROM buildpack-deps:jessie
 RUN groupadd --gid 1000 node \
   && useradd --uid 1000 --gid node --shell /bin/bash --create-home node
 
-ENV NODE_VERSION 6.16.0
+ENV NODE_VERSION 6.17.0
 
 RUN ARCH= && dpkgArch="$(dpkg --print-architecture)" \
   && case "${dpkgArch##*-}" in \

--- a/6/onbuild/Dockerfile
+++ b/6/onbuild/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:6.16.0-stretch
+FROM node:6.17.0-stretch
 
 RUN mkdir -p /usr/src/app
 WORKDIR /usr/src/app

--- a/6/stretch-slim/Dockerfile
+++ b/6/stretch-slim/Dockerfile
@@ -3,7 +3,7 @@ FROM debian:stretch-slim
 RUN groupadd --gid 1000 node \
   && useradd --uid 1000 --gid node --shell /bin/bash --create-home node
 
-ENV NODE_VERSION 6.16.0
+ENV NODE_VERSION 6.17.0
 
 RUN buildDeps='xz-utils' \
     && ARCH= && dpkgArch="$(dpkg --print-architecture)" \

--- a/6/stretch/Dockerfile
+++ b/6/stretch/Dockerfile
@@ -3,7 +3,7 @@ FROM buildpack-deps:stretch
 RUN groupadd --gid 1000 node \
   && useradd --uid 1000 --gid node --shell /bin/bash --create-home node
 
-ENV NODE_VERSION 6.16.0
+ENV NODE_VERSION 6.17.0
 
 RUN ARCH= && dpkgArch="$(dpkg --print-architecture)" \
   && case "${dpkgArch##*-}" in \

--- a/8/alpine/Dockerfile
+++ b/8/alpine/Dockerfile
@@ -1,6 +1,6 @@
 FROM alpine:3.8
 
-ENV NODE_VERSION 8.15.0
+ENV NODE_VERSION 8.15.1
 
 RUN addgroup -g 1000 node \
     && adduser -u 1000 -G node -s /bin/sh -D node \

--- a/8/jessie-slim/Dockerfile
+++ b/8/jessie-slim/Dockerfile
@@ -3,7 +3,7 @@ FROM debian:jessie-slim
 RUN groupadd --gid 1000 node \
   && useradd --uid 1000 --gid node --shell /bin/bash --create-home node
 
-ENV NODE_VERSION 8.15.0
+ENV NODE_VERSION 8.15.1
 
 RUN buildDeps='xz-utils' \
     && ARCH= && dpkgArch="$(dpkg --print-architecture)" \

--- a/8/jessie/Dockerfile
+++ b/8/jessie/Dockerfile
@@ -3,7 +3,7 @@ FROM buildpack-deps:jessie
 RUN groupadd --gid 1000 node \
   && useradd --uid 1000 --gid node --shell /bin/bash --create-home node
 
-ENV NODE_VERSION 8.15.0
+ENV NODE_VERSION 8.15.1
 
 RUN ARCH= && dpkgArch="$(dpkg --print-architecture)" \
   && case "${dpkgArch##*-}" in \

--- a/8/onbuild/Dockerfile
+++ b/8/onbuild/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:8.15.0-stretch
+FROM node:8.15.1-stretch
 
 RUN mkdir -p /usr/src/app
 WORKDIR /usr/src/app

--- a/8/stretch-slim/Dockerfile
+++ b/8/stretch-slim/Dockerfile
@@ -3,7 +3,7 @@ FROM debian:stretch-slim
 RUN groupadd --gid 1000 node \
   && useradd --uid 1000 --gid node --shell /bin/bash --create-home node
 
-ENV NODE_VERSION 8.15.0
+ENV NODE_VERSION 8.15.1
 
 RUN buildDeps='xz-utils' \
     && ARCH= && dpkgArch="$(dpkg --print-architecture)" \

--- a/8/stretch/Dockerfile
+++ b/8/stretch/Dockerfile
@@ -3,7 +3,7 @@ FROM buildpack-deps:stretch
 RUN groupadd --gid 1000 node \
   && useradd --uid 1000 --gid node --shell /bin/bash --create-home node
 
-ENV NODE_VERSION 8.15.0
+ENV NODE_VERSION 8.15.1
 
 RUN ARCH= && dpkgArch="$(dpkg --print-architecture)" \
   && case "${dpkgArch##*-}" in \


### PR DESCRIPTION
https://github.com/nodejs/node/releases/tag/v11.10.1
https://github.com/nodejs/node/releases/tag/v10.15.2
https://github.com/nodejs/node/releases/tag/v8.15.1
https://github.com/nodejs/node/releases/tag/v6.17.0

Close #996