### PR TITLE
chore: Don't comment on PR for no-op

### DIFF
--- a/.github/workflows/official-pr.yml
+++ b/.github/workflows/official-pr.yml
@@ -59,6 +59,7 @@ jobs:
 
       - name: Create PR comment
         uses: peter-evans/create-or-update-comment@v1
+        if: ${{ steps.create-pr.outputs.pull-request-url != '' }}
         with:
           issue-number: ${{ github.event.pull_request.number }}
           body: |


### PR DESCRIPTION
I'd expect landing this will still show the message because of the `pull_request_target`