### PR TITLE
chore: Set permissions for GitHub actions

### DIFF
--- a/.github/workflows/doctoc.yml
+++ b/.github/workflows/doctoc.yml
@@ -6,6 +6,9 @@ on:
       - "README.md"
       - "docs/BestPractices.md"
 
+permissions:
+  contents: read
+
 jobs:
   doctoc:
     name: Doc TOC Check

--- a/.github/workflows/eclint.yml
+++ b/.github/workflows/eclint.yml
@@ -2,6 +2,9 @@ name: Test Whitespace and line endings
 
 on: [pull_request]
 
+permissions:
+  contents: read
+
 jobs:
   eclint:
     runs-on: ubuntu-latest

--- a/.github/workflows/markdown-link-check.yml
+++ b/.github/workflows/markdown-link-check.yml
@@ -5,6 +5,9 @@ on:
     paths:
       - "**/*.md"
 
+permissions:
+  contents: read
+
 jobs:
   markdown-link-check:
     runs-on: ubuntu-latest

--- a/.github/workflows/missing-checksum.yml
+++ b/.github/workflows/missing-checksum.yml
@@ -6,6 +6,9 @@ on:
       - ".github/workflows/missing-checksum.yml"
       - "**/alpine*/Dockerfile"
 
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: ubuntu-latest

--- a/.github/workflows/shfmt.yml
+++ b/.github/workflows/shfmt.yml
@@ -5,6 +5,9 @@ on:
     paths:
       - "**/*.sh"
 
+permissions:
+  contents: read
+
 jobs:
   shfmt:
     runs-on: ubuntu-latest


### PR DESCRIPTION
 Restrict the GitHub token permissions only to the required ones; this way, even if the attackers will succeed in compromising your workflow, they won’t be able to do much.

- Included permissions for the action. https://github.com/ossf/scorecard/blob/main/docs/checks.md#token-permissions

https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#permissions

https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs

[Keeping your GitHub Actions and workflows secure Part 1: Preventing pwn requests](https://securitylab.github.com/research/github-actions-preventing-pwn-requests/)

Signed-off-by: naveensrinivasan <172697+naveensrinivasan@users.noreply.github.com>
