### PR TITLE
fix: set correct default distro

### DIFF
--- a/config
+++ b/config
@@ -1,4 +1,4 @@
 baseuri     https://nodejs.org/dist
-default_variant stretch
+default_variant bullseye
 alpine_version  3.15
 debian_versions stretch bullseye buster


### PR DESCRIPTION
I'm unsure if this is is correct, but without it, this fails to list v18 (meaning the update script doesn't work for the new 18.1.0)(which atm doesn't matter since musl build isn't done, but still))

```sh-session
$ source functions.js
$ get_versions
14 16 17
```

https://github.com/nodejs/docker-node/blob/494c3c3775b4385099a75abfe339b9efcbb1a970/functions.sh#L139-L156

(we really should rewrite these to JS 😅)