### PR TITLE
Clean up Alpine 3.10 in architectures file, cc #1490

### DIFF
--- a/architectures
+++ b/architectures
@@ -1,8 +1,8 @@
 bashbrew-arch  variants
-amd64          alpine3.10,alpine3.11,alpine3.12,alpine3.13,buster,buster-slim,stretch,stretch-slim
-arm32v6        alpine3.10,alpine3.11,alpine3.12,alpine3.13
-arm32v7        alpine3.10,alpine3.11,alpine3.12,alpine3.13,buster,buster-slim,stretch,stretch-slim
-arm64v8        alpine3.10,alpine3.11,alpine3.12,alpine3.13,buster,buster-slim,stretch,stretch-slim
-i386           alpine3.10,alpine3.11,alpine3.12,alpine3.13
-ppc64le        alpine3.10,alpine3.11,alpine3.12,alpine3.13,buster,buster-slim
-s390x          alpine3.10,alpine3.11,alpine3.12,alpine3.13,buster,buster-slim
+amd64          alpine3.11,alpine3.12,alpine3.13,buster,buster-slim,stretch,stretch-slim
+arm32v6        alpine3.11,alpine3.12,alpine3.13
+arm32v7        alpine3.11,alpine3.12,alpine3.13,buster,buster-slim,stretch,stretch-slim
+arm64v8        alpine3.11,alpine3.12,alpine3.13,buster,buster-slim,stretch,stretch-slim
+i386           alpine3.11,alpine3.12,alpine3.13
+ppc64le        alpine3.11,alpine3.12,alpine3.13,buster,buster-slim
+s390x          alpine3.11,alpine3.12,alpine3.13,buster,buster-slim


### PR DESCRIPTION
## Description

Clean up Alpine 3.10 in architectures file, cc #1490

## Motivation and Context

Those configs seem to be missed in the Alpine v3.10 drop in #1490

## Types of changes

- [ ] Documentation
- [ ] Version change (Update, remove or add more Node.js versions)
- [x] Variant change (Update, remove or add more variants, or versions of variants)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Others (non of above)

## Checklist

- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING.md** document.
- [x] All new and existing tests passed.

