### PR TITLE
Switch to recommend node version

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ See: http://nodejs.org
 
 ```dockerfile
 # specify the node base image with your desired version node:<version>
-FROM node:6
+FROM node:10
 # replace this with your application's default port
 EXPOSE 8888
 ```


### PR DESCRIPTION
The current recommend node version is 10.

Source: https://nodejs.org/en/

So don't have a competing recommendation in this file.