### PR TITLE
fix: get correct commit message and PR title for auto PRs

### DIFF
--- a/.github/workflows/automatic-updates.yml
+++ b/.github/workflows/automatic-updates.yml
@@ -16,6 +16,7 @@ jobs:
         uses: actions/github-script@v6
         id: updt
         with:
+          result-encoding: string
           script: |
             const { default: script } = await import(`${process.env.GITHUB_WORKSPACE}/build-automation.mjs`);
             return script(github);
@@ -28,8 +29,8 @@ jobs:
           author: "Node.js GitHub Bot <nodejs-github-bot@users.noreply.github.com>"
           branch: update-branch
           base: main
-          commit-message: "feat: Node.js ${{ steps.updt.outputs.result.updatedVersionsString }}"
-          title: "feat: Node.js ${{ steps.updt.outputs.result.updatedVersionsString }}"
+          commit-message: "feat: Node.js ${{ steps.updt.outputs.result }}"
+          title: "feat: Node.js ${{ steps.updt.outputs.result }}"
           delete-branch: true
           team-reviewers: |
             @nodejs/docker

--- a/build-automation.mjs
+++ b/build-automation.mjs
@@ -100,6 +100,6 @@ export default async function(github) {
     const { stdout } = (await exec(`git diff`));
     console.log(stdout);
 
-    return { updatedVersions, updatedVersionsString: updatedVersions.join(', ') };
+    return updatedVersions.join(', ');
   }
 }


### PR DESCRIPTION
See #1688 which is missing the versions. I think by returning JSON we need to parse it in the later step. Since we only use the string, returning that directly seems easier.

https://github.com/actions/github-script/blob/9bd6ae64c1b3b9677eba79c33befd8c1c45088c0/src/main.ts#L54