### PR TITLE
updating Dockerfile-alpine.template

### DIFF
--- a/Dockerfile-alpine.template
+++ b/Dockerfile-alpine.template
@@ -4,10 +4,9 @@ ENV NODE_VERSION 0.0.0
 
 RUN addgroup -g 1000 node \
     && adduser -u 1000 -G node -s /bin/sh -D node \
-    && apk add --no-cache \
-        libstdc++ \
     && apk add --no-cache --virtual .build-deps \
         curl \
+        libstdc++ \
     && ARCH= && alpineArch="$(apk --print-arch)" \
       && case "${alpineArch##*-}" in \
         x86_64) \


### PR DESCRIPTION
updating Dockerfile-alpine.template to include libstdc++ into .build-deps virtual package for correct cleanup
discussion is here https://github.com/nodejs/docker-node/issues/1315