### PR TITLE
Update OS/ Distro to latest package versions

### DIFF
--- a/12/alpine3.12/Dockerfile
+++ b/12/alpine3.12/Dockerfile
@@ -2,7 +2,9 @@ FROM alpine:3.12
 
 ENV NODE_VERSION 12.22.7
 
-RUN addgroup -g 1000 node \
+RUN apk update \
+    && apk upgrade \
+    && addgroup -g 1000 node \
     && adduser -u 1000 -G node -s /bin/sh -D node \
     && apk add --no-cache \
         libstdc++ \

--- a/12/alpine3.13/Dockerfile
+++ b/12/alpine3.13/Dockerfile
@@ -2,7 +2,9 @@ FROM alpine:3.13
 
 ENV NODE_VERSION 12.22.7
 
-RUN addgroup -g 1000 node \
+RUN apk update \
+    && apk upgrade \
+    && addgroup -g 1000 node \
     && adduser -u 1000 -G node -s /bin/sh -D node \
     && apk add --no-cache \
         libstdc++ \

--- a/12/alpine3.14/Dockerfile
+++ b/12/alpine3.14/Dockerfile
@@ -2,7 +2,9 @@ FROM alpine:3.14
 
 ENV NODE_VERSION 12.22.7
 
-RUN addgroup -g 1000 node \
+RUN apk update \
+    && apk upgrade \
+    && addgroup -g 1000 node \
     && adduser -u 1000 -G node -s /bin/sh -D node \
     && apk add --no-cache \
         libstdc++ \

--- a/12/bullseye-slim/Dockerfile
+++ b/12/bullseye-slim/Dockerfile
@@ -17,7 +17,9 @@ RUN ARCH= && dpkgArch="$(dpkg --print-architecture)" \
     esac \
     && set -ex \
     # libatomic1 for arm
