### PR TITLE
Update Upgrading/downgrading Yarn best practice

### DIFF
--- a/docs/BestPractices.md
+++ b/docs/BestPractices.md
@@ -32,13 +32,27 @@ ENV PATH=$PATH:/home/node/.npm-global/bin # optionally if you want to run npm gl
 
 ## Upgrading/downgrading Yarn
 
-If you need to upgrade/downgrade `yarn`, you can do so by issuing the following commands in your `Dockerfile`:
+### Local
+
+If you need to upgrade/downgrade `yarn` for a local install, you can do so by issuing the following commands in your `Dockerfile`:
+
+> Note that if you create some other directory which is not a descendant one from where you ran the command, you will end up using the global (dated) version. If you wish to upgrade `yarn` globally follow the instructions in the next section.
+
+> When following the local install instructions, due to duplicated yarn the image will end up being bigger.
 
 ```Dockerfile
 FROM node:6
 
-ENV YARN_VERSION 1.5.1
+ENV YARN_VERSION 1.16.0
 
+RUN yarn policies set-version $YARN_VERSION
+```
+
+### Global
+
+```Dockerfile
+FROM node:6
+ENV YARN_VERSION 1.16.0
 RUN curl -fSLO --compressed "https://yarnpkg.com/downloads/$YARN_VERSION/yarn-v$YARN_VERSION.tar.gz" \
     && tar -xzf yarn-v$YARN_VERSION.tar.gz -C /opt/ \
     && ln -snf /opt/yarn-v$YARN_VERSION/bin/yarn /usr/local/bin/yarn \
@@ -50,9 +64,7 @@ If you're using an Alpine-based image, `curl` won't be present, so you'll need t
 
 ```Dockerfile
 FROM node:6-alpine
-
 ENV YARN_VERSION 1.5.1
-
 RUN apk add --no-cache --virtual .build-deps-yarn curl \
     && curl -fSLO --compressed "https://yarnpkg.com/downloads/$YARN_VERSION/yarn-v$YARN_VERSION.tar.gz" \
     && tar -xzf yarn-v$YARN_VERSION.tar.gz -C /opt/ \


### PR DESCRIPTION
Edit the best practice documentation on how to change yarn version based on the yarn [recommended practice](https://yarnpkg.com/lang/en/docs/cli/policies/#toc-policies-set-version)

> Note that this command also is the preferred way to upgrade Yarn - it will work no matter how you originally installed it, which might sometimes prove difficult to figure out otherwise.

It works on alpine based images too.