### PR TITLE
chore: Sort and sync default architecture file

### DIFF
--- a/architectures
+++ b/architectures
@@ -1,8 +1,8 @@
-bashbrew-arch   variants
-amd64    stretch,stretch-slim,buster,buster-slim,alpine3.9,alpine3.10,alpine3.11,alpine3.12
-arm32v6  stretch,stretch-slim,buster,buster-slim,alpine3.9,alpine3.10,alpine3.11,alpine3.12
-arm32v7  stretch,stretch-slim,buster,buster-slim,alpine3.9,alpine3.10,alpine3.11,alpine3.12
-arm64v8  stretch,stretch-slim,buster,buster-slim,alpine3.9,alpine3.10,alpine3.11,alpine3.12
-i386     stretch,stretch-slim,buster,buster-slim,alpine3.9,alpine3.10,alpine3.11,alpine3.12
-ppc64le  stretch,stretch-slim,buster,buster-slim,alpine3.9,alpine3.10,alpine3.11,alpine3.12
-s390x    stretch,stretch-slim,buster,buster-slim,alpine3.9,alpine3.10,alpine3.11,alpine3.12
+bashbrew-arch  variants
+amd64          alpine3.10,alpine3.11,alpine3.12,alpine3.9,buster,buster-slim,stretch,stretch-slim
+arm32v6        alpine3.10,alpine3.11,alpine3.12,alpine3.9
+arm32v7        alpine3.10,alpine3.11,alpine3.12,alpine3.9,buster,buster-slim,stretch,stretch-slim
+arm64v8        alpine3.10,alpine3.11,alpine3.12,alpine3.9,buster,buster-slim,stretch,stretch-slim
+i386           alpine3.10,alpine3.11,alpine3.12,alpine3.9
+ppc64le        alpine3.10,alpine3.11,alpine3.12,alpine3.9,buster,buster-slim
+s390x          alpine3.10,alpine3.11,alpine3.12,alpine3.9,buster,buster-slim


### PR DESCRIPTION

- Remove slim architectures no longer supported
- Sort architecture names to match children