### PR TITLE
GitHub actions

### DIFF
--- a/.github/workflows/doctoc.yml
+++ b/.github/workflows/doctoc.yml
@@ -1,0 +1,27 @@
+name: Check generated TOCs
+
+on:
+  pull_request:
+    paths:
+      - "README.md"
+      - "docs/BestPractices.md"
+
+jobs:
+  doctoc:
+    name: Doc TOC Check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v1
+        with:
+          node-version: '12.x'
+      - name: Install doctoc
+        run: npm i -g doctoc
+      - name: Create README copy and diff with doctoc
+        run: cp README.md README.md.tmp &&
+          doctoc --title='## Table of Contents' --github README.md &&
+          diff -q README.md README.md.tmp
+      - name: Create "docs/BestPractices.md" copy and diff with doctoc
+        run: cp docs/BestPractices.md docs/BestPractices.md.tmp &&
+          doctoc --title='## Table of Contents' --github docs/BestPractices.md &&
+          diff -q docs/BestPractices.md docs/BestPractices.md.tmp

--- a/.github/workflows/eclint.yml
+++ b/.github/workflows/eclint.yml
@@ -1,0 +1,14 @@
+name: Test Whitespace and line endings
+
+on: [pull_request]
+
+jobs:
+  eclint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v1
+        with:
+          node-version: '12.x'
+      - run: npm i -g eclint
+      - run: eclint check

--- a/.github/workflows/markdown-link-check.yml
+++ b/.github/workflows/markdown-link-check.yml
@@ -1,0 +1,19 @@
+name: Check Markdown links
+
+on:
+  pull_request:
+    paths:
+      - "**/*.md"
+
+jobs:
+  markdown-link-check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v1
+        with:
+          node-version: '12.x'
+      - name: Install markdown-link-check
+        run: npm i -g markdown-link-check
+      - name: Run markdown-link-check on MD files
+        run: find . -name "*.md" | xargs -n 1 markdown-link-check -q

--- a/.github/workflows/shfmt.yml
+++ b/.github/workflows/shfmt.yml
@@ -1,0 +1,20 @@
+name: Check Shell scripts
+
+on:
+  pull_request:
+    paths:
+      - "**/*.sh"
+
+jobs:
+  shfmt:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+      - run: docker run -v "$(pwd)":/sh -w /sh peterdavehello/shfmt:2.6.3 shfmt -sr -i 2 -l -w -ci .
+      - run: git diff --color --exit-code
+
+  shellcheck:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+      - run: shellcheck *.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -58,17 +58,6 @@ jobs:
         - find . -name "*.md" | xargs -n 1 markdown-link-check
 
     - stage: Test
-      name: shfmt check
-      script:
-        - docker run -it --rm -v "$(pwd)":/sh -w /sh peterdavehello/shfmt:2.6.3 shfmt -sr -i 2 -l -w -ci .
-        - git diff --color
-        - git diff --stat=220 --color --exit-code
-
-    - stage: Test
-      name: Shell Check
-      script: shellcheck *.sh
-
-    - stage: Test
       name: .travis.yml and travis.yml.template consistency
       script:
         - ./update.sh -t

--- a/.travis.yml
+++ b/.travis.yml
@@ -40,23 +40,8 @@ stages:
 
 jobs:
   fast_finish: true
-  allow_failures:
-    - env:
-        - TEST=mardown_lint
 
   include:
-    - stage: Test
-      name: Markdown link check
-      env:
-        - TEST=mardown_lint
-      language: node_js
-      node_js:
-        - lts/*
-      install:
-        - npm i -g markdown-link-check
-      script:
-        - find . -name "*.md" | xargs -n 1 markdown-link-check
-
     - stage: Test
       name: .travis.yml and travis.yml.template consistency
       script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -58,17 +58,6 @@ jobs:
         - find . -name "*.md" | xargs -n 1 markdown-link-check
 
     - stage: Test
-      name: Doc Toc Check
-      language: node_js
-      node_js:
-        - lts/*
-      install: npm i -g doctoc
-      script:
-        - cp README.md README.md.tmp &&
-          doctoc --title='## Table of Contents' --github README.md &&
-          diff -q README.md README.md.tmp
-
-    - stage: Test
       name: shfmt check
       script:
         - docker run -it --rm -v "$(pwd)":/sh -w /sh peterdavehello/shfmt:2.6.3 shfmt -sr -i 2 -l -w -ci .

--- a/.travis.yml
+++ b/.travis.yml
@@ -58,16 +58,6 @@ jobs:
         - find . -name "*.md" | xargs -n 1 markdown-link-check
 
     - stage: Test
-      name: Editor Config check
-      language: node_js
-      node_js:
-        - lts/*
-      install:
-        - npm i -g eclint
-      script:
-        - eclint check
-
-    - stage: Test
       name: Doc Toc Check
       language: node_js
       node_js:

--- a/travis.yml.template
+++ b/travis.yml.template
@@ -56,16 +56,6 @@ jobs:
         - find . -name "*.md" | xargs -n 1 markdown-link-check
 
     - stage: Test
-      name: Editor Config check
-      language: node_js
-      node_js:
-        - lts/*
-      install:
-        - npm i -g eclint
-      script:
-        - eclint check
-
-    - stage: Test
       name: Doc Toc Check
       language: node_js
       node_js:

--- a/travis.yml.template
+++ b/travis.yml.template
@@ -56,17 +56,6 @@ jobs:
         - find . -name "*.md" | xargs -n 1 markdown-link-check
 
     - stage: Test
-      name: shfmt check
-      script:
-        - docker run -it --rm -v "$(pwd)":/sh -w /sh peterdavehello/shfmt:2.6.3 shfmt -sr -i 2 -l -w -ci .
-        - git diff --color
-        - git diff --stat=220 --color --exit-code
-
-    - stage: Test
-      name: Shell Check
-      script: shellcheck *.sh
-
-    - stage: Test
       name: .travis.yml and travis.yml.template consistency
       script:
         - ./update.sh -t

--- a/travis.yml.template
+++ b/travis.yml.template
@@ -38,23 +38,8 @@ stages:
 
 jobs:
   fast_finish: true
-  allow_failures:
-    - env:
-        - TEST=mardown_lint
 
   include:
-    - stage: Test
-      name: Markdown link check
-      env:
-        - TEST=mardown_lint
-      language: node_js
-      node_js:
-        - lts/*
-      install:
-        - npm i -g markdown-link-check
-      script:
-        - find . -name "*.md" | xargs -n 1 markdown-link-check
-
     - stage: Test
       name: .travis.yml and travis.yml.template consistency
       script:

--- a/travis.yml.template
+++ b/travis.yml.template
@@ -56,17 +56,6 @@ jobs:
         - find . -name "*.md" | xargs -n 1 markdown-link-check
 
     - stage: Test
-      name: Doc Toc Check
-      language: node_js
-      node_js:
-        - lts/*
-      install: npm i -g doctoc
-      script:
-        - cp README.md README.md.tmp &&
-          doctoc --title='## Table of Contents' --github README.md &&
-          diff -q README.md README.md.tmp
-
-    - stage: Test
       name: shfmt check
       script:
         - docker run -it --rm -v "$(pwd)":/sh -w /sh peterdavehello/shfmt:2.6.3 shfmt -sr -i 2 -l -w -ci .


### PR DESCRIPTION
Pulls a few of the minor ones over to GitHub actions to reduce the Travis load. This also has a little better built in job filtering, so if affected files in the "path" values doesn't match, it doesn't even launch a job.
I did some testing on the path executions on my fork, but I can add some dummy commits to show it if you want.