### PR TITLE
fix: alpine: add xz package

### DIFF
--- a/12/alpine3.14/Dockerfile
+++ b/12/alpine3.14/Dockerfile
@@ -8,6 +8,7 @@ RUN addgroup -g 1000 node \
         libstdc++ \
     && apk add --no-cache --virtual .build-deps \
         curl \
+        xz \
     && ARCH= && alpineArch="$(apk --print-arch)" \
       && case "${alpineArch##*-}" in \
         x86_64) \

--- a/12/alpine3.15/Dockerfile
+++ b/12/alpine3.15/Dockerfile
@@ -8,6 +8,7 @@ RUN addgroup -g 1000 node \
         libstdc++ \
     && apk add --no-cache --virtual .build-deps \
         curl \
+        xz \
     && ARCH= && alpineArch="$(apk --print-arch)" \
       && case "${alpineArch##*-}" in \
         x86_64) \

--- a/14/alpine3.14/Dockerfile
+++ b/14/alpine3.14/Dockerfile
@@ -8,6 +8,7 @@ RUN addgroup -g 1000 node \
         libstdc++ \
     && apk add --no-cache --virtual .build-deps \
         curl \
+        xz \
     && ARCH= && alpineArch="$(apk --print-arch)" \
       && case "${alpineArch##*-}" in \
         x86_64) \

--- a/14/alpine3.15/Dockerfile
+++ b/14/alpine3.15/Dockerfile
@@ -8,6 +8,7 @@ RUN addgroup -g 1000 node \
         libstdc++ \
     && apk add --no-cache --virtual .build-deps \
         curl \
+        xz \
     && ARCH= && alpineArch="$(apk --print-arch)" \
       && case "${alpineArch##*-}" in \
         x86_64) \

--- a/16/alpine3.14/Dockerfile
+++ b/16/alpine3.14/Dockerfile
@@ -8,6 +8,7 @@ RUN addgroup -g 1000 node \
         libstdc++ \
     && apk add --no-cache --virtual .build-deps \
         curl \
+        xz \
     && ARCH= && alpineArch="$(apk --print-arch)" \
       && case "${alpineArch##*-}" in \
         x86_64) \

--- a/16/alpine3.15/Dockerfile
+++ b/16/alpine3.15/Dockerfile
@@ -8,6 +8,7 @@ RUN addgroup -g 1000 node \
         libstdc++ \
     && apk add --no-cache --virtual .build-deps \
         curl \
+        xz \
     && ARCH= && alpineArch="$(apk --print-arch)" \
       && case "${alpineArch##*-}" in \
         x86_64) \

--- a/17/alpine3.14/Dockerfile
+++ b/17/alpine3.14/Dockerfile
@@ -8,6 +8,7 @@ RUN addgroup -g 1000 node \
         libstdc++ \
     && apk add --no-cache --virtual .build-deps \
         curl \
+        xz \
     && ARCH= && alpineArch="$(apk --print-arch)" \
       && case "${alpineArch##*-}" in \
         x86_64) \

--- a/17/alpine3.15/Dockerfile
+++ b/17/alpine3.15/Dockerfile
@@ -8,6 +8,7 @@ RUN addgroup -g 1000 node \
         libstdc++ \
     && apk add --no-cache --virtual .build-deps \
         curl \
+        xz \
     && ARCH= && alpineArch="$(apk --print-arch)" \
       && case "${alpineArch##*-}" in \
         x86_64) \

--- a/18/alpine3.14/Dockerfile
+++ b/18/alpine3.14/Dockerfile
@@ -8,6 +8,7 @@ RUN addgroup -g 1000 node \
         libstdc++ \
     && apk add --no-cache --virtual .build-deps \
         curl \
+        xz \
     && ARCH= && alpineArch="$(apk --print-arch)" \
       && case "${alpineArch##*-}" in \
         x86_64) \

--- a/18/alpine3.15/Dockerfile
+++ b/18/alpine3.15/Dockerfile
@@ -8,6 +8,7 @@ RUN addgroup -g 1000 node \
         libstdc++ \
     && apk add --no-cache --virtual .build-deps \
         curl \
+        xz \
     && ARCH= && alpineArch="$(apk --print-arch)" \
       && case "${alpineArch##*-}" in \
         x86_64) \


### PR DESCRIPTION
xz is used to extract the archive.

This is included on default on most architectures but not on riscv.

Add xz with "apk add" to ensure that it is available.
