### PR TITLE
fix: Use folder commmit for Stackbrew

### DIFF
--- a/stackbrew.js
+++ b/stackbrew.js
@@ -140,11 +140,11 @@ for(version of versions) {
     // remove duplicates
     tags = tags.filter((x, i, a) => a.indexOf(x) == i)
     tags = tags.sort()
-
+    let directory = `${version}/${variant}`
     stackbrew += `\nTags: ${tags.join(', ')}\n`
     stackbrew += `Architectures: ${config[version].variants[variant].join(', ')}\n`
-    stackbrew += `GitCommit: ${getCommitHasForPath(dockerfilePath)}\n`
-    stackbrew += `Directory: ${version}/${variant}\n`
+    stackbrew += `GitCommit: ${getCommitHasForPath(directory)}\n`
+    stackbrew += `Directory: ${directory}\n`
   }
 }
 


### PR DESCRIPTION
<!--
Provide a general summary of your changes in the Title above.
-->

## Description

<!--
Describe your changes in detail.
-->

Current script just takes the commit hash for the Dockerfile, so when the commit bit was fixed, it isn't getting picked up for the upstream PR. Now it will use the whole variant folder when looking for the latest commithash

## Motivation and Context

<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
-->

## Testing Details

<!--
Please describe in detail how you tested your changes. Include details of
your testing environment, and the tests you ran to see how your change
affects other areas of the code, etc.
-->

## Example Output(if appropriate)

## Types of changes

<!--
What types of changes does your code introduce? Put an `x` in all the boxes that apply.
-->

- [ ] Documentation
- [ ] Version change (Update, remove or add more Node.js versions)
- [ ] Variant change (Update, remove or add more variants, or versions of variants)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Others (non of above)

## Checklist

<!--
Go over all the following points, and put an `x` in all the boxes that apply.
If you're unsure about any of these, don't hesitate to ask. We're here to help!
-->

- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING.md** document.
- [ ] All new and existing tests passed.

