### PR TITLE
fix: Revert default variant changes

### DIFF
--- a/config
+++ b/config
@@ -1,4 +1,4 @@
 baseuri     https://nodejs.org/dist
-default_variant buster
-alpine_version  3.12
+default_variant stretch
+alpine_version  3.11
 debian_versions stretch buster


### PR DESCRIPTION
This changed the defaults for all previous versions. This is a temporary workaround so we can get out the 15 release and look at the overall config management afterwards