### PR TITLE
feat: default shell for alpine images

### DIFF
--- a/10/alpine3.10/Dockerfile
+++ b/10/alpine3.10/Dockerfile
@@ -67,6 +67,8 @@ RUN addgroup -g 1000 node \
   fi \
   && rm -f "node-v$NODE_VERSION-linux-$ARCH-musl.tar.xz" \
   && apk del .build-deps \
+  && npm config set shell sh \
+  && npm config set script-shell sh \
   # smoke tests
   && node --version \
   && npm --version

--- a/10/alpine3.11/Dockerfile
+++ b/10/alpine3.11/Dockerfile
@@ -67,6 +67,8 @@ RUN addgroup -g 1000 node \
   fi \
   && rm -f "node-v$NODE_VERSION-linux-$ARCH-musl.tar.xz" \
   && apk del .build-deps \
+  && npm config set shell sh \
+  && npm config set script-shell sh \
   # smoke tests
   && node --version \
   && npm --version

--- a/10/alpine3.9/Dockerfile
+++ b/10/alpine3.9/Dockerfile
@@ -67,6 +67,8 @@ RUN addgroup -g 1000 node \
   fi \
   && rm -f "node-v$NODE_VERSION-linux-$ARCH-musl.tar.xz" \
   && apk del .build-deps \
+  && npm config set shell sh \
+  && npm config set script-shell sh \
   # smoke tests
   && node --version \
   && npm --version

--- a/12/alpine3.10/Dockerfile
+++ b/12/alpine3.10/Dockerfile
@@ -67,6 +67,8 @@ RUN addgroup -g 1000 node \
   fi \
   && rm -f "node-v$NODE_VERSION-linux-$ARCH-musl.tar.xz" \
   && apk del .build-deps \
+  && npm config set shell sh \
+  && npm config set script-shell sh \
   # smoke tests
   && node --version \
   && npm --version

--- a/12/alpine3.11/Dockerfile
+++ b/12/alpine3.11/Dockerfile
@@ -67,6 +67,8 @@ RUN addgroup -g 1000 node \
   fi \
   && rm -f "node-v$NODE_VERSION-linux-$ARCH-musl.tar.xz" \
   && apk del .build-deps \
+  && npm config set shell sh \
+  && npm config set script-shell sh \
   # smoke tests
   && node --version \
   && npm --version

--- a/12/alpine3.12/Dockerfile
+++ b/12/alpine3.12/Dockerfile
@@ -67,6 +67,8 @@ RUN addgroup -g 1000 node \
   fi \
   && rm -f "node-v$NODE_VERSION-linux-$ARCH-musl.tar.xz" \
   && apk del .build-deps \
+  && npm config set shell sh \
+  && npm config set script-shell sh \
   # smoke tests
   && node --version \
   && npm --version

--- a/12/alpine3.9/Dockerfile
+++ b/12/alpine3.9/Dockerfile
@@ -67,6 +67,8 @@ RUN addgroup -g 1000 node \
   fi \
   && rm -f "node-v$NODE_VERSION-linux-$ARCH-musl.tar.xz" \
   && apk del .build-deps \
+  && npm config set shell sh \
+  && npm config set script-shell sh \
   # smoke tests
   && node --version \
   && npm --version

--- a/14/alpine3.10/Dockerfile
+++ b/14/alpine3.10/Dockerfile
@@ -68,6 +68,8 @@ RUN addgroup -g 1000 node \
   fi \
   && rm -f "node-v$NODE_VERSION-linux-$ARCH-musl.tar.xz" \
   && apk del .build-deps \
+  && npm config set shell sh \
+  && npm config set script-shell sh \
   # smoke tests
   && node --version \
   && npm --version

--- a/14/alpine3.11/Dockerfile
+++ b/14/alpine3.11/Dockerfile
@@ -68,6 +68,8 @@ RUN addgroup -g 1000 node \
   fi \
   && rm -f "node-v$NODE_VERSION-linux-$ARCH-musl.tar.xz" \
   && apk del .build-deps \
+  && npm config set shell sh \
+  && npm config set script-shell sh \
   # smoke tests
   && node --version \
   && npm --version

--- a/14/alpine3.12/Dockerfile
+++ b/14/alpine3.12/Dockerfile
@@ -68,6 +68,8 @@ RUN addgroup -g 1000 node \
   fi \
   && rm -f "node-v$NODE_VERSION-linux-$ARCH-musl.tar.xz" \
   && apk del .build-deps \
+  && npm config set shell sh \
+  && npm config set script-shell sh \
   # smoke tests
   && node --version \
   && npm --version

--- a/15/alpine3.10/Dockerfile
+++ b/15/alpine3.10/Dockerfile
@@ -68,6 +68,8 @@ RUN addgroup -g 1000 node \
   fi \
   && rm -f "node-v$NODE_VERSION-linux-$ARCH-musl.tar.xz" \
   && apk del .build-deps \
+  && npm config set shell sh \
+  && npm config set script-shell sh \
   # smoke tests
   && node --version \
   && npm --version

--- a/15/alpine3.11/Dockerfile
+++ b/15/alpine3.11/Dockerfile
@@ -68,6 +68,8 @@ RUN addgroup -g 1000 node \
   fi \
   && rm -f "node-v$NODE_VERSION-linux-$ARCH-musl.tar.xz" \
   && apk del .build-deps \
+  && npm config set shell sh \
+  && npm config set script-shell sh \
   # smoke tests
   && node --version \
   && npm --version

--- a/15/alpine3.12/Dockerfile
+++ b/15/alpine3.12/Dockerfile
@@ -68,6 +68,8 @@ RUN addgroup -g 1000 node \
   fi \
   && rm -f "node-v$NODE_VERSION-linux-$ARCH-musl.tar.xz" \
   && apk del .build-deps \
+  && npm config set shell sh \
+  && npm config set script-shell sh \
   # smoke tests
   && node --version \
   && npm --version

--- a/Dockerfile-alpine.template
+++ b/Dockerfile-alpine.template
@@ -58,6 +58,8 @@ RUN addgroup -g 1000 node \
   fi \
   && rm -f "node-v$NODE_VERSION-linux-$ARCH-musl.tar.xz" \
   && apk del .build-deps \
+  && npm config set shell sh \
+  && npm config set script-shell sh \
   # smoke tests
   && node --version \
   && npm --version


### PR DESCRIPTION
`npm` defaults `shell` and `script-shell` config settings to `bash`, which is not available in alpine image.
Npm 7 respects this setting and tries to call `bash -c 'git rev-parse ...'` while trying to install package directly from git.

Fixes #1378 