### PR TITLE
Add new bare image tag

### DIFF
--- a/14/scratch/Dockerfile
+++ b/14/scratch/Dockerfile
@@ -1,0 +1,117 @@
+FROM alpine:3.10 as builder
+
+ENV NODE_VERSION 14.4.0
+
+RUN addgroup -g 1000 node \
+    && adduser -u 1000 -G node -s /bin/sh -D node \
+    && apk add --no-cache \
+        libstdc++ \
+    && apk add --no-cache --virtual .build-deps \
+        curl \
+    && ARCH= && alpineArch="$(apk --print-arch)" \
+      && case "${alpineArch##*-}" in \
+        x86_64) \
+          ARCH='x64' \
+          CHECKSUM="c33037cadcd6caab8593b1b3f8befad6137b621378462fad24b4100eba879e4c" \
+          ;; \
+        *) ;; \
+      esac \
+  && if [ -n "${CHECKSUM}" ]; then \
+    set -eu; \
+    curl -fsSLO --compressed "https://unofficial-builds.nodejs.org/download/release/v$NODE_VERSION/node-v$NODE_VERSION-linux-$ARCH-musl.tar.xz"; \
+    echo "$CHECKSUM  node-v$NODE_VERSION-linux-$ARCH-musl.tar.xz" | sha256sum -c - \
+      && tar -xJf "node-v$NODE_VERSION-linux-$ARCH-musl.tar.xz" -C /usr/local --strip-components=1 --no-same-owner \
+      && ln -s /usr/local/bin/node /usr/local/bin/nodejs; \
+  else \
+    echo "Building from source" \
+    # backup build
+    && apk add --no-cache --virtual .build-deps-full \
+        binutils-gold \
+        g++ \
+        gcc \
+        gnupg \
+        libgcc \
+        linux-headers \
+        make \
+        python \
+    # gpg keys listed at https://github.com/nodejs/node#release-keys
+    && for key in \
+      94AE36675C464D64BAFA68DD7434390BDBE9B9C5 \
+      FD3A5288F042B6850C66B31F09FE44734EB7990E \
+      71DCFD284A79C3B38668286BC97EC7A07EDE3FC1 \
+      DD8F2338BAE7501E3DD5AC78C273792F7D83545D \
+      C4F0DFFF4E8C1A8236409D08E73BC641CC11F4C8 \
+      B9AE9905FFD7803F25714661B63B535A4C206CA9 \
+      77984A986EBC2AA786BC0F66B01FBB92821C587A \
+      8FCCA13FEF1D0C2E91008E09770F7A9A5AE15600 \
+      4ED778F539E3634C779C87C6D7062848A1AB005C \
+      A48C2BEE680E841632CD4E44F07496B3EB3C1762 \
+      B9E2F5981AA6E0CD28160D9FF13993A75599653C \
+    ; do \
+      gpg --batch --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys "$key" || \
+      gpg --batch --keyserver hkp://ipv4.pool.sks-keyservers.net --recv-keys "$key" || \
+      gpg --batch --keyserver hkp://pgp.mit.edu:80 --recv-keys "$key" ; \
+    done \
+    && curl -fsSLO --compressed "https://nodejs.org/dist/v$NODE_VERSION/node-v$NODE_VERSION.tar.xz" \
+    && curl -fsSLO --compressed "https://nodejs.org/dist/v$NODE_VERSION/SHASUMS256.txt.asc" \
+    && gpg --batch --decrypt --output SHASUMS256.txt SHASUMS256.txt.asc \
+    && grep " node-v$NODE_VERSION.tar.xz\$" SHASUMS256.txt | sha256sum -c - \
+    && tar -xf "node-v$NODE_VERSION.tar.xz" \
+    && cd "node-v$NODE_VERSION" \
+    && ./configure \
+    && make -j$(getconf _NPROCESSORS_ONLN) V= \
+    && make install \
+    && apk del .build-deps-full \
+    && cd .. \
+    && rm -Rf "node-v$NODE_VERSION" \
+    && rm "node-v$NODE_VERSION.tar.xz" SHASUMS256.txt.asc SHASUMS256.txt; \
+  fi \
+  && rm -f "node-v$NODE_VERSION-linux-$ARCH-musl.tar.xz" \
+  && apk del .build-deps \
+  # smoke tests
+  && node --version \
+  && npm --version
+
+RUN  set -x \
+  && apk add --no-cache \
+        binutils \
+  && strip /usr/local/bin/node \
+  && apk del binutils \
+  && rm -rf \
+    /usr/local/lib/node_modules/npm \
+    /usr/local/include/node/ \
+    /usr/local/bin/npm \
+    /usr/local/bin/npx \
+    /usr/local/share \
+    /usr/local/*.md \
+    /usr/share \
+    /usr/bin/getent \
+    /usr/bin/lzmainfo \
+    /usr/bin/ssl_client \
+    /usr/bin/scanelf \
+    /usr/bin/iconv \
+    /usr/bin/getconf \
+    /usr/bin/lzmadec \
+    /usr/bin/xzmore \
+    /usr/bin/xzless \
+    /usr/bin/xzgrep \
+    /usr/bin/xzdiff \
+    /usr/bin/xzdec \
+    /usr/bin/ldd
+
+FROM scratch
+
+ENV NODE_VERSION 14.4.0
+
+COPY docker-entrypoint.sh /usr/local/bin/
+
+COPY --from=builder /etc /etc
+COPY --from=builder /bin /bin
+COPY --from=builder /usr /usr
+COPY --from=builder /lib/ld-musl-x86_64.so.1 /lib/ld-musl-x86_64.so.1
+
+RUN ln -s /lib/ld-musl-x86_64.so.1 /lib/libc.musl-x86_64.so.1
+
+ENTRYPOINT ["docker-entrypoint.sh"]
+
+CMD [ "node" ]

--- a/14/scratch/docker-entrypoint.sh
+++ b/14/scratch/docker-entrypoint.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+set -e
+
+if [ "${1#-}" != "${1}" ] || [ -z "$(command -v "${1}")" ]; then
+  set -- node "$@"
+fi
+
+exec "$@"


### PR DESCRIPTION
## What does this PR do

This PR introduce a new image tag (name proposals: `node:14-scratch`, `node:14-minimal`, `node:14-bare`) which correspond to a minimal image containing only Node binary and it's dependencies (mostly the `libstdc++` and musl).

The image size is `68.9MB` which is 40% smaller than the `14-alpine3.10` image (`117MB`).

If you like the idea I will adds images for other Node version.

**EDIT (2020/07/03):**

This image is now based on `alpine` to benefits from the shell and package manager for only `5MB`.  
The image is `71MB`.  
I've renamed the image tag from `scratch` to `bare`.

## Usage

This image can be used in a multi-stage build:
 - from the `alpine` image, build the application
 - from  the `bare` image, just copy the files

```Dockerfile
FROM node:14-alpine3.10 as builder

COPY . /opt/kuzzle

RUN cd /opt/kuzzle && npm install --production

FROM node:14-bare

COPY --from=builder /opt/kuzzle /opt/kuzzle

CMD ["node", "/opt/kuzzle/bin/start-kuzzle-server"]
```
## Why

When you go to production, you may want to deploy images containing only your application and not your build chain (npm, yarn).
Also there is a lot of unnecessary files like documentation or c headers that you don't need either.

This could allows to save a lot of disk space but also bandwidth for people deploying Node.js applications.

## How

Builder image steps description:
 - use the node 14 alpine 3.10 build steps to download and compile Node
 - strip node binaries
 - remove unnecessary files (NPM, headers, documentation, some binaries)

Then in the final image is built from `alpine` with only Node.js.
