### PR TITLE
chore: run all GH actions using Node LTS, not v12

### DIFF
--- a/.github/workflows/doctoc.yml
+++ b/.github/workflows/doctoc.yml
@@ -14,7 +14,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v3
         with:
-          node-version: '12.x'
+          node-version: 'lts/*'
       - name: Install doctoc
         run: npm i -g doctoc
       - name: Create README copy and diff with doctoc

--- a/.github/workflows/eclint.yml
+++ b/.github/workflows/eclint.yml
@@ -9,6 +9,6 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v3
         with:
-          node-version: '12.x'
+          node-version: 'lts/*'
       - run: npm i -g eclint
       - run: eclint check

--- a/.github/workflows/markdown-link-check.yml
+++ b/.github/workflows/markdown-link-check.yml
@@ -12,7 +12,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v3
         with:
-          node-version: '12.x'
+          node-version: 'lts/*'
       - name: Install markdown-link-check
         run: npm i -g markdown-link-check
       - name: Run markdown-link-check on MD files


### PR DESCRIPTION
12 is soon EOL, and just targeting `lts` means one less thing to keep up to date 🙂 