### PR TITLE
Clean up temp Dockerfile in update.sh before fatal exit

### DIFF
--- a/update.sh
+++ b/update.sh
@@ -160,6 +160,7 @@ function update_node_version() {
         curl -sSL --compressed "https://unofficial-builds.nodejs.org/download/release/v${nodeVersion}/SHASUMS256.txt" | grep "node-v${nodeVersion}-linux-x64-musl.tar.xz" | cut -d' ' -f1
       )
       if [ -z "$checksum" ]; then
+        rm -f "${dockerfile}-tmp"
         fatal "Failed to fetch checksum for version ${nodeVersion}"
       fi
       sed -Ei -e "s/(alpine:)0.0/\\1${alpine_version}/" "${dockerfile}-tmp"


### PR DESCRIPTION
## Description

Clean up temporarily generated Dockerfiles in the update.sh before fatal exit

## Motivation and Context

Currently, the fatal exit will leave the temporarily generated Dockerfiles, should be removed:

```
Untracked files:
  (use "git add <file>..." to include in what will be committed)
	14/alpine3.14/Dockerfile-tmp
	14/alpine3.15/Dockerfile-tmp
```


## Testing Details

Run `./update.sh` with fatal error situation, and make sure the patched version left no additional temp files.

## Types of changes

- [ ] Documentation
- [ ] Version change (Update, remove or add more Node.js versions)
- [ ] Variant change (Update, remove or add more variants, or versions of variants)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Others (non of above)

## Checklist

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING.md** document.
- [x] All new and existing tests passed.

