### PR TITLE
docs(BestPractices.md/Handling Kernel Signals): fix

### DIFF
--- a/docs/BestPractices.md
+++ b/docs/BestPractices.md
@@ -64,7 +64,7 @@ RUN apk add --no-cache --virtual .build-deps-yarn curl \
 
 ## Handling Kernel Signals
 
-Node.js was not designed to run as PID 1 which leads to unexpected behaviour when running inside of Docker. For example, a Node.js process running as PID 1 will not respond to `SIGTERM` (`CTRL-C`) and similar signals. As of Docker 1.13, you can use the `--init` flag to wrap your Node.js process with a [lightweight init system](https://github.com/krallin/tini) that properly handles running as PID 1.
+Node.js was not designed to run as PID 1 which leads to unexpected behaviour when running inside of Docker. For example, a Node.js process running as PID 1 will not respond to `SIGINT` (`CTRL-C`) and similar signals. As of Docker 1.13, you can use the `--init` flag to wrap your Node.js process with a [lightweight init system](https://github.com/krallin/tini) that properly handles running as PID 1.
 
 ```
 docker run -it --init node


### PR DESCRIPTION
`CTRL-C` sends `SIGINT` signal, not `SIGTERM`.