### PR TITLE
Fix architectures lists for consistency and correctness

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -305,6 +305,13 @@ jobs:
 
     - stage: Build
       before_script: *auto_skip
+      name: 8 on onbuild
+      env:
+        - NODE_VERSION="8"
+        - VARIANT="onbuild"
+
+    - stage: Build
+      before_script: *auto_skip
       name: chakracore/10 on default
       env:
         - NODE_VERSION="chakracore/10"

--- a/13/architectures
+++ b/13/architectures
@@ -1,8 +1,8 @@
 bashbrew-arch   variants
-amd64    alpine,stretch,stretch-slim,buster,buster-slim
-arm32v6  alpine
-arm32v7  alpine,stretch,stretch-slim,buster,buster-slim
-arm64v8  alpine,stretch,stretch-slim,buster,buster-slim
-i386     alpine
-ppc64le  alpine,stretch,stretch-slim,buster,buster-slim
-s390x    alpine,stretch,stretch-slim,buster,buster-slim
+amd64    stretch,stretch-slim,buster,buster-slim,alpine3.10
+arm32v6  alpine3.10
+arm32v7  stretch,stretch-slim,buster,buster-slim,alpine3.10
+arm64v8  stretch,stretch-slim,buster,buster-slim,alpine3.10
+i386     alpine3.10
+ppc64le  stretch,stretch-slim,buster,buster-slim,alpine3.10
+s390x    stretch,stretch-slim,buster,buster-slim,alpine3.10

--- a/8/architectures
+++ b/8/architectures
@@ -3,6 +3,6 @@ amd64    jessie,jessie-slim,stretch,stretch-slim,buster,buster-slim,alpine3.9,al
 arm32v6  alpine3.9,alpine3.10
 arm32v7  jessie,jessie-slim,stretch,stretch-slim,buster,buster-slim,alpine3.9,alpine3.10,onbuild
 arm64v8  stretch,stretch-slim,buster,buster-slim,alpine3.9,alpine3.10,onbuild
-i386     jessie,jessie-slim,alpine,stretch-slim,buster,buster-slim,alpine3.9,alpine3.10,onbuild
+i386     jessie,jessie-slim,stretch,stretch-slim,buster,buster-slim,alpine3.9,alpine3.10,onbuild
 ppc64le  stretch,stretch-slim,buster,buster-slim,alpine3.9,alpine3.10,onbuild
 s390x    stretch,stretch-slim,buster,buster-slim,alpine3.9,alpine3.10,onbuild

--- a/architectures
+++ b/architectures
@@ -1,8 +1,8 @@
 bashbrew-arch   variants
-amd64    jessie,jessie-slim,stretch,stretch-slim,buster,buster-slim,alpine3.9,alpine3.10
-arm32v6  jessie,jessie-slim,stretch,stretch-slim,buster,buster-slim,alpine3.9,alpine3.10
-arm32v7  jessie,jessie-slim,stretch,stretch-slim,buster,buster-slim,alpine3.9,alpine3.10
-arm64v8  jessie,jessie-slim,stretch,stretch-slim,buster,buster-slim,alpine3.9,alpine3.10
-i386     jessie,jessie-slim,stretch,stretch-slim,buster,buster-slim,alpine3.9,alpine3.10
-ppc64le  jessie,jessie-slim,stretch,stretch-slim,buster,buster-slim,alpine3.9,alpine3.10
-s390x    jessie,jessie-slim,stretch,stretch-slim,buster,buster-slim,alpine3.9,alpine3.10
+amd64    jessie,jessie-slim,stretch,stretch-slim,buster,buster-slim,alpine3.9,alpine3.10,onbuild
+arm32v6  jessie,jessie-slim,stretch,stretch-slim,buster,buster-slim,alpine3.9,alpine3.10,onbuild
+arm32v7  jessie,jessie-slim,stretch,stretch-slim,buster,buster-slim,alpine3.9,alpine3.10,onbuild
+arm64v8  jessie,jessie-slim,stretch,stretch-slim,buster,buster-slim,alpine3.9,alpine3.10,onbuild
+i386     jessie,jessie-slim,stretch,stretch-slim,buster,buster-slim,alpine3.9,alpine3.10,onbuild
+ppc64le  jessie,jessie-slim,stretch,stretch-slim,buster,buster-slim,alpine3.9,alpine3.10,onbuild
+s390x    jessie,jessie-slim,stretch,stretch-slim,buster,buster-slim,alpine3.9,alpine3.10,onbuild


### PR DESCRIPTION
This addresses the failure from https://github.com/docker-library/official-images/pull/6972#discussion_r346550004.

<details>
<summary>Diff:</summary>

