### PR TITLE
chore: tag node v14 as current

### DIFF
--- a/generate-stackbrew-library.sh
+++ b/generate-stackbrew-library.sh
@@ -9,11 +9,11 @@ hash git 2> /dev/null || { echo >&2 "git not found, exiting."; }
 # shellcheck disable=SC2034
 array_10='10 dubnium'
 # shellcheck disable=SC2034
-array_12='12 erbium lts current'
+array_12='12 erbium lts'
 # shellcheck disable=SC2034
 array_13='13'
 # shellcheck disable=SC2034
-array_14='14 latest'
+array_14='14 latest current'
 
 default_variant=$(get_config "./" "default_variant")
 


### PR DESCRIPTION
why is 12 `current`? do we mean it's `current lts`? `current` in node terms is equivalent to `latest` in docker terms.