### PR TITLE
Fix update.sh example with slim

### DIFF
--- a/update.sh
+++ b/update.sh
@@ -10,14 +10,14 @@ function usage() {
     $0 [-s] [MAJOR_VERSION(S)] [VARIANT(S)]
 
   Examples:
-    - update.sh                   # Update all images
-    - update.sh -s                # Update all images, skip updating Alpine and Yarn
-    - update.sh 8,10              # Update version 8 and 10 and variants (default, slim, alpine etc.)
-    - update.sh -s 8              # Update version 8 and variants, skip updating Alpine and Yarn
-    - update.sh 8 slim,stretch    # Update only slim and stretch variants for version 8
-    - update.sh -s 8 slim,stretch # Update only slim and stretch variants for version 8, skip updating Alpine and Yarn
-    - update.sh . alpine          # Update the alpine variant for all versions
-    - update.sh -t                # Update .travis.yml only
+    - update.sh                      # Update all images
+    - update.sh -s                   # Update all images, skip updating Alpine and Yarn
+    - update.sh 8,10                 # Update all variants of version 8 and 10
+    - update.sh -s 8                 # Update version 8 and variants, skip updating Alpine and Yarn
+    - update.sh 8 buster-slim,buster # Update only buster's slim and buster variants for version 8
+    - update.sh -s 8 stretch         # Update only stretch variant for version 8, skip updating Alpine and Yarn
+    - update.sh . alpine             # Update the alpine variant for all versions
+    - update.sh -t                   # Update .travis.yml only
 
   OPTIONS:
     -s Security update; skip updating the yarn and alpine versions.


### PR DESCRIPTION
Invoking update.sh with `slim` variant did not work, because slim
variants are always tied to Debian version (e.g. stretch, buster).