```diff
$ diff -u <(bashbrew cat node) <(bashbrew cat <(./generate-stackbrew-library.sh))
--- /dev/fd/63	2019-11-14 13:22:15.381053187 -0800
+++ /dev/fd/62	2019-11-14 13:22:15.381053187 -0800
@@ -11,16 +11,6 @@
 GitCommit: fa27514a3fd775e1cb6bddac326f6f97dad05fb2
 Directory: 8/jessie-slim
 
-Tags: 8.16.2-alpine, 8.16-alpine, 8-alpine, carbon-alpine
-Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 93c5e098567620200e5a374622a86b4aff153506
-Directory: 8/alpine
-
-Tags: 8.16.2-onbuild, 8.16-onbuild, 8-onbuild, carbon-onbuild
-Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: fa27514a3fd775e1cb6bddac326f6f97dad05fb2
-Directory: 8/onbuild
-
 Tags: 8.16.2-stretch, 8.16-stretch, 8-stretch, carbon-stretch, 8.16.2, 8.16, 8, carbon
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: fa27514a3fd775e1cb6bddac326f6f97dad05fb2
@@ -41,10 +31,20 @@
 GitCommit: fa27514a3fd775e1cb6bddac326f6f97dad05fb2
 Directory: 8/buster-slim
 
-Tags: 13.1.0-alpine, 13.1-alpine, 13-alpine, alpine
+Tags: 8.16.2-alpine3.9, 8.16-alpine3.9, 8-alpine3.9, carbon-alpine3.9
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: bf40ad9d1c903c9d0d7ad71f0c1d7aea92f2051a
-Directory: 13/alpine
+GitCommit: c6bc44e84afcdb81d9749b7b034c60e916a519ad
+Directory: 8/alpine3.9
+
+Tags: 8.16.2-alpine3.10, 8.16-alpine3.10, 8-alpine3.10, carbon-alpine3.10, 8.16.2-alpine, 8.16-alpine, 8-alpine, carbon-alpine
+Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
+GitCommit: c6bc44e84afcdb81d9749b7b034c60e916a519ad
+Directory: 8/alpine3.10
+
+Tags: 8.16.2-onbuild, 8.16-onbuild, 8-onbuild, carbon-onbuild
+Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
+GitCommit: fa27514a3fd775e1cb6bddac326f6f97dad05fb2
+Directory: 8/onbuild
 
 Tags: 13.1.0-stretch, 13.1-stretch, 13-stretch, stretch, 13.1.0, 13.1, 13, latest
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
@@ -66,10 +66,10 @@
 GitCommit: bf40ad9d1c903c9d0d7ad71f0c1d7aea92f2051a
 Directory: 13/buster-slim
 
-Tags: 12.13.0-alpine, 12.13-alpine, 12-alpine, erbium-alpine, lts-alpine, current-alpine
+Tags: 13.1.0-alpine3.10, 13.1-alpine3.10, 13-alpine3.10, alpine3.10, 13.1.0-alpine, 13.1-alpine, 13-alpine, alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 93c5e098567620200e5a374622a86b4aff153506
-Directory: 12/alpine
+GitCommit: c6bc44e84afcdb81d9749b7b034c60e916a519ad
+Directory: 13/alpine3.10
 
 Tags: 12.13.0-stretch, 12.13-stretch, 12-stretch, erbium-stretch, lts-stretch, current-stretch, 12.13.0, 12.13, 12, erbium, lts, current
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
@@ -91,6 +91,16 @@
 GitCommit: c31a071c73c5cc40dc662b75a4ee9f9fc23d6a39
 Directory: 12/buster-slim
 
+Tags: 12.13.0-alpine3.9, 12.13-alpine3.9, 12-alpine3.9, erbium-alpine3.9, lts-alpine3.9, current-alpine3.9
+Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
+GitCommit: c6bc44e84afcdb81d9749b7b034c60e916a519ad
+Directory: 12/alpine3.9
+
+Tags: 12.13.0-alpine3.10, 12.13-alpine3.10, 12-alpine3.10, erbium-alpine3.10, lts-alpine3.10, current-alpine3.10, 12.13.0-alpine, 12.13-alpine, 12-alpine, erbium-alpine, lts-alpine, current-alpine
+Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
+GitCommit: c6bc44e84afcdb81d9749b7b034c60e916a519ad
+Directory: 12/alpine3.10
+
 Tags: 10.17.0-jessie, 10.17-jessie, 10-jessie, dubnium-jessie
 Architectures: amd64, arm32v7
 GitCommit: f5875531604b4b3b9fbc36437182781c3655c8ae
@@ -101,11 +111,6 @@
 GitCommit: f5875531604b4b3b9fbc36437182781c3655c8ae
 Directory: 10/jessie-slim
 
-Tags: 10.17.0-alpine, 10.17-alpine, 10-alpine, dubnium-alpine
-Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 93c5e098567620200e5a374622a86b4aff153506
-Directory: 10/alpine
-
 Tags: 10.17.0-stretch, 10.17-stretch, 10-stretch, dubnium-stretch, 10.17.0, 10.17, 10, dubnium
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
 GitCommit: f5875531604b4b3b9fbc36437182781c3655c8ae
@@ -126,10 +131,20 @@
 GitCommit: f5875531604b4b3b9fbc36437182781c3655c8ae
 Directory: 10/buster-slim
 
+Tags: 10.17.0-alpine3.9, 10.17-alpine3.9, 10-alpine3.9, dubnium-alpine3.9
+Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
+GitCommit: c6bc44e84afcdb81d9749b7b034c60e916a519ad
+Directory: 10/alpine3.9
+
+Tags: 10.17.0-alpine3.10, 10.17-alpine3.10, 10-alpine3.10, dubnium-alpine3.10, 10.17.0-alpine, 10.17-alpine, 10-alpine, dubnium-alpine
+Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
+GitCommit: c6bc44e84afcdb81d9749b7b034c60e916a519ad
+Directory: 10/alpine3.10
+
 Tags: chakracore-8.11.1, chakracore-8.11, chakracore-8
-GitCommit: 2c75ae92f8257f7c6306a39f1e46303b29efce0d
+GitCommit: 8ccd57c1457a1b47adc4d82f9fed9ad51ccef3c5
 Directory: chakracore/8
 
 Tags: chakracore-10.13.0, chakracore-10.13, chakracore-10, chakracore
-GitCommit: 2c75ae92f8257f7c6306a39f1e46303b29efce0d
+GitCommit: 69c8a5f448f46f9e34d7fb577eca79ba01f6864d
 Directory: chakracore/10
````

</details>