### PR TITLE
Replace`arch` with `apk --print-arch` in Dockerfile-alpine.template

### DIFF
--- a/Dockerfile-alpine.template
+++ b/Dockerfile-alpine.template
@@ -8,7 +8,7 @@ RUN addgroup -g 1000 node \
         libstdc++ \
     && apk add --no-cache --virtual .build-deps \
         curl \
-    && ARCH= && alpineArch="$(arch)" \
+    && ARCH= && alpineArch="$(apk --print-arch)" \
       && case "${alpineArch##*-}" in \
         x86_64) \
           ARCH='x64' \


### PR DESCRIPTION
As suggested by @tianon in docker-library/official-images#6871