### PR TITLE
Update node.js v12.2.0 to v12.3.0 with Yarn v1.16.0

### DIFF
--- a/12/alpine/Dockerfile
+++ b/12/alpine/Dockerfile
@@ -1,6 +1,6 @@
 FROM alpine:3.9
 
-ENV NODE_VERSION 12.2.0
+ENV NODE_VERSION 12.3.0
 
 RUN addgroup -g 1000 node \
     && adduser -u 1000 -G node -s /bin/sh -D node \
@@ -48,7 +48,7 @@ RUN addgroup -g 1000 node \
     && rm -Rf "node-v$NODE_VERSION" \
     && rm "node-v$NODE_VERSION.tar.xz" SHASUMS256.txt.asc SHASUMS256.txt
 
-ENV YARN_VERSION 1.15.2
+ENV YARN_VERSION 1.16.0
 
 RUN apk add --no-cache --virtual .build-deps-yarn curl gnupg tar \
   && for key in \

--- a/12/stretch-slim/Dockerfile
+++ b/12/stretch-slim/Dockerfile
@@ -3,7 +3,7 @@ FROM debian:stretch-slim
 RUN groupadd --gid 1000 node \
   && useradd --uid 1000 --gid node --shell /bin/bash --create-home node
 
-ENV NODE_VERSION 12.2.0
+ENV NODE_VERSION 12.3.0
 
 RUN buildDeps='xz-utils' \
     && ARCH= && dpkgArch="$(dpkg --print-architecture)" \
@@ -45,7 +45,7 @@ RUN buildDeps='xz-utils' \
     && apt-get purge -y --auto-remove $buildDeps \
     && ln -s /usr/local/bin/node /usr/local/bin/nodejs
 
-ENV YARN_VERSION 1.15.2
+ENV YARN_VERSION 1.16.0
 
 RUN set -ex \
   && for key in \

--- a/12/stretch/Dockerfile
+++ b/12/stretch/Dockerfile
@@ -3,7 +3,7 @@ FROM buildpack-deps:stretch
 RUN groupadd --gid 1000 node \
   && useradd --uid 1000 --gid node --shell /bin/bash --create-home node
 
-ENV NODE_VERSION 12.2.0
+ENV NODE_VERSION 12.3.0
 
 RUN ARCH= && dpkgArch="$(dpkg --print-architecture)" \
   && case "${dpkgArch##*-}" in \
@@ -42,7 +42,7 @@ RUN ARCH= && dpkgArch="$(dpkg --print-architecture)" \
   && rm "node-v$NODE_VERSION-linux-$ARCH.tar.xz" SHASUMS256.txt.asc SHASUMS256.txt \
   && ln -s /usr/local/bin/node /usr/local/bin/nodejs
 
-ENV YARN_VERSION 1.15.2
+ENV YARN_VERSION 1.16.0
 
 RUN set -ex \
   && for key in \


### PR DESCRIPTION
- https://nodejs.org/en/blog/release/v12.3.0/
- https://github.com/nodejs/node/releases/tag/v12.3.0
- https://github.com/nodejs/node/blob/master/doc/changelogs/CHANGELOG_V12.md#12.3.0