-    && apt-get update && apt-get install -y ca-certificates curl wget gnupg dirmngr xz-utils libatomic1 --no-install-recommends \
+    && apt-get update \
+    && apt-get upgrade -y \
+    && apt-get install -y ca-certificates curl wget gnupg dirmngr xz-utils libatomic1 --no-install-recommends \
     && rm -rf /var/lib/apt/lists/* \
     && for key in \
       4ED778F539E3634C779C87C6D7062848A1AB005C \

--- a/12/bullseye/Dockerfile
+++ b/12/bullseye/Dockerfile
@@ -1,7 +1,9 @@
 FROM buildpack-deps:bullseye
 
-RUN groupadd --gid 1000 node \
-  && useradd --uid 1000 --gid node --shell /bin/bash --create-home node
+RUN apt-get update \
+    && apt-get upgrade -y \
+    && groupadd --gid 1000 node \
+    && useradd --uid 1000 --gid node --shell /bin/bash --create-home node
 
 ENV NODE_VERSION 12.22.7
 

--- a/12/buster-slim/Dockerfile
+++ b/12/buster-slim/Dockerfile
@@ -17,7 +17,9 @@ RUN ARCH= && dpkgArch="$(dpkg --print-architecture)" \
     esac \
     && set -ex \
     # libatomic1 for arm
-    && apt-get update && apt-get install -y ca-certificates curl wget gnupg dirmngr xz-utils libatomic1 --no-install-recommends \
+    && apt-get update \
+    && apt-get upgrade -y \
+    && apt-get install -y ca-certificates curl wget gnupg dirmngr xz-utils libatomic1 --no-install-recommends \
     && rm -rf /var/lib/apt/lists/* \
     && for key in \
       4ED778F539E3634C779C87C6D7062848A1AB005C \

--- a/12/buster/Dockerfile
+++ b/12/buster/Dockerfile
@@ -1,7 +1,9 @@
 FROM buildpack-deps:buster
 
-RUN groupadd --gid 1000 node \
-  && useradd --uid 1000 --gid node --shell /bin/bash --create-home node
+RUN apt-get update \
+    && apt-get upgrade -y \
+    && groupadd --gid 1000 node \
+    && useradd --uid 1000 --gid node --shell /bin/bash --create-home node
 
 ENV NODE_VERSION 12.22.7
 

--- a/12/stretch-slim/Dockerfile
+++ b/12/stretch-slim/Dockerfile
@@ -17,7 +17,9 @@ RUN ARCH= && dpkgArch="$(dpkg --print-architecture)" \
     esac \
     && set -ex \
     # libatomic1 for arm
-    && apt-get update && apt-get install -y ca-certificates curl wget gnupg dirmngr xz-utils libatomic1 --no-install-recommends \
+    && apt-get update \
+    && apt-get upgrade -y \
+    && apt-get install -y ca-certificates curl wget gnupg dirmngr xz-utils libatomic1 --no-install-recommends \
     && rm -rf /var/lib/apt/lists/* \
     && for key in \
       4ED778F539E3634C779C87C6D7062848A1AB005C \

--- a/12/stretch/Dockerfile
+++ b/12/stretch/Dockerfile
@@ -1,7 +1,9 @@
 FROM buildpack-deps:stretch
 
-RUN groupadd --gid 1000 node \
-  && useradd --uid 1000 --gid node --shell /bin/bash --create-home node
+RUN apt-get update \
+    && apt-get upgrade -y \
+    && groupadd --gid 1000 node \
+    && useradd --uid 1000 --gid node --shell /bin/bash --create-home node
 
 ENV NODE_VERSION 12.22.7
 

--- a/14/alpine3.12/Dockerfile
+++ b/14/alpine3.12/Dockerfile
@@ -2,7 +2,9 @@ FROM alpine:3.12
 
 ENV NODE_VERSION 14.18.2
 
-RUN addgroup -g 1000 node \
+RUN apk update \
+    && apk upgrade \
+    && addgroup -g 1000 node \
     && adduser -u 1000 -G node -s /bin/sh -D node \
     && apk add --no-cache \
         libstdc++ \

--- a/14/alpine3.13/Dockerfile
+++ b/14/alpine3.13/Dockerfile
@@ -2,7 +2,9 @@ FROM alpine:3.13
 
 ENV NODE_VERSION 14.18.2
 
-RUN addgroup -g 1000 node \
+RUN apk update \
+    && apk upgrade \
+    && addgroup -g 1000 node \
     && adduser -u 1000 -G node -s /bin/sh -D node \
     && apk add --no-cache \
         libstdc++ \

--- a/14/alpine3.14/Dockerfile
+++ b/14/alpine3.14/Dockerfile
@@ -2,7 +2,9 @@ FROM alpine:3.14
 
 ENV NODE_VERSION 14.18.2
 
-RUN addgroup -g 1000 node \
+RUN apk update \
+    && apk upgrade \
+    && addgroup -g 1000 node \
     && adduser -u 1000 -G node -s /bin/sh -D node \
     && apk add --no-cache \
         libstdc++ \

--- a/14/bullseye-slim/Dockerfile
+++ b/14/bullseye-slim/Dockerfile
@@ -17,7 +17,9 @@ RUN ARCH= && dpkgArch="$(dpkg --print-architecture)" \
     esac \
     && set -ex \
     # libatomic1 for arm
-    && apt-get update && apt-get install -y ca-certificates curl wget gnupg dirmngr xz-utils libatomic1 --no-install-recommends \
+    && apt-get update \
+    && apt-get upgrade -y \
+    && apt-get install -y ca-certificates curl wget gnupg dirmngr xz-utils libatomic1 --no-install-recommends \
     && rm -rf /var/lib/apt/lists/* \
     && for key in \
       4ED778F539E3634C779C87C6D7062848A1AB005C \

--- a/14/bullseye/Dockerfile
+++ b/14/bullseye/Dockerfile
@@ -1,7 +1,9 @@
 FROM buildpack-deps:bullseye
 
-RUN groupadd --gid 1000 node \
-  && useradd --uid 1000 --gid node --shell /bin/bash --create-home node
+RUN apt-get update \
+    && apt-get upgrade -y \
+    && groupadd --gid 1000 node \
+    && useradd --uid 1000 --gid node --shell /bin/bash --create-home node
 
 ENV NODE_VERSION 14.18.2
 

--- a/14/buster-slim/Dockerfile
+++ b/14/buster-slim/Dockerfile
@@ -17,7 +17,9 @@ RUN ARCH= && dpkgArch="$(dpkg --print-architecture)" \
     esac \
     && set -ex \
     # libatomic1 for arm
-    && apt-get update && apt-get install -y ca-certificates curl wget gnupg dirmngr xz-utils libatomic1 --no-install-recommends \
+    && apt-get update \
+    && apt-get upgrade -y \
+    && apt-get install -y ca-certificates curl wget gnupg dirmngr xz-utils libatomic1 --no-install-recommends \
     && rm -rf /var/lib/apt/lists/* \
     && for key in \
       4ED778F539E3634C779C87C6D7062848A1AB005C \

--- a/14/buster/Dockerfile
+++ b/14/buster/Dockerfile
@@ -1,7 +1,9 @@
 FROM buildpack-deps:buster
 
-RUN groupadd --gid 1000 node \
-  && useradd --uid 1000 --gid node --shell /bin/bash --create-home node
+RUN apt-get update \
+    && apt-get upgrade -y \
+    && groupadd --gid 1000 node \
+    && useradd --uid 1000 --gid node --shell /bin/bash --create-home node
 
 ENV NODE_VERSION 14.18.2
 

--- a/14/stretch-slim/Dockerfile
+++ b/14/stretch-slim/Dockerfile
@@ -17,7 +17,9 @@ RUN ARCH= && dpkgArch="$(dpkg --print-architecture)" \
     esac \
     && set -ex \
     # libatomic1 for arm
-    && apt-get update && apt-get install -y ca-certificates curl wget gnupg dirmngr xz-utils libatomic1 --no-install-recommends \
+    && apt-get update \
+    && apt-get upgrade -y \
+    && apt-get install -y ca-certificates curl wget gnupg dirmngr xz-utils libatomic1 --no-install-recommends \
     && rm -rf /var/lib/apt/lists/* \
     && for key in \
       4ED778F539E3634C779C87C6D7062848A1AB005C \

--- a/14/stretch/Dockerfile
+++ b/14/stretch/Dockerfile
@@ -1,7 +1,9 @@
 FROM buildpack-deps:stretch
 
-RUN groupadd --gid 1000 node \
-  && useradd --uid 1000 --gid node --shell /bin/bash --create-home node
+RUN apt-get update \
+    && apt-get upgrade -y \
+    && groupadd --gid 1000 node \
+    && useradd --uid 1000 --gid node --shell /bin/bash --create-home node
 
 ENV NODE_VERSION 14.18.2
 

--- a/16/alpine3.12/Dockerfile
+++ b/16/alpine3.12/Dockerfile
@@ -2,7 +2,9 @@ FROM alpine:3.12
 
 ENV NODE_VERSION 16.13.1
 
-RUN addgroup -g 1000 node \
+RUN apk update \
+    && apk upgrade \
+    && addgroup -g 1000 node \
     && adduser -u 1000 -G node -s /bin/sh -D node \
     && apk add --no-cache \
         libstdc++ \

--- a/16/alpine3.13/Dockerfile
+++ b/16/alpine3.13/Dockerfile
@@ -2,7 +2,9 @@ FROM alpine:3.13
 
 ENV NODE_VERSION 16.13.1
 
-RUN addgroup -g 1000 node \
+RUN apk update \
+    && apk upgrade \
+    && addgroup -g 1000 node \
     && adduser -u 1000 -G node -s /bin/sh -D node \
     && apk add --no-cache \
         libstdc++ \

--- a/16/alpine3.14/Dockerfile
+++ b/16/alpine3.14/Dockerfile
@@ -2,7 +2,9 @@ FROM alpine:3.14
 
 ENV NODE_VERSION 16.13.1
 
-RUN addgroup -g 1000 node \
+RUN apk update \
+    && apk upgrade \
+    && addgroup -g 1000 node \
     && adduser -u 1000 -G node -s /bin/sh -D node \
     && apk add --no-cache \
         libstdc++ \

--- a/16/bullseye-slim/Dockerfile
+++ b/16/bullseye-slim/Dockerfile
@@ -17,7 +17,9 @@ RUN ARCH= && dpkgArch="$(dpkg --print-architecture)" \
     esac \
     && set -ex \
     # libatomic1 for arm
-    && apt-get update && apt-get install -y ca-certificates curl wget gnupg dirmngr xz-utils libatomic1 --no-install-recommends \
+    && apt-get update \
+    && apt-get upgrade -y \
+    && apt-get install -y ca-certificates curl wget gnupg dirmngr xz-utils libatomic1 --no-install-recommends \
     && rm -rf /var/lib/apt/lists/* \
     && for key in \
       4ED778F539E3634C779C87C6D7062848A1AB005C \

--- a/16/bullseye/Dockerfile
+++ b/16/bullseye/Dockerfile
@@ -1,7 +1,9 @@
 FROM buildpack-deps:bullseye
 
-RUN groupadd --gid 1000 node \
-  && useradd --uid 1000 --gid node --shell /bin/bash --create-home node
+RUN apt-get update \
+    && apt-get upgrade -y \
+    && groupadd --gid 1000 node \
+    && useradd --uid 1000 --gid node --shell /bin/bash --create-home node
 
 ENV NODE_VERSION 16.13.1
 

--- a/16/buster-slim/Dockerfile
+++ b/16/buster-slim/Dockerfile
@@ -17,7 +17,9 @@ RUN ARCH= && dpkgArch="$(dpkg --print-architecture)" \
     esac \
     && set -ex \
     # libatomic1 for arm
-    && apt-get update && apt-get install -y ca-certificates curl wget gnupg dirmngr xz-utils libatomic1 --no-install-recommends \
+    && apt-get update \
+    && apt-get upgrade -y \
+    && apt-get install -y ca-certificates curl wget gnupg dirmngr xz-utils libatomic1 --no-install-recommends \
     && rm -rf /var/lib/apt/lists/* \
     && for key in \
       4ED778F539E3634C779C87C6D7062848A1AB005C \

--- a/16/buster/Dockerfile
+++ b/16/buster/Dockerfile
@@ -1,7 +1,9 @@
 FROM buildpack-deps:buster
 
-RUN groupadd --gid 1000 node \
-  && useradd --uid 1000 --gid node --shell /bin/bash --create-home node
+RUN apt-get update \
+    && apt-get upgrade -y \
+    && groupadd --gid 1000 node \
+    && useradd --uid 1000 --gid node --shell /bin/bash --create-home node
 
 ENV NODE_VERSION 16.13.1
 

--- a/16/stretch-slim/Dockerfile
+++ b/16/stretch-slim/Dockerfile
@@ -17,7 +17,9 @@ RUN ARCH= && dpkgArch="$(dpkg --print-architecture)" \
     esac \
     && set -ex \
     # libatomic1 for arm
-    && apt-get update && apt-get install -y ca-certificates curl wget gnupg dirmngr xz-utils libatomic1 --no-install-recommends \
+    && apt-get update \
+    && apt-get upgrade -y \
+    && apt-get install -y ca-certificates curl wget gnupg dirmngr xz-utils libatomic1 --no-install-recommends \
     && rm -rf /var/lib/apt/lists/* \
     && for key in \
       4ED778F539E3634C779C87C6D7062848A1AB005C \

--- a/16/stretch/Dockerfile
+++ b/16/stretch/Dockerfile
@@ -1,7 +1,9 @@
 FROM buildpack-deps:stretch
 
-RUN groupadd --gid 1000 node \
-  && useradd --uid 1000 --gid node --shell /bin/bash --create-home node
+RUN apt-get update \
+    && apt-get upgrade -y \
+    && groupadd --gid 1000 node \
+    && useradd --uid 1000 --gid node --shell /bin/bash --create-home node
 
 ENV NODE_VERSION 16.13.1
 

--- a/17/alpine3.12/Dockerfile
+++ b/17/alpine3.12/Dockerfile
@@ -2,7 +2,9 @@ FROM alpine:3.12
 
 ENV NODE_VERSION 17.2.0
 
-RUN addgroup -g 1000 node \
+RUN apk update \
+    && apk upgrade \
+    && addgroup -g 1000 node \
     && adduser -u 1000 -G node -s /bin/sh -D node \
     && apk add --no-cache \
         libstdc++ \

--- a/17/alpine3.13/Dockerfile
+++ b/17/alpine3.13/Dockerfile
@@ -2,7 +2,9 @@ FROM alpine:3.13
 
 ENV NODE_VERSION 17.2.0
 
-RUN addgroup -g 1000 node \
+RUN apk update \
+    && apk upgrade \
+    && addgroup -g 1000 node \
     && adduser -u 1000 -G node -s /bin/sh -D node \
     && apk add --no-cache \
         libstdc++ \

--- a/17/alpine3.14/Dockerfile
+++ b/17/alpine3.14/Dockerfile
@@ -2,7 +2,9 @@ FROM alpine:3.14
 
 ENV NODE_VERSION 17.2.0
 
-RUN addgroup -g 1000 node \
+RUN apk update \
+    && apk upgrade \
+    && addgroup -g 1000 node \
     && adduser -u 1000 -G node -s /bin/sh -D node \
     && apk add --no-cache \
         libstdc++ \

--- a/17/bullseye-slim/Dockerfile
+++ b/17/bullseye-slim/Dockerfile
@@ -17,7 +17,9 @@ RUN ARCH= && dpkgArch="$(dpkg --print-architecture)" \
     esac \
     && set -ex \
     # libatomic1 for arm
-    && apt-get update && apt-get install -y ca-certificates curl wget gnupg dirmngr xz-utils libatomic1 --no-install-recommends \
+    && apt-get update \
+    && apt-get upgrade -y \
+    && apt-get install -y ca-certificates curl wget gnupg dirmngr xz-utils libatomic1 --no-install-recommends \
     && rm -rf /var/lib/apt/lists/* \
     && for key in \
       4ED778F539E3634C779C87C6D7062848A1AB005C \

--- a/17/bullseye/Dockerfile
+++ b/17/bullseye/Dockerfile
@@ -1,7 +1,9 @@
 FROM buildpack-deps:bullseye
 
-RUN groupadd --gid 1000 node \
-  && useradd --uid 1000 --gid node --shell /bin/bash --create-home node
+RUN apt-get update \
+    && apt-get upgrade -y \
+    && groupadd --gid 1000 node \
+    && useradd --uid 1000 --gid node --shell /bin/bash --create-home node
 
 ENV NODE_VERSION 17.2.0
 

--- a/17/buster-slim/Dockerfile
+++ b/17/buster-slim/Dockerfile
@@ -17,7 +17,9 @@ RUN ARCH= && dpkgArch="$(dpkg --print-architecture)" \
     esac \
     && set -ex \
     # libatomic1 for arm
-    && apt-get update && apt-get install -y ca-certificates curl wget gnupg dirmngr xz-utils libatomic1 --no-install-recommends \
+    && apt-get update \
+    && apt-get upgrade -y \
+    && apt-get install -y ca-certificates curl wget gnupg dirmngr xz-utils libatomic1 --no-install-recommends \
     && rm -rf /var/lib/apt/lists/* \
     && for key in \
       4ED778F539E3634C779C87C6D7062848A1AB005C \

--- a/17/buster/Dockerfile
+++ b/17/buster/Dockerfile
@@ -1,7 +1,9 @@
 FROM buildpack-deps:buster
 
-RUN groupadd --gid 1000 node \
-  && useradd --uid 1000 --gid node --shell /bin/bash --create-home node
+RUN apt-get update \
+    && apt-get upgrade -y \
+    && groupadd --gid 1000 node \
+    && useradd --uid 1000 --gid node --shell /bin/bash --create-home node
 
 ENV NODE_VERSION 17.2.0
 

--- a/17/stretch-slim/Dockerfile
+++ b/17/stretch-slim/Dockerfile
@@ -17,7 +17,9 @@ RUN ARCH= && dpkgArch="$(dpkg --print-architecture)" \
     esac \
     && set -ex \
     # libatomic1 for arm
-    && apt-get update && apt-get install -y ca-certificates curl wget gnupg dirmngr xz-utils libatomic1 --no-install-recommends \
+    && apt-get update \
+    && apt-get upgrade -y \
+    && apt-get install -y ca-certificates curl wget gnupg dirmngr xz-utils libatomic1 --no-install-recommends \
     && rm -rf /var/lib/apt/lists/* \
     && for key in \
       4ED778F539E3634C779C87C6D7062848A1AB005C \

--- a/17/stretch/Dockerfile
+++ b/17/stretch/Dockerfile
@@ -1,7 +1,9 @@
 FROM buildpack-deps:stretch
 
-RUN groupadd --gid 1000 node \
-  && useradd --uid 1000 --gid node --shell /bin/bash --create-home node
+RUN apt-get update \
+    && apt-get upgrade -y \
+    && groupadd --gid 1000 node \
+    && useradd --uid 1000 --gid node --shell /bin/bash --create-home node
 
 ENV NODE_VERSION 17.2.0
 

--- a/Dockerfile-alpine.template
+++ b/Dockerfile-alpine.template
@@ -2,7 +2,9 @@ FROM alpine:0.0
 
 ENV NODE_VERSION 0.0.0
 
-RUN addgroup -g 1000 node \
+RUN apk update \
+    && apk upgrade \
+    && addgroup -g 1000 node \
     && adduser -u 1000 -G node -s /bin/sh -D node \
     && apk add --no-cache \
         libstdc++ \

--- a/Dockerfile-debian.template
+++ b/Dockerfile-debian.template
@@ -1,7 +1,9 @@
 FROM buildpack-deps:name
 
-RUN groupadd --gid 1000 node \
-  && useradd --uid 1000 --gid node --shell /bin/bash --create-home node
+RUN apt-get update \
+    && apt-get upgrade -y \
+    && groupadd --gid 1000 node \
+    && useradd --uid 1000 --gid node --shell /bin/bash --create-home node
 
 ENV NODE_VERSION 0.0.0
 

--- a/Dockerfile-slim.template
+++ b/Dockerfile-slim.template
@@ -17,7 +17,9 @@ RUN ARCH= && dpkgArch="$(dpkg --print-architecture)" \
     esac \
     && set -ex \
     # libatomic1 for arm
-    && apt-get update && apt-get install -y ca-certificates curl wget gnupg dirmngr xz-utils libatomic1 --no-install-recommends \
+    && apt-get update \
+    && apt-get upgrade -y \
+    && apt-get install -y ca-certificates curl wget gnupg dirmngr xz-utils libatomic1 --no-install-recommends \
     && rm -rf /var/lib/apt/lists/* \
     && for key in \
       "${NODE_KEYS[@]}"


### PR DESCRIPTION
updated `Dockerfile-*.template` files to update OS/ Distro packages at build time. 
Updated other files by running `./update.sh`.

This change ensure latest built images also include latest package versions from the underlying OS.

## Motivation and Context

I maintain base images for our infrastructures and end up doing `apk update && apk upgrade` or `apt-get update && apt-get upgrade -y` in all dockerfiles.
This change ensure every time a new node image is built, latest OS packages are fetched too, which are not latest at times due to node image release and underlying distro image release not being done in sync.

## Testing Details

Please see example output.

## Example Output(if appropriate)

example below shows busybox, ssl_client and alpine-keys being updated, where first two have sever vulnerability fixes:

```
docker-node/14/alpine3.14 (branch: include-OS-updates)$ docker  build --tag node:14.18.2-alpine3.14   .
Sending build context to Docker daemon  6.656kB
Step 1/8 : FROM alpine:3.14
 ---> 14119a10abf4
Step 2/8 : ENV NODE_VERSION 14.18.2
 ---> Using cache
 ---> e0d40b0f6d40
Step 3/8 : RUN apk update     && apk upgrade     && addgroup -g 1000 node     && adduser -u 1000 -G node -s /bin/sh -D node     && apk add --no-cache         libstdc++     && apk add --no-cache --virtual .build-deps         curl     && ARCH= && alpineArch="$(apk --print-arch)"       && case "${alpineArch##*-}" in         x86_64)           ARCH='x64'           CHECKSUM="7a1a1a18e51ad20245fc366a0848cdb55e968094c807a094555ec2c214e8e9c6"           ;;         *) ;;       esac   && if [ -n "${CHECKSUM}" ]; then     set -eu;     curl -fsSLO --compressed "https://unofficial-builds.nodejs.org/download/release/v$NODE_VERSION/node-v$NODE_VERSION-linux-$ARCH-musl.tar.xz";     echo "$CHECKSUM  node-v$NODE_VERSION-linux-$ARCH-musl.tar.xz" | sha256sum -c -       && tar -xJf "node-v$NODE_VERSION-linux-$ARCH-musl.tar.xz" -C /usr/local --strip-components=1 --no-same-owner       && ln -s /usr/local/bin/node /usr/local/bin/nodejs;   else     echo "Building from source"     && apk add --no-cache --virtual .build-deps-full         binutils-gold         g++         gcc         gnupg         libgcc         linux-headers         make         python3     && for key in       4ED778F539E3634C779C87C6D7062848A1AB005C       94AE36675C464D64BAFA68DD7434390BDBE9B9C5       74F12602B6F1C4E913FAA37AD3A89613643B6201       71DCFD284A79C3B38668286BC97EC7A07EDE3FC1       8FCCA13FEF1D0C2E91008E09770F7A9A5AE15600       C4F0DFFF4E8C1A8236409D08E73BC641CC11F4C8       C82FA3AE1CBEDC6BE46B9360C43CEC45C17AB93C       DD8F2338BAE7501E3DD5AC78C273792F7D83545D       A48C2BEE680E841632CD4E44F07496B3EB3C1762       108F52B48DB57BB0CC439B2997B01419BD92F80A       B9E2F5981AA6E0CD28160D9FF13993A75599653C     ; do       gpg --batch --keyserver hkps://keys.openpgp.org --recv-keys "$key" ||       gpg --batch --keyserver keyserver.ubuntu.com --recv-keys "$key" ;     done     && curl -fsSLO --compressed "https://nodejs.org/dist/v$NODE_VERSION/node-v$NODE_VERSION.tar.xz"     && curl -fsSLO --compressed "https://nodejs.org/dist/v$NODE_VERSION/SHASUMS256.txt.asc"     && gpg --batch --decrypt --output SHASUMS256.txt SHASUMS256.txt.asc     && grep " node-v$NODE_VERSION.tar.xz\$" SHASUMS256.txt | sha256sum -c -     && tar -xf "node-v$NODE_VERSION.tar.xz"     && cd "node-v$NODE_VERSION"     && ./configure     && make -j$(getconf _NPROCESSORS_ONLN) V=     && make install     && apk del .build-deps-full     && cd ..     && rm -Rf "node-v$NODE_VERSION"     && rm "node-v$NODE_VERSION.tar.xz" SHASUMS256.txt.asc SHASUMS256.txt;   fi   && rm -f "node-v$NODE_VERSION-linux-$ARCH-musl.tar.xz"   && apk del .build-deps   && node --version   && npm --version
 ---> Running in 783ec629014f
fetch https://dl-cdn.alpinelinux.org/alpine/v3.14/main/x86_64/APKINDEX.tar.gz
fetch https://dl-cdn.alpinelinux.org/alpine/v3.14/community/x86_64/APKINDEX.tar.gz
v3.14.3-43-gd011d60ecc [https://dl-cdn.alpinelinux.org/alpine/v3.14/main]
v3.14.3-41-g6391631eb3 [https://dl-cdn.alpinelinux.org/alpine/v3.14/community]
OK: 14945 distinct packages available
(1/3) Upgrading busybox (1.33.1-r3 -> 1.33.1-r6)
Executing busybox-1.33.1-r6.post-upgrade
(2/3) Upgrading alpine-keys (2.3-r1 -> 2.4-r0)
(3/3) Upgrading ssl_client (1.33.1-r3 -> 1.33.1-r6)
Executing busybox-1.33.1-r6.trigger
OK: 6 MiB in 14 packages
fetch https://dl-cdn.alpinelinux.org/alpine/v3.14/main/x86_64/APKINDEX.tar.gz
fetch https://dl-cdn.alpinelinux.org/alpine/v3.14/community/x86_64/APKINDEX.tar.gz
(1/2) Installing libgcc (10.3.1_git20210424-r2)
(2/2) Installing libstdc++ (10.3.1_git20210424-r2)
OK: 7 MiB in 16 packages
fetch https://dl-cdn.alpinelinux.org/alpine/v3.14/main/x86_64/APKINDEX.tar.gz
fetch https://dl-cdn.alpinelinux.org/alpine/v3.14/community/x86_64/APKINDEX.tar.gz
(1/6) Installing ca-certificates (20191127-r5)
(2/6) Installing brotli-libs (1.0.9-r5)
(3/6) Installing nghttp2-libs (1.43.0-r0)
(4/6) Installing libcurl (7.79.1-r0)
(5/6) Installing curl (7.79.1-r0)
(6/6) Installing .build-deps (20211206.144900)
Executing busybox-1.33.1-r6.trigger
Executing ca-certificates-20191127-r5.trigger
OK: 10 MiB in 22 packages
node-v14.18.2-linux-x64-musl.tar.xz: OK
(1/6) Purging .build-deps (20211206.144900)
(2/6) Purging curl (7.79.1-r0)
(3/6) Purging libcurl (7.79.1-r0)
(4/6) Purging ca-certificates (20191127-r5)
Executing ca-certificates-20191127-r5.post-deinstall
(5/6) Purging brotli-libs (1.0.9-r5)
(6/6) Purging nghttp2-libs (1.43.0-r0)
Executing busybox-1.33.1-r6.trigger
OK: 7 MiB in 16 packages
v14.18.2
6.14.15
Removing intermediate container 783ec629014f
 ---> ea8ecf53260e
Step 4/8 : ENV YARN_VERSION 1.22.15
 ---> Running in f31fa11842ee
Removing intermediate container f31fa11842ee
 ---> bedecda0b845
Step 5/8 : RUN apk add --no-cache --virtual .build-deps-yarn curl gnupg tar   && for key in     6A010C5166006599AA17F08146C2130DFD2497F5   ; do     gpg --batch --keyserver hkps://keys.openpgp.org --recv-keys "$key" ||     gpg --batch --keyserver keyserver.ubuntu.com --recv-keys "$key" ;   done   && curl -fsSLO --compressed "https://yarnpkg.com/downloads/$YARN_VERSION/yarn-v$YARN_VERSION.tar.gz"   && curl -fsSLO --compressed "https://yarnpkg.com/downloads/$YARN_VERSION/yarn-v$YARN_VERSION.tar.gz.asc"   && gpg --batch --verify yarn-v$YARN_VERSION.tar.gz.asc yarn-v$YARN_VERSION.tar.gz   && mkdir -p /opt   && tar -xzf yarn-v$YARN_VERSION.tar.gz -C /opt/   && ln -s /opt/yarn-v$YARN_VERSION/bin/yarn /usr/local/bin/yarn   && ln -s /opt/yarn-v$YARN_VERSION/bin/yarnpkg /usr/local/bin/yarnpkg   && rm yarn-v$YARN_VERSION.tar.gz.asc yarn-v$YARN_VERSION.tar.gz   && apk del .build-deps-yarn   && yarn --version
 ---> Running in 2902887fabf8
fetch https://dl-cdn.alpinelinux.org/alpine/v3.14/main/x86_64/APKINDEX.tar.gz
fetch https://dl-cdn.alpinelinux.org/alpine/v3.14/community/x86_64/APKINDEX.tar.gz
(1/36) Installing ca-certificates (20191127-r5)
(2/36) Installing brotli-libs (1.0.9-r5)
(3/36) Installing nghttp2-libs (1.43.0-r0)
(4/36) Installing libcurl (7.79.1-r0)
(5/36) Installing curl (7.79.1-r0)
(6/36) Installing libgpg-error (1.42-r0)
(7/36) Installing libassuan (2.5.5-r0)
(8/36) Installing libcap (2.50-r0)
(9/36) Installing libffi (3.3-r2)
(10/36) Installing libintl (0.21-r0)
(11/36) Installing libblkid (2.37.2-r0)
(12/36) Installing libmount (2.37.2-r0)
(13/36) Installing pcre (8.44-r0)
(14/36) Installing glib (2.68.3-r0)
(15/36) Installing ncurses-terminfo-base (6.2_p20210612-r0)
(16/36) Installing ncurses-libs (6.2_p20210612-r0)
(17/36) Installing libgcrypt (1.9.4-r0)
(18/36) Installing libsecret (0.20.4-r1)
(19/36) Installing pinentry (1.1.1-r0)
Executing pinentry-1.1.1-r0.post-install
(20/36) Installing libbz2 (1.0.8-r1)
(21/36) Installing gmp (6.2.1-r0)
(22/36) Installing nettle (3.7.3-r0)
(23/36) Installing p11-kit (0.23.22-r0)
(24/36) Installing libtasn1 (4.17.0-r0)
(25/36) Installing libunistring (0.9.10-r1)
(26/36) Installing gnutls (3.7.1-r0)
(27/36) Installing libksba (1.5.1-r0)
(28/36) Installing gdbm (1.19-r0)
(29/36) Installing libsasl (2.1.27-r12)
(30/36) Installing libldap (2.4.58-r0)
(31/36) Installing npth (1.6-r0)
(32/36) Installing sqlite-libs (3.35.5-r0)
(33/36) Installing gnupg (2.2.31-r0)
(34/36) Installing libacl (2.2.53-r0)
(35/36) Installing tar (1.34-r0)
(36/36) Installing .build-deps-yarn (20211206.144907)
Executing busybox-1.33.1-r6.trigger
Executing ca-certificates-20191127-r5.trigger
OK: 30 MiB in 52 packages
gpg: directory '/root/.gnupg' created
gpg: keybox '/root/.gnupg/pubring.kbx' created
gpg: /root/.gnupg/trustdb.gpg: trustdb created
gpg: key 1646B01B86E50310: public key "Yarn Packaging <yarn@dan.cx>" imported
gpg: Total number processed: 1
gpg:               imported: 1
gpg: Signature made Thu Sep 30 00:14:59 2021 UTC
gpg:                using RSA key 6D98490C6F1ACDDD448E45954F77679369475BAA
gpg: Good signature from "Yarn Packaging <yarn@dan.cx>" [unknown]
gpg: WARNING: This key is not certified with a trusted signature!
gpg:          There is no indication that the signature belongs to the owner.
Primary key fingerprint: 72EC F46A 56B4 AD39 C907  BBB7 1646 B01B 86E5 0310
     Subkey fingerprint: 6D98 490C 6F1A CDDD 448E  4595 4F77 6793 6947 5BAA
(1/36) Purging .build-deps-yarn (20211206.144907)
(2/36) Purging curl (7.79.1-r0)
(3/36) Purging gnupg (2.2.31-r0)
(4/36) Purging pinentry (1.1.1-r0)
(5/36) Purging tar (1.34-r0)
(6/36) Purging libcurl (7.79.1-r0)
(7/36) Purging ca-certificates (20191127-r5)
Executing ca-certificates-20191127-r5.post-deinstall
(8/36) Purging brotli-libs (1.0.9-r5)
(9/36) Purging nghttp2-libs (1.43.0-r0)
(10/36) Purging libksba (1.5.1-r0)
(11/36) Purging libsecret (0.20.4-r1)
(12/36) Purging libgcrypt (1.9.4-r0)
(13/36) Purging libassuan (2.5.5-r0)
(14/36) Purging libgpg-error (1.42-r0)
(15/36) Purging libcap (2.50-r0)
(16/36) Purging glib (2.68.3-r0)
(17/36) Purging gnutls (3.7.1-r0)
(18/36) Purging p11-kit (0.23.22-r0)
(19/36) Purging libffi (3.3-r2)
(20/36) Purging libintl (0.21-r0)
(21/36) Purging libmount (2.37.2-r0)
(22/36) Purging libblkid (2.37.2-r0)
(23/36) Purging pcre (8.44-r0)
(24/36) Purging ncurses-libs (6.2_p20210612-r0)
(25/36) Purging ncurses-terminfo-base (6.2_p20210612-r0)
(26/36) Purging libbz2 (1.0.8-r1)
(27/36) Purging nettle (3.7.3-r0)
(28/36) Purging gmp (6.2.1-r0)
(29/36) Purging libtasn1 (4.17.0-r0)
(30/36) Purging libunistring (0.9.10-r1)
(31/36) Purging libldap (2.4.58-r0)
(32/36) Purging libsasl (2.1.27-r12)
(33/36) Purging gdbm (1.19-r0)
(34/36) Purging npth (1.6-r0)
(35/36) Purging sqlite-libs (3.35.5-r0)
(36/36) Purging libacl (2.2.53-r0)
Executing busybox-1.33.1-r6.trigger
OK: 7 MiB in 16 packages
1.22.15
Removing intermediate container 2902887fabf8
 ---> d39069eab0a7
Step 6/8 : COPY docker-entrypoint.sh /usr/local/bin/
 ---> c604621988d8
Step 7/8 : ENTRYPOINT ["docker-entrypoint.sh"]
 ---> Running in 205fdb4cc07a
Removing intermediate container 205fdb4cc07a
 ---> e1a4b855667c
Step 8/8 : CMD [ "node" ]
 ---> Running in 7e4c77ccdc86
Removing intermediate container 7e4c77ccdc86
 ---> 30d5ab2b8847
Successfully built 30d5ab2b8847
Successfully tagged node:14.18.2-alpine3.14
```

## Types of changes

- [ ] Documentation
- [ ] Version change (Update, remove or add more Node.js versions)
- [ ] Variant change (Update, remove or add more variants, or versions of variants)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Others (non of above)

## Checklist

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING.md** document.
- [x] All new and existing tests passed.