### PR TITLE
Document default OS policy and set default variant per node version

### DIFF
--- a/14/config
+++ b/14/config
@@ -1,0 +1,2 @@
+default_variant buster
+alpine_version  3.12

--- a/README.md
+++ b/README.md
@@ -150,6 +150,15 @@ supported architecture, the supported variants are different. In the file:
 [architectures](./architectures), it lists all supported variants for all of
 the architectures that we support now.
 
+Each image flavors is build on the stable release of the base operating system.
+Default operating system release is the latest stable release of given base
+operating system at the time of `node` entering LTS maintenance period or
+initial release, which one is latter.  During the maintenance period of given
+`node` version the base operating system release is not changed as long as
+there is security support.  However during LTS maintenance period of `node`
+it might necessary to change default tag of an image flavor and drop support
+for some operating system releases if the security support ends.
+
 ### `node:<version>`
 
 This is the defacto image. If you are unsure about what your needs are, you

--- a/generate-stackbrew-library.sh
+++ b/generate-stackbrew-library.sh
@@ -55,8 +55,16 @@ get_stub() {
 }
 
 for version in "${versions[@]}"; do
+  if [ -f "./${version}/config" ]; then
+    version_default_variant=$(get_config "./${version}" "default_variant")
+    version_default_alpine=$(get_config "./${version}" "alpine_version")
+  else
+    version_default_variant="${default_variant}"
+    version_default_alpine="${default_alpine}"
+  fi
+
   # Skip "docs" and other non-docker directories
-  [ -f "${version}/Dockerfile" ] || [ -f "${version}/${default_variant}/Dockerfile" ] || continue
+  [ -f "${version}/Dockerfile" ] || [ -f "${version}/${version_default_variant}/Dockerfile" ] || continue
 
   stub=$(get_stub "${version}")
   commit="$(fileCommit "${version}")"
@@ -87,11 +95,11 @@ for version in "${versions[@]}"; do
 
     slash='/'
     variantAliases=("${versionAliases[@]/%/-${variant//${slash}/-}}")
-    if [ "${variant}" = "${default_variant}-slim" ]; then
+    if [ "${variant}" = "${version_default_variant}-slim" ]; then
       variantAliases+=("${versionAliases[@]/%/-slim}")
-    elif [ "${variant}" = "alpine${default_alpine}" ]; then
+    elif [ "${variant}" = "alpine${version_default_alpine}" ]; then
       variantAliases+=("${versionAliases[@]/%/-alpine}")
-    elif [ "${variant}" = "${default_variant}" ]; then
+    elif [ "${variant}" = "${version_default_variant}" ]; then
       variantAliases+=("${versionAliases[@]}")
     fi
     variantAliases=("${variantAliases[@]//latest-/}")


### PR DESCRIPTION
The default operating system release used by `node` images has not been properly documented, and the policy of updating the operating system release underlying a specific `node` release has been causing unexpected behavior when the operating system release had been updated.  The clearest description of the issue was in #1068, which was closed without properly documenting the maintenance policy.

Changes here in `README.md` I'm trying to write down sensible policy of the operating system release. There are arguably also other ways to define the OS release policy than that one.

The policy written and implemented causes different default operating system release to be used per nodejs version. In my opinion this makes sense, because the operating system support period and nodejs maintenance period should be in sync as much as possible.
The policy here defines default operating system release of both Debian and Alpine **per nodejs version** compared to earlier solution of defining the default release shared for all nodejs versions. This allows the operating system support period and nodejs maintenance period to be more in sync. The policy allows changing the underlying default operating system release when specific nodejs version enters LTS maintenance period. IMHO it would make sense to switch default Debian release used with Nodejs v14 to be Debian 10 (buster) instead of Debian 9 (stretch), which it is now, so it does not need to be changed during the Nodejs v14 LTS maintenance period. On the other hand Nodejs v10 LTS maintenance period ends at 2021-04-30, which is earlier than Debian 9 (stretch) extended support, which ends at June 30, 2022, and therefore Nodejs v10 default Debian release should not be changed, just my 0.02 cents. Nodejs v12 LTS maintenance ends at 2022-04-30, which is also before Debian 9 (stretch) extended support ends, which also should not be changed.

I did not analyze Alpine release timeline, but the configuration change here allows also Alpine default tag to be configured per node version.

This also cleans up some chakracore configuration support as it was removed and supporting that complex logic was in conflict of having `config` file per nodejs version.