### PR TITLE
docs: update contributing to mentions security yarn releases

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,7 +8,7 @@ New **Node.js** releases are released as soon as possible.
 
 New **NPM** releases are not tracked. We simply use the NPM version bundled in the corresponding Node.js release.
 
-**Yarn** is updated to the latest version only when there is a new Node.js SemVer PATCH release, and it's updated only in the branch with the new release, preferably in the same PR. The `update.sh` script does this automatically when invoked with a specific branch, e.g. `./update.sh 6.10`.
+**Yarn** is updated to the latest version only when there is a new Node.js SemVer PATCH release (unless Yarn has received a security update), and it's updated only in the branch with the new release, preferably in the same PR. The `update.sh` script does this automatically when invoked with a specific branch, e.g. `./update.sh 6.10`.
 
 ## Adding dependencies to the base images
 


### PR DESCRIPTION
@PeterDaveHello brought up a great point in https://github.com/nodejs/docker-node/pull/1170#discussion_r359206734 - our current policy states that we only update yarn when there's new releases of node. I somewhat regret just moving on instead of backing out those changes and discussing. However, I think we _should_ update it on security updates, so here's a PR with a policy update