### PR TITLE
redundant line in example

### DIFF
--- a/docs/BestPractices.md
+++ b/docs/BestPractices.md
@@ -176,8 +176,6 @@ FROM node:alpine as builder
 RUN apk add --no-cache python make g++
 RUN npm install [ your npm dependencies here ]
 
-FROM node:alpine as app
-
 ## Copy built node modules and binaries without including the toolchain
 COPY --from=builder node_modules .
 ```


### PR DESCRIPTION
think it's redundant (FROM node:alpine as app), as builder is used in the next line?