### PR TITLE
Publish packages to GitHub Registry

### DIFF
--- a/.github/workflows/publish-to-github-registry.yml
+++ b/.github/workflows/publish-to-github-registry.yml
@@ -1,0 +1,78 @@
+name: Publish to GitHub Registry
+
+on:
+  push:
+    branches:
+      - master
+    paths:
+      - "**/Dockerfile"
+      - "**/docker-entrypoint.sh"
+      - genMatrix.js
+      - .github/workflows/publish-to-github-registry.yml
+
+jobs:
+  gen_matrix:
+    name: Generate matrix
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.generator.outputs.result }}
+    steps:
+      - name: Calculate file differences
+        uses: lots0logs/gh-action-get-changed-files@2.1.4
+        id: diff
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Generate testing matrix
+        uses: actions/github-script@v3
+        id: generator
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const script = require(`${process.env.GITHUB_WORKSPACE}/genMatrix.js`)
+            return script(
+              ${{ steps.diff.outputs.added }},
+              ${{ steps.diff.outputs.modified }},
+              ${{ steps.diff.outputs.renamed }},
+            );
+
+  publish:
+    name: Push Image
+    if: ${{ fromJson(needs.gen_matrix.outputs.matrix) }}
+    needs: gen_matrix
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJson(needs.gen_matrix.outputs.matrix) }}
+    steps:
+      - name: Setup builder
+        uses: docker/setup-buildx-action@v1
+
+      - name: Login to Github Docker Registry
+        uses: docker/login-action@v1
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.CR_PAT }}
+
+      - name: Get short Node version
+        uses: actions/github-script@v3
+        id: short-version
+        with:
+          result-encoding: string
+          script: return "${{ matrix.version }}".split('.')[0]
+
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Build and push
+        uses: docker/build-push-action@v2
+        with:
+          push: true
+          context: .
+          file: ./${{ steps.short-version.outputs.result }}/${{ matrix.variant }}/Dockerfile
+          tags: |
+            ghcr.io/${{ github.repository }}/node:${{ matrix.version }}-${{ matrix.variant }}

--- a/.github/workflows/publish-to-github-registry.yml
+++ b/.github/workflows/publish-to-github-registry.yml
@@ -56,7 +56,7 @@ jobs:
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
-          password: ${{ secrets.CR_PAT }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Get short Node version
         uses: actions/github-script@v3


### PR DESCRIPTION
## Missing Steps

1. Create a new personal access token (PAT) with the appropriate scopes for the tasks you want to accomplish
  - Select the `read:packages` scope to download container images and read their metadata.
  - Select the `write:packages` scope to download and upload container images and read and write their metadata.
  - Select the `delete:packages` scope to delete container images.
2. Create a repository secret called `CR_PAT` with the value of the PAT created before.

More details at: [Migrating to GitHub Container Registry for Docker images](https://docs.github.com/en/free-pro-team@latest/packages/guides/migrating-to-github-container-registry-for-docker-images)

## Description

Publish the images to Github Docker Registry.

closes #1392 

## Motivation and Context

Docker is rate-limiting pulling the images from Docker Hub.

## Testing Details

- Make sure the images are being published correctly

## Types of changes

- [ ] Documentation
- [ ] Version change (Update, remove or add more Node.js versions)
- [ ] Variant change (Update, remove or add more variants, or versions of variants)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Others (non of above)

## Checklist

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING.md** document.
- [x] All new and existing tests passed.