### PR TITLE
fix: building node:14.19.1 with alpine:3.15.4 to fix busybox vulnerab…

### DIFF
--- a/14/alpine3.15/Dockerfile
+++ b/14/alpine3.15/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.15
+FROM alpine:3.15.4
 
 ENV NODE_VERSION 14.19.1
 


### PR DESCRIPTION
This PR addresses to fix a busybox vulnerability found in the existing node:14.9.1-alpine-3:15 ### image.

Build node:14.19.1 with later version of Alpine base image

## Description

Alpine 3.15.4 fixes the busybox vulernability and this PR updates the docker file to consume 3:15.4

## Motivation and Context

The rationale is to fix a busybox issue found in alpine3:15

## Testing Details

Performed docker build and tested

## Types of changes


- [ ] Documentation
- [ ] Version change (Update, remove or add more Node.js versions)
- [ x] Variant change (Update, remove or add more variants, or versions of variants)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Others (non of above)

## Checklist

- [ x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ x] I have read the **CONTRIBUTING.md** document.
- [x ] All new and existing tests passed.

