### PR TITLE
fix: update the Alpine base image version to v3.10

### DIFF
--- a/10/alpine/Dockerfile
+++ b/10/alpine/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.9
+FROM alpine:3.10
 
 ENV NODE_VERSION 10.16.0
 

--- a/12/alpine/Dockerfile
+++ b/12/alpine/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.9
+FROM alpine:3.10
 
 ENV NODE_VERSION 12.7.0
 

--- a/8/alpine/Dockerfile
+++ b/8/alpine/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.9
+FROM alpine:3.10
 
 ENV NODE_VERSION 8.16.0
 

--- a/config
+++ b/config
@@ -1,4 +1,4 @@
 baseuri     https://nodejs.org/dist
 default_variant stretch
-alpine_version  3.9
+alpine_version  3.10
 debian_versions jessie stretch buster


### PR DESCRIPTION
Alpine Linux released 3.10.0 on 13 June 2019:
https://alpinelinux.org/posts/Alpine-3.10.0-released.html