### PR TITLE
Update node.js v10 & v12

### DIFF
--- a/10/alpine/Dockerfile
+++ b/10/alpine/Dockerfile
@@ -1,6 +1,6 @@
 FROM alpine:3.9
 
-ENV NODE_VERSION 10.16.1
+ENV NODE_VERSION 10.16.2
 
 RUN addgroup -g 1000 node \
     && adduser -u 1000 -G node -s /bin/sh -D node \

--- a/10/buster-slim/Dockerfile
+++ b/10/buster-slim/Dockerfile
@@ -3,7 +3,7 @@ FROM debian:buster-slim
 RUN groupadd --gid 1000 node \
   && useradd --uid 1000 --gid node --shell /bin/bash --create-home node
 
-ENV NODE_VERSION 10.16.1
+ENV NODE_VERSION 10.16.2
 
 RUN buildDeps='xz-utils' \
     && ARCH= && dpkgArch="$(dpkg --print-architecture)" \

--- a/10/buster/Dockerfile
+++ b/10/buster/Dockerfile
@@ -3,7 +3,7 @@ FROM buildpack-deps:buster
 RUN groupadd --gid 1000 node \
   && useradd --uid 1000 --gid node --shell /bin/bash --create-home node
 
-ENV NODE_VERSION 10.16.1
+ENV NODE_VERSION 10.16.2
 
 RUN ARCH= && dpkgArch="$(dpkg --print-architecture)" \
   && case "${dpkgArch##*-}" in \

--- a/10/jessie-slim/Dockerfile
+++ b/10/jessie-slim/Dockerfile
@@ -3,7 +3,7 @@ FROM debian:jessie-slim
 RUN groupadd --gid 1000 node \
   && useradd --uid 1000 --gid node --shell /bin/bash --create-home node
 
-ENV NODE_VERSION 10.16.1
+ENV NODE_VERSION 10.16.2
 
 RUN buildDeps='xz-utils' \
     && ARCH= && dpkgArch="$(dpkg --print-architecture)" \

--- a/10/jessie/Dockerfile
+++ b/10/jessie/Dockerfile
@@ -3,7 +3,7 @@ FROM buildpack-deps:jessie
 RUN groupadd --gid 1000 node \
   && useradd --uid 1000 --gid node --shell /bin/bash --create-home node
 
-ENV NODE_VERSION 10.16.1
+ENV NODE_VERSION 10.16.2
 
 RUN ARCH= && dpkgArch="$(dpkg --print-architecture)" \
   && case "${dpkgArch##*-}" in \

--- a/10/stretch-slim/Dockerfile
+++ b/10/stretch-slim/Dockerfile
@@ -3,7 +3,7 @@ FROM debian:stretch-slim
 RUN groupadd --gid 1000 node \
   && useradd --uid 1000 --gid node --shell /bin/bash --create-home node
 
-ENV NODE_VERSION 10.16.1
+ENV NODE_VERSION 10.16.2
 
 RUN buildDeps='xz-utils' \
     && ARCH= && dpkgArch="$(dpkg --print-architecture)" \

--- a/10/stretch/Dockerfile
+++ b/10/stretch/Dockerfile
@@ -3,7 +3,7 @@ FROM buildpack-deps:stretch
 RUN groupadd --gid 1000 node \
   && useradd --uid 1000 --gid node --shell /bin/bash --create-home node
 
-ENV NODE_VERSION 10.16.1
+ENV NODE_VERSION 10.16.2
 
 RUN ARCH= && dpkgArch="$(dpkg --print-architecture)" \
   && case "${dpkgArch##*-}" in \

--- a/12/alpine/Dockerfile
+++ b/12/alpine/Dockerfile
@@ -1,6 +1,6 @@
 FROM alpine:3.9
 
-ENV NODE_VERSION 12.7.0
+ENV NODE_VERSION 12.8.0
 
 RUN addgroup -g 1000 node \
     && adduser -u 1000 -G node -s /bin/sh -D node \

--- a/12/buster-slim/Dockerfile
+++ b/12/buster-slim/Dockerfile
@@ -3,7 +3,7 @@ FROM debian:buster-slim
 RUN groupadd --gid 1000 node \
   && useradd --uid 1000 --gid node --shell /bin/bash --create-home node
 
-ENV NODE_VERSION 12.7.0
+ENV NODE_VERSION 12.8.0
 
 RUN buildDeps='xz-utils' \
     && ARCH= && dpkgArch="$(dpkg --print-architecture)" \

--- a/12/buster/Dockerfile
+++ b/12/buster/Dockerfile
@@ -3,7 +3,7 @@ FROM buildpack-deps:buster
 RUN groupadd --gid 1000 node \
   && useradd --uid 1000 --gid node --shell /bin/bash --create-home node
 
-ENV NODE_VERSION 12.7.0
+ENV NODE_VERSION 12.8.0
 
 RUN ARCH= && dpkgArch="$(dpkg --print-architecture)" \
   && case "${dpkgArch##*-}" in \

--- a/12/stretch-slim/Dockerfile
+++ b/12/stretch-slim/Dockerfile
@@ -3,7 +3,7 @@ FROM debian:stretch-slim
 RUN groupadd --gid 1000 node \
   && useradd --uid 1000 --gid node --shell /bin/bash --create-home node
 
-ENV NODE_VERSION 12.7.0
+ENV NODE_VERSION 12.8.0
 
 RUN buildDeps='xz-utils' \
     && ARCH= && dpkgArch="$(dpkg --print-architecture)" \

--- a/12/stretch/Dockerfile
+++ b/12/stretch/Dockerfile
@@ -3,7 +3,7 @@ FROM buildpack-deps:stretch
 RUN groupadd --gid 1000 node \
   && useradd --uid 1000 --gid node --shell /bin/bash --create-home node
 
-ENV NODE_VERSION 12.7.0
+ENV NODE_VERSION 12.8.0
 
 RUN ARCH= && dpkgArch="$(dpkg --print-architecture)" \
   && case "${dpkgArch##*-}" in \


### PR DESCRIPTION
Update node.js v10 from v10.16.1 to v10.16.2
    
    - https://nodejs.org/en/blog/release/v10.16.2/
    - https://github.com/nodejs/node/releases/tag/v10.16.2
    - https://github.com/nodejs/node/blob/master/doc/changelogs/CHANGELOG_V10.md#10.16.2

Update node.js v12 from v12.6.0 to v12.7.0
    
    - https://nodejs.org/en/blog/release/v12.7.0/
    - https://github.com/nodejs/node/releases/tag/v12.7.0
    - https://github.com/nodejs/node/blob/master/doc/changelogs/CHANGELOG_V12.md#12.7.0
