### PR TITLE
Fix update.sh invocation with unknown variant

### DIFF
--- a/update.sh
+++ b/update.sh
@@ -97,7 +97,7 @@ function in_variants_to_update() {
   local variant=$1
 
   if [ "${#update_variants[@]}" -eq 0 ]; then
-    echo 0
+    echo 1
     return
   fi
 


### PR DESCRIPTION
If update.sh was invoked with non-existing variant, it updated all
variants.  Change in_variants_to_update to return true always if
second variant argument was not given, but not when given variant
argument does not match to available variants.