### PR TITLE
chore: upgrade to node 12.16.1

### DIFF
--- a/12/alpine3.10/Dockerfile
+++ b/12/alpine3.10/Dockerfile
@@ -1,6 +1,6 @@
 FROM alpine:3.10
 
-ENV NODE_VERSION 12.16.0
+ENV NODE_VERSION 12.16.1
 
 RUN addgroup -g 1000 node \
     && adduser -u 1000 -G node -s /bin/sh -D node \
@@ -12,7 +12,7 @@ RUN addgroup -g 1000 node \
       && case "${alpineArch##*-}" in \
         x86_64) \
           ARCH='x64' \
-          CHECKSUM="c7c38c170c38a491ecffbd5324415818f88abc2a6a79076493c1028a19bf64df" \
+          CHECKSUM="7606d86e842b710e4321fe1c7f7a32a8e145f5e0659de406399cda5a37411d92" \
           ;; \
         *) ;; \
       esac \

--- a/12/alpine3.11/Dockerfile
+++ b/12/alpine3.11/Dockerfile
@@ -1,6 +1,6 @@
 FROM alpine:3.11
 
-ENV NODE_VERSION 12.16.0
+ENV NODE_VERSION 12.16.1
 
 RUN addgroup -g 1000 node \
     && adduser -u 1000 -G node -s /bin/sh -D node \
@@ -12,7 +12,7 @@ RUN addgroup -g 1000 node \
       && case "${alpineArch##*-}" in \
         x86_64) \
           ARCH='x64' \
-          CHECKSUM="c7c38c170c38a491ecffbd5324415818f88abc2a6a79076493c1028a19bf64df" \
+          CHECKSUM="7606d86e842b710e4321fe1c7f7a32a8e145f5e0659de406399cda5a37411d92" \
           ;; \
         *) ;; \
       esac \

--- a/12/alpine3.9/Dockerfile
+++ b/12/alpine3.9/Dockerfile
@@ -1,6 +1,6 @@
 FROM alpine:3.9
 
-ENV NODE_VERSION 12.16.0
+ENV NODE_VERSION 12.16.1
 
 RUN addgroup -g 1000 node \
     && adduser -u 1000 -G node -s /bin/sh -D node \
@@ -12,7 +12,7 @@ RUN addgroup -g 1000 node \
       && case "${alpineArch##*-}" in \
         x86_64) \
           ARCH='x64' \
-          CHECKSUM="c7c38c170c38a491ecffbd5324415818f88abc2a6a79076493c1028a19bf64df" \
+          CHECKSUM="7606d86e842b710e4321fe1c7f7a32a8e145f5e0659de406399cda5a37411d92" \
           ;; \
         *) ;; \
       esac \

--- a/12/buster-slim/Dockerfile
+++ b/12/buster-slim/Dockerfile
@@ -3,7 +3,7 @@ FROM debian:buster-slim
 RUN groupadd --gid 1000 node \
   && useradd --uid 1000 --gid node --shell /bin/bash --create-home node
 
-ENV NODE_VERSION 12.16.0
+ENV NODE_VERSION 12.16.1
 
 RUN ARCH= && dpkgArch="$(dpkg --print-architecture)" \
     && case "${dpkgArch##*-}" in \

--- a/12/buster/Dockerfile
+++ b/12/buster/Dockerfile
@@ -3,7 +3,7 @@ FROM buildpack-deps:buster
 RUN groupadd --gid 1000 node \
   && useradd --uid 1000 --gid node --shell /bin/bash --create-home node
 
-ENV NODE_VERSION 12.16.0
+ENV NODE_VERSION 12.16.1
 
 RUN ARCH= && dpkgArch="$(dpkg --print-architecture)" \
   && case "${dpkgArch##*-}" in \

--- a/12/stretch-slim/Dockerfile
+++ b/12/stretch-slim/Dockerfile
@@ -3,7 +3,7 @@ FROM debian:stretch-slim
 RUN groupadd --gid 1000 node \
   && useradd --uid 1000 --gid node --shell /bin/bash --create-home node
 
-ENV NODE_VERSION 12.16.0
+ENV NODE_VERSION 12.16.1
 
 RUN ARCH= && dpkgArch="$(dpkg --print-architecture)" \
     && case "${dpkgArch##*-}" in \

--- a/12/stretch/Dockerfile
+++ b/12/stretch/Dockerfile
@@ -3,7 +3,7 @@ FROM buildpack-deps:stretch
 RUN groupadd --gid 1000 node \
   && useradd --uid 1000 --gid node --shell /bin/bash --create-home node
 
-ENV NODE_VERSION 12.16.0
+ENV NODE_VERSION 12.16.1
 
 RUN ARCH= && dpkgArch="$(dpkg --print-architecture)" \
   && case "${dpkgArch##*-}" in \


### PR DESCRIPTION
https://nodejs.org/en/blog/release/v12.16.1/

13.9 has been released as well (https://github.com/nodejs/node/releases/tag/v13.9.0) but no blog post or Alpine release yet