### PR TITLE
Fix update.sh invocation with slim

### DIFF
--- a/update.sh
+++ b/update.sh
@@ -10,14 +10,14 @@ function usage() {
     $0 [-s] [MAJOR_VERSION(S)] [VARIANT(S)]
 
   Examples:
-    - update.sh                   # Update all images
-    - update.sh -s                # Update all images, skip updating Alpine and Yarn
-    - update.sh 8,10              # Update version 8 and 10 and variants (default, slim, alpine etc.)
-    - update.sh -s 8              # Update version 8 and variants, skip updating Alpine and Yarn
-    - update.sh 8 slim,stretch    # Update only slim and stretch variants for version 8
-    - update.sh -s 8 slim,stretch # Update only slim and stretch variants for version 8, skip updating Alpine and Yarn
-    - update.sh . alpine          # Update the alpine variant for all versions
-    - update.sh -t                # Update .travis.yml only
+    - update.sh                      # Update all images
+    - update.sh -s                   # Update all images, skip updating Alpine and Yarn
+    - update.sh 8,10                 # Update all variants of version 8 and 10
+    - update.sh -s 8                 # Update version 8 and variants, skip updating Alpine and Yarn
+    - update.sh 8 buster-slim,buster # Update only buster's slim and buster variants for version 8
+    - update.sh -s 8 stretch         # Update only stretch variant for version 8, skip updating Alpine and Yarn
+    - update.sh . alpine             # Update the alpine variant for all versions
+    - update.sh -t                   # Update .travis.yml only
 
   OPTIONS:
     -s Security update; skip updating the yarn and alpine versions.

--- a/update.sh
+++ b/update.sh
@@ -96,7 +96,7 @@ function in_versions_to_update() {
 function in_variants_to_update() {
   local variant=$1
 
-  if [ "${#update_variants[@]}" -eq 0 ]; then
+  if [ "${#variant_arg[@]}" -eq 0 ]; then
     echo 0
     return
   fi


### PR DESCRIPTION
When working on update.sh to get Debian 10 buster variants, I noticed that `update.sh` example invocation with `slim` does not work correctly. There is two issues:
1. Variant name for `slim` needs to contain base operating system such as `stretch` or `buster`
2. Invocation with unknown variant causes all variants to be updated

These changes cause unknown variants to be ignored if passed as arguments. Instead of skipping, triggering error would be another behavior that could be expected.
