### PR TITLE
Update Node.js v13 for Alpine to v13.8.0

### DIFF
--- a/13/alpine3.10/Dockerfile
+++ b/13/alpine3.10/Dockerfile
@@ -1,6 +1,6 @@
 FROM alpine:3.10
 
-ENV NODE_VERSION 13.7.0
+ENV NODE_VERSION 13.8.0
 
 RUN addgroup -g 1000 node \
     && adduser -u 1000 -G node -s /bin/sh -D node \
@@ -12,7 +12,7 @@ RUN addgroup -g 1000 node \
       && case "${alpineArch##*-}" in \
         x86_64) \
           ARCH='x64' \
-          CHECKSUM="4c153345a08d2eeb40dfbb62f1ef6ade7ec369630f9cf9f061bf9d52b10acafc" \
+          CHECKSUM="3325ec0bff602d30222e0c6c6af81aefa04d7d20946bac65d55dbb09d7d7e1e0" \
           ;; \
         *) ;; \
       esac \

--- a/13/alpine3.11/Dockerfile
+++ b/13/alpine3.11/Dockerfile
@@ -1,6 +1,6 @@
 FROM alpine:3.11
 
-ENV NODE_VERSION 13.7.0
+ENV NODE_VERSION 13.8.0
 
 RUN addgroup -g 1000 node \
     && adduser -u 1000 -G node -s /bin/sh -D node \
@@ -12,7 +12,7 @@ RUN addgroup -g 1000 node \
       && case "${alpineArch##*-}" in \
         x86_64) \
           ARCH='x64' \
-          CHECKSUM="4c153345a08d2eeb40dfbb62f1ef6ade7ec369630f9cf9f061bf9d52b10acafc" \
+          CHECKSUM="3325ec0bff602d30222e0c6c6af81aefa04d7d20946bac65d55dbb09d7d7e1e0" \
           ;; \
         *) ;; \
       esac \


### PR DESCRIPTION
v13 update for Alpine Linux was missing due to the delay of unofficial
build for Alpine.

, cc #1209