### PR TITLE
Adjust GitHub Action Job names

### DIFF
--- a/.github/workflows/10-alpine3.10.yml
+++ b/.github/workflows/10-alpine3.10.yml
@@ -16,7 +16,7 @@ on:
 
 jobs:
   build:
-    name: 10 on alpine3.10
+    name: test build
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/10-alpine3.11.yml
+++ b/.github/workflows/10-alpine3.11.yml
@@ -16,7 +16,7 @@ on:
 
 jobs:
   build:
-    name: 10 on alpine3.11
+    name: test build
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/10-alpine3.9.yml
+++ b/.github/workflows/10-alpine3.9.yml
@@ -16,7 +16,7 @@ on:
 
 jobs:
   build:
-    name: 10 on alpine3.9
+    name: test build
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/10-buster-slim.yml
+++ b/.github/workflows/10-buster-slim.yml
@@ -16,7 +16,7 @@ on:
 
 jobs:
   build:
-    name: 10 on buster-slim
+    name: test build
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/10-buster.yml
+++ b/.github/workflows/10-buster.yml
@@ -16,7 +16,7 @@ on:
 
 jobs:
   build:
-    name: 10 on buster
+    name: test build
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/10-stretch-slim.yml
+++ b/.github/workflows/10-stretch-slim.yml
@@ -16,7 +16,7 @@ on:
 
 jobs:
   build:
-    name: 10 on stretch-slim
+    name: test build
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/10-stretch.yml
+++ b/.github/workflows/10-stretch.yml
@@ -16,7 +16,7 @@ on:
 
 jobs:
   build:
-    name: 10 on stretch
+    name: test build
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/12-alpine3.10.yml
+++ b/.github/workflows/12-alpine3.10.yml
@@ -16,7 +16,7 @@ on:
 
 jobs:
   build:
-    name: 12 on alpine3.10
+    name: test build
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/12-alpine3.11.yml
+++ b/.github/workflows/12-alpine3.11.yml
@@ -16,7 +16,7 @@ on:
 
 jobs:
   build:
-    name: 12 on alpine3.11
+    name: test build
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/12-alpine3.12.yml
+++ b/.github/workflows/12-alpine3.12.yml
@@ -16,7 +16,7 @@ on:
 
 jobs:
   build:
-    name: 12 on alpine3.12
+    name: test build
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/12-alpine3.9.yml
+++ b/.github/workflows/12-alpine3.9.yml
@@ -16,7 +16,7 @@ on:
 
 jobs:
   build:
-    name: 12 on alpine3.9
+    name: test build
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/12-buster-slim.yml
+++ b/.github/workflows/12-buster-slim.yml
@@ -16,7 +16,7 @@ on:
 
 jobs:
   build:
-    name: 12 on buster-slim
+    name: test build
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/12-buster.yml
+++ b/.github/workflows/12-buster.yml
@@ -16,7 +16,7 @@ on:
 
 jobs:
   build:
-    name: 12 on buster
+    name: test build
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/12-stretch-slim.yml
+++ b/.github/workflows/12-stretch-slim.yml
@@ -16,7 +16,7 @@ on:
 
 jobs:
   build:
-    name: 12 on stretch-slim
+    name: test build
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/12-stretch.yml
+++ b/.github/workflows/12-stretch.yml
@@ -16,7 +16,7 @@ on:
 
 jobs:
   build:
-    name: 12 on stretch
+    name: test build
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/14-alpine3.10.yml
+++ b/.github/workflows/14-alpine3.10.yml
@@ -16,7 +16,7 @@ on:
 
 jobs:
   build:
-    name: 14 on alpine3.10
+    name: test build
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/14-alpine3.11.yml
+++ b/.github/workflows/14-alpine3.11.yml
@@ -16,7 +16,7 @@ on:
 
 jobs:
   build:
-    name: 14 on alpine3.11
+    name: test build
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/14-alpine3.12.yml
+++ b/.github/workflows/14-alpine3.12.yml
@@ -16,7 +16,7 @@ on:
 
 jobs:
   build:
-    name: 14 on alpine3.12
+    name: test build
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/14-buster-slim.yml
+++ b/.github/workflows/14-buster-slim.yml
@@ -16,7 +16,7 @@ on:
 
 jobs:
   build:
-    name: 14 on buster-slim
+    name: test build
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/14-buster.yml
+++ b/.github/workflows/14-buster.yml
@@ -16,7 +16,7 @@ on:
 
 jobs:
   build:
-    name: 14 on buster
+    name: test build
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/14-stretch-slim.yml
+++ b/.github/workflows/14-stretch-slim.yml
@@ -16,7 +16,7 @@ on:
 
 jobs:
   build:
-    name: 14 on stretch-slim
+    name: test build
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/14-stretch.yml
+++ b/.github/workflows/14-stretch.yml
@@ -16,7 +16,7 @@ on:
 
 jobs:
   build:
-    name: 14 on stretch
+    name: test build
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
The job name was duplicated with the top level name.

Maybe just name it as "test build", just like the name of its test script, also, we may add some other  tests in the future, use a different name will be less confusion.

cc #1194