### PR TITLE
fix: NodeJS date parsing from string

### DIFF
--- a/stackbrew.js
+++ b/stackbrew.js
@@ -25,21 +25,23 @@ const config = require('./versions.json');
 
 const versions = Object.keys(config).reverse()
 
-const now = new Date().getTime()
+let midnight = new Date()
+midnight.setHours(0, 0, 0, 0)
+const now = midnight.getTime()
 const aplineRE = new RegExp(/alpine*/);
 const slimRE = new RegExp(/\*-slim/);
 
-for(version of versions) {
-  let lts = new Date(config[version].lts).getTime();
-  let maintenance = new Date(config[version].maintenance).getTime();
-  let isCurrent = lts > now;
-  let isLTS = (maintenance > now) && (now > lts);
+for (version of versions) {
+  let lts = new Date(`${config[version].lts}T00:00:00.00`).getTime();
+  let maintenance = new Date(`${config[version].maintenance}T00:00:00.00`).getTime();
+  let isCurrent = lts >= now;
+  let isLTS = (maintenance >= now) && (now >= lts);
   let codename = config[version].codename
   let defaultAlpine = config[version]['alpine-default']
   let defaultDebian = config[version]['debian-default']
   let variants = config[version].variants
   let fullversion;
-  for(variant in variants) {
+  for (variant in variants) {
     let dockerfilePath = path.join(version, variant, 'Dockerfile');
     let isAlpine = aplineRE.test(variant)
     let isSlim = slimRE.test(variant)


### PR DESCRIPTION
Use an explicit timezone to work around an "off by one" issue with date parsing

<!--
Provide a general summary of your changes in the Title above.
-->

## Description

<!--
Describe your changes in detail.
-->

## Motivation and Context

<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
-->

## Testing Details

<!--
Please describe in detail how you tested your changes. Include details of
your testing environment, and the tests you ran to see how your change
affects other areas of the code, etc.
-->

## Example Output(if appropriate)

## Types of changes

<!--
What types of changes does your code introduce? Put an `x` in all the boxes that apply.
-->

- [ ] Documentation
- [ ] Version change (Update, remove or add more Node.js versions)
- [ ] Variant change (Update, remove or add more variants, or versions of variants)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Others (non of above)

## Checklist

<!--
Go over all the following points, and put an `x` in all the boxes that apply.
If you're unsure about any of these, don't hesitate to ask. We're here to help!
-->

- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING.md** document.
- [ ] All new and existing tests passed.

