### PR TITLE
feat: Add back BATS for testing images

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -69,8 +69,6 @@ jobs:
 
       - name: Checkout
         uses: actions/checkout@v2
-        with:
-          submodules: true
 
       - name: Build image
         uses: docker/build-push-action@v2
@@ -81,4 +79,4 @@ jobs:
           tags: ${{ env.IMAGE_TAG }}
 
       - name: Run tests with BATS
-        run: test/bats/bin/bats --verbose-run test/docker-image.bats
+        run: npx bats@1.6.0 --verbose-run test/docker-image.bats

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -55,6 +55,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix: ${{ fromJson(needs.gen-matrix.outputs.matrix) }}
+    env:
+      NODE_VERSION: ${{ matrix.version }}
+      IMAGE_TAG: node:${{ matrix.version }}-${{ matrix.variant }}
 
     steps:
       - name: Get short node version
@@ -66,31 +69,16 @@ jobs:
 
       - name: Checkout
         uses: actions/checkout@v2
+        with:
+          submodules: true
 
       - name: Build image
         uses: docker/build-push-action@v2
         with:
           push: false
           load: true
-          context: .
-          file: ./${{ steps.short-version.outputs.result }}/${{ matrix.variant }}/Dockerfile
-          tags: node:${{ matrix.version }}-${{ matrix.variant }}
+          context: ./${{ steps.short-version.outputs.result }}/${{ matrix.variant }}
+          tags: ${{ env.IMAGE_TAG }}
 
-      - name: Test for node version
-        run: |
-          image_node_version=$(docker run --rm node:${{ matrix.version }}-${{ matrix.variant }} node --print "process.versions.node")
-          echo "Expected: \"${{ matrix.version }}\", Got: \"${image_node_version}\""
-          [ "${image_node_version}" == "${{ matrix.version }}" ]
-
-      - name: Verify entrypoint runs regular, non-executable files with node
-        run: |
-          tmp_file=$(mktemp)
-          echo 'console.log("success")' > "${tmp_file}"
-          output=$(docker run --rm -v "${tmp_file}:/app/index.js" node:${{ matrix.version }}-${{ matrix.variant }} app/index.js)
-          [ "${output}" = 'success' ]
-
-      - name: Test for npm
-        run: docker run --rm node:${{ matrix.version }}-${{ matrix.variant }} npm --version
-
-      - name: Test for yarn
-        run: docker run --rm node:${{ matrix.version }}-${{ matrix.variant }} yarn --version
+      - name: Run tests with BATS
+        run: test/bats/bin/bats --verbose-run test/docker-image.bats

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "test/bats"]
+  path = test/bats
+  url = https://github.com/bats-core/bats-core.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "test/bats"]
-  path = test/bats
-  url = https://github.com/bats-core/bats-core.git

--- a/test/docker-image.bats
+++ b/test/docker-image.bats
@@ -1,0 +1,36 @@
+# Docs: https://bats-core.readthedocs.io/en/stable/writing-tests.html
+
+setup() {
+  tmp_file=$(mktemp)
+  echo 'console.log("success")' > "${tmp_file}"
+}
+
+@test "Test for node version" {
+  run -0 docker run --rm "${IMAGE_TAG}" node --print "process.versions.node"
+  [ "$output" = "${NODE_VERSION}" ]
+}
+
+@test "Test for node version, without directly invoking node" {
+  run -0 docker run --rm "${IMAGE_TAG}" --print "process.versions.node"
+  [ "$output" = "${NODE_VERSION}" ]
+}
+
+@test "Test for npm" {
+  run -0 docker run --rm "${IMAGE_TAG}" npm --version
+  [ -n "$output" ]
+}
+
+@test "Test for yarn" {
+  run -0 docker run --rm "${IMAGE_TAG}" yarn --version
+  [ -n "$output" ]
+}
+
+@test "Verify entrypoint runs relative path pointing to regular, non-executable file with node" {
+  run -0 docker run --rm -v "${tmp_file}:/index.js" "${IMAGE_TAG}" index.js
+  [ "$output" = 'success' ]
+}
+
+@test "Verify entrypoint runs absolute path pointing to regular, non-executable file with node" {
+  run -0 docker run --rm -v "${tmp_file}:/index.js" "${IMAGE_TAG}" /index.js
+  [ "$output" = 'success' ]
+}


### PR DESCRIPTION
## Description

BATS was initially added to this repository in https://github.com/nodejs/docker-node/pull/802, but was then removed in https://github.com/nodejs/docker-node/pull/1339. This adds it back, and hooks it up to Github Actions.

This also fixes #1583, which happened due to a bug in the "Build image" step: the build context was set to the root project directory, which meant the `COPY docker-entrypoint.sh /usr/local/bin/` instruction was copying the base `docker-entrypoint.sh` file into the Docker image instead of the one in the variant directory. Changing the context to the variant directory solves that.

## Motivation and Context
https://github.com/nodejs/docker-node/pull/1579#issuecomment-947302579

## Testing Details

Link to run for this PR: https://github.com/nodejs/docker-node/actions/runs/1374569169

## Example Output(if appropriate)

N/A

## Types of changes

<!--
What types of changes does your code introduce? Put an `x` in all the boxes that apply.
-->

- [ ] Documentation
- [ ] Version change (Update, remove or add more Node.js versions)
- [ ] Variant change (Update, remove or add more variants, or versions of variants)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Others (non of above)

## Checklist

<!--
Go over all the following points, and put an `x` in all the boxes that apply.
If you're unsure about any of these, don't hesitate to ask. We're here to help!
-->

- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING.md** document.
- [X] All new and existing tests passed.