### PR TITLE
fix: Remove 386 architecture for v12 and v14

### DIFF
--- a/12/architectures
+++ b/12/architectures
@@ -3,6 +3,5 @@ amd64    stretch,stretch-slim,buster,buster-slim,alpine3.9,alpine3.10,alpine3.11
 arm32v6  alpine3.9,alpine3.10,alpine3.11,alpine3.12
 arm32v7  stretch,stretch-slim,buster,buster-slim,alpine3.9,alpine3.10,alpine3.11,alpine3.12
 arm64v8  stretch,stretch-slim,buster,buster-slim,alpine3.9,alpine3.10,alpine3.11,alpine3.12
-i386     alpine3.9,alpine3.10,alpine3.11,alpine3.12
 ppc64le  buster,buster-slim,alpine3.9,alpine3.10,alpine3.11,alpine3.12
 s390x    buster,buster-slim,alpine3.9,alpine3.10,alpine3.11,alpine3.12

--- a/14/architectures
+++ b/14/architectures
@@ -3,6 +3,5 @@ amd64    stretch,stretch-slim,buster,buster-slim,alpine3.10,alpine3.11,alpine3.1
 arm32v6  alpine3.10,alpine3.11,alpine3.12
 arm32v7  stretch,stretch-slim,buster,buster-slim,alpine3.10,alpine3.11,alpine3.12
 arm64v8  stretch,stretch-slim,buster,buster-slim,alpine3.10,alpine3.11,alpine3.12
-i386     alpine3.10,alpine3.11,alpine3.12
 ppc64le  buster,buster-slim,alpine3.10,alpine3.11,alpine3.12
 s390x    buster,buster-slim,alpine3.10,alpine3.11,alpine3.12


### PR DESCRIPTION

Official support stopped in v8 and is currnetly all failing in the
official-images CI.
Can be re-enabled if support is fixed