### PR TITLE
Reduce image size

### DIFF
--- a/14/alpine3.10/Dockerfile
+++ b/14/alpine3.10/Dockerfile
@@ -70,7 +70,23 @@ RUN addgroup -g 1000 node \
   && apk del .build-deps \
   # smoke tests
   && node --version \
-  && npm --version
+  && npm --version \
+  # strip node binary
+  && apk add --no-cache \
+        binutils \
+  && strip /usr/local/bin/node \
+  && apk del binutils \
+  # remove unnecessary files
+  && rm -rf \
+    /usr/local/include/node \
+    /usr/local/lib/node_modules/npm/changelogs \
+    /usr/local/lib/node_modules/npm/man \
+    /usr/local/lib/node_modules/npm/docs \
+  && find . -type f \( \
+      -name "*.md" \
+      -name "LICENSE" \
+      -name "*.d.ts" \
+    \) -exec rm {} \;
 
 ENV YARN_VERSION 1.22.4
 
@@ -92,7 +108,12 @@ RUN apk add --no-cache --virtual .build-deps-yarn curl gnupg tar \
   && rm yarn-v$YARN_VERSION.tar.gz.asc yarn-v$YARN_VERSION.tar.gz \
   && apk del .build-deps-yarn \
   # smoke test
-  && yarn --version
+  && yarn --version \
+  # remove unnecessary files
+  && rm -rf \
+    /opt/yarn-*/LICENSE \
+    /opt/yarn-*/README.md \
+    /tmp/v8-compile-cache-*
 
 COPY docker-entrypoint.sh /usr/local/bin/
 ENTRYPOINT ["docker-entrypoint.sh"]

--- a/14/alpine3.10/Dockerfile
+++ b/14/alpine3.10/Dockerfile
@@ -100,7 +100,7 @@ RUN apk add --no-cache --virtual .build-deps-yarn curl gnupg tar \
   && yarn --version \
   # remove unnecessary files
   && rm -rf \
-    /tmp/v8-compile-cache-*
+    /tmp/*
 
 COPY docker-entrypoint.sh /usr/local/bin/
 ENTRYPOINT ["docker-entrypoint.sh"]

--- a/14/alpine3.10/Dockerfile
+++ b/14/alpine3.10/Dockerfile
@@ -71,22 +71,11 @@ RUN addgroup -g 1000 node \
   # smoke tests
   && node --version \
   && npm --version \
-  # strip node binary
-  && apk add --no-cache \
-        binutils \
-  && strip /usr/local/bin/node \
-  && apk del binutils \
   # remove unnecessary files
   && rm -rf \
-    /usr/local/include/node \
     /usr/local/lib/node_modules/npm/changelogs \
     /usr/local/lib/node_modules/npm/man \
-    /usr/local/lib/node_modules/npm/docs \
-  && find . -type f \( \
-      -name "*.md" \
-      -name "LICENSE" \
-      -name "*.d.ts" \
-    \) -exec rm {} \;
+    /usr/local/lib/node_modules/npm/docs
 
 ENV YARN_VERSION 1.22.4
 
@@ -111,8 +100,6 @@ RUN apk add --no-cache --virtual .build-deps-yarn curl gnupg tar \
   && yarn --version \
   # remove unnecessary files
   && rm -rf \
-    /opt/yarn-*/LICENSE \
-    /opt/yarn-*/README.md \
     /tmp/v8-compile-cache-*
 
 COPY docker-entrypoint.sh /usr/local/bin/


### PR DESCRIPTION
## What this PR do?

~This PR reduce the `alpine` image size by 20% from `117MB` to `93.5MB`~.

This PR reduce the `alpine` image size by 7,5% from `117MB` to `108MB`.

 - ~strip node binary (`10MB`)~
 - ~remove c headers (`3.9MB`)~
 - remove documentation (`~6MB`)
 - ~remove unnecessary files such as `LICENSE`~
 - yarn compile cache (`2.3MB`)

If those changes are ok for you, I will do the same for other images.
