### PR TITLE
Use `-V` instead of `-n` to sort in update.sh, fix #1636

### DIFF
--- a/update.sh
+++ b/update.sh
@@ -122,7 +122,7 @@ function update_node_version() {
     shift
   fi
 
-  fullVersion="$(curl -sSL --compressed "${baseuri}" | grep '<a href="v'"${version}." | sed -E 's!.*<a href="v([^"/]+)/?".*!\1!' | cut -d'.' -f2,3 | sort -n | tail -1)"
+  fullVersion="$(curl -sSL --compressed "${baseuri}" | grep '<a href="v'"${version}." | sed -E 's!.*<a href="v([^"/]+)/?".*!\1!' | cut -d'.' -f2,3 | sort -V | tail -1)"
   (
     cp "${template}" "${dockerfile}-tmp"
     local fromprefix=""


### PR DESCRIPTION
## Description

Fix `update.sh` does not pick up new node release #1636 issue

We should use `sort -V` instead of `sort -n` here. The order is a little bit different:

| Result from `sort -V` | Result from `sort -n` |
| ---- | ---- |
| 0.0 | 0.0 |
| 1.0 | 1.0 |
| 2.0 | 2.0 |
| 3.0 | 3.0 |
| 3.1 | 3.1 |
| 4.0 | 4.0 |
| 5.0 | 5.0 |
| 6.0 | 6.0 |
| 7.0 | 7.0 |
| 8.0 | 8.0 |
| 8.1 | 8.1 |
| 9.0 | 9.0 |
| 9.1 | 9.1 |
| 10.0 | 10.0 |
| 11.0 | 11.0 |
| 11.1 | 11.1 |
| 12.0 | 12.0 |
| 13.0 | 13.0 |
| 13.1 | 13.1 |
| 14.0 | 14.0 |
| 14.1 | 14.1 |
| 15.0 | 15.0 |
| 16.0 | 16.0 |
| 16.1 | 16.1 |
| 16.2 | 16.2 |
| 16.3 | 16.3 |
| 17.0 | 17.0 |
| 18.0 | 18.0 |
| 18.1 | 18.1 |
| 18.2 | 18.2 |
| 18.3 | 18.3 |
| 18.4 | 18.4 |
| 19.0 | 19.0 |
| 19.1 | 19.1 |
| 20.0 | 20.0 |
| 20.1 | 20.1 |
| 20.2 | 20.2 |
| 21.0 | 21.0 |
| 22.0 | 22.0 |
| 22.1 | 22.1 |
| **22.10** | **22.2** |
| 22.2 | 22.3 |
| 22.3 | 22.4 |
| 22.4 | 22.5 |
| 22.5 | 22.6 |
| 22.6 | 22.7 |
| 22.7 | 22.8 |
| 22.8 | 22.9 |
| **22.9** | **22.10** |

## Motivation and Context

`update.sh` failed to fetch v12.22.10

## Testing Details

Simply run patched & unpatched `update.sh` at the `main` branch and compare the result of updated Dockerfiles.

## Types of changes

- [ ] Documentation
- [ ] Version change (Update, remove or add more Node.js versions)
- [ ] Variant change (Update, remove or add more variants, or versions of variants)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Others (non of above)

## Checklist

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING.md** document.
- [ ] All new and existing tests passed.

