### PR TITLE
chore: add awk escapes for openpgp keyserver

### DIFF
--- a/update-keys.sh
+++ b/update-keys.sh
@@ -1,3 +1,3 @@
 #!/bin/sh -ex
 
-curl -fsSLo- --compressed https://github.com/nodejs/node/raw/master/README.md | awk '/^gpg --keyserver hkps://keys.openpgp.org --recv-keys/ {print $NF}' > keys/node.keys
+curl -fsSLo- --compressed https://github.com/nodejs/node/raw/master/README.md | awk '/^gpg --keyserver hkps:\/\/keys\.openpgp\.org --recv-keys/ {print $NF}' > keys/node.keys


### PR DESCRIPTION
## Description

Add awk escape sequences to opengpg key server url to update-keys.sh

## Motivation and Context

The awk command in update-keys.sh was failing with the unescaped URL. 

## Testing Details

Ran `./update-keys.sh` to confirm output to `keys/node.keys`

## Types of changes

<!--
What types of changes does your code introduce? Put an `x` in all the boxes that apply.
-->

- [ ] Documentation
- [ ] Version change (Update, remove or add more Node.js versions)
- [ ] Variant change (Update, remove or add more variants, or versions of variants)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Others (non of above)

## Checklist

<!--
Go over all the following points, and put an `x` in all the boxes that apply.
If you're unsure about any of these, don't hesitate to ask. We're here to help!
-->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING.md** document.
- [ ] All new and existing tests passed.

