### PR TITLE
Check node.js version same as in default variant

### DIFF
--- a/functions.sh
+++ b/functions.sh
@@ -231,14 +231,18 @@ function get_full_version() {
   version=$1
   shift
 
-  local default_dockerfile
-  if [ -f "${version}/${default_variant}/Dockerfile" ]; then
-    default_dockerfile="${version}/${default_variant}/Dockerfile"
+  local variant
+  variant=${1:-${default_variant}}
+  shift
+
+  local dockerfile
+  if [ -f "${version}/${variant}/Dockerfile" ]; then
+    dockerfile="${version}/${variant}/Dockerfile"
   else
-    default_dockerfile="${version}/Dockerfile"
+    dockerfile="${version}/Dockerfile"
   fi
 
-  grep -m1 'ENV NODE_VERSION ' "${default_dockerfile}" | cut -d' ' -f3
+  grep -m1 'ENV NODE_VERSION ' "${dockerfile}" | cut -d' ' -f3
 }
 
 function get_major_minor_version() {

--- a/test-build.sh
+++ b/test-build.sh
@@ -93,6 +93,13 @@ for version in "${versions[@]}"; do
       test_image "${full_version}" "${default_variant}" "$tag"
     fi
 
+    if [ "${variant}" != "onbuild" ]; then
+      variant_full_version=$(get_full_version "${version}" "${variant}")
+      if [ "${full_version}" != "${variant_full_version}" ]; then
+        fatal "${variant}'s version is ${variant_full_version}, but should be ${full_version}"
+      fi
+    fi
+
     build "${version}" "${variant}" "${tag}"
     test_image "${full_version}" "${variant}" "${tag}"
   done


### PR DESCRIPTION
Verify that node.js version for each variant as it is for default variant for each node.js major version.

This prevents accidents such as #1063 where only some variant images were updated to newer Node.js version.

The test is skipped with onbuild variant, because it specifies the version differently, and ongoing variant is deprecated.