### PR TITLE
chore: Add gitattributes for Git Bash LF checkout

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+* text=auto eol=lf


### PR DESCRIPTION
Already set through EditorConfig, but the key replacement gets messed up on Windows with the initial CRLF checkout of files