### PR TITLE
Fixed bug in node:16-alpine Dockerfile that appears on arm64 architecture

### DIFF
--- a/16/alpine3.15/Dockerfile
+++ b/16/alpine3.15/Dockerfile
@@ -96,4 +96,6 @@ RUN apk add --no-cache --virtual .build-deps-yarn curl gnupg tar \
 COPY docker-entrypoint.sh /usr/local/bin/
 ENTRYPOINT ["docker-entrypoint.sh"]
 
+RUN mkdir /usr/local/sbin; ln -ns /usr/local/bin/node /usr/local/sbin/node || true
+
 CMD [ "node" ]


### PR DESCRIPTION
Bug:
I was unable to use yarn on arm64 architecture

## Description

I normally used `node:16-alpine` in my docker file. It works fine on amd64 architecture. Then I was needed to build an arm64 image of the container. And there happened a problem.

Simplified Dockerfile for this example:
```
FROM node:16-alpine
RUN yarn --version
```

Output of `docker buildx inspect`:
```
Name:   mybuilder
Driver: docker-container

Nodes:
Name:      mybuilder0
Endpoint:  unix:///var/run/docker.sock
Status:    running
Platforms: linux/arm64*, linux/amd64*, linux/amd64/v2, linux/amd64/v3, linux/386
```

Command I use to build container for both architectures:
```
docker buildx build --push --platform=linux/amd64,linux/arm64/v8 -t nikelborm/home:front-latest .
```

Previous command causes this output:
```
[+] Building 13.2s (9/9) FINISHED                                                                                                                                                                                    
 => [internal] load build definition from Dockerfile                                                                                                                                                            0.0s
 => => transferring dockerfile: 1.74kB                                                                                                                                                                          0.0s
 => [internal] load .dockerignore                                                                                                                                                                               0.0s
 => => transferring context: 76B                                                                                                                                                                                0.0s
 => [linux/arm64 internal] load metadata for docker.io/library/node:16-alpine                                                                                                                                  12.7s
 => [auth] library/node:pull token for registry-1.docker.io                                                                                                                                                     0.0s
 => [linux/amd64 internal] load metadata for docker.io/library/node:16-alpine                                                                                                                                   6.8s
 => CACHED [linux/arm64 1/2] FROM docker.io/library/node:16-alpine@sha256:1a9a71ea86aad332aa7740316d4111ee1bd4e890df47d3b5eff3e5bded3b3d10                                                                      0.0s
 => => resolve docker.io/library/node:16-alpine@sha256:1a9a71ea86aad332aa7740316d4111ee1bd4e890df47d3b5eff3e5bded3b3d10                                                                                         0.0s
 => [linux/amd64 1/2] FROM docker.io/library/node:16-alpine@sha256:1a9a71ea86aad332aa7740316d4111ee1bd4e890df47d3b5eff3e5bded3b3d10                                                                             0.0s
 => => resolve docker.io/library/node:16-alpine@sha256:1a9a71ea86aad332aa7740316d4111ee1bd4e890df47d3b5eff3e5bded3b3d10                                                                                         0.0s
 => CACHED [linux/amd64 2/2] RUN yarn --version                                                                                                                                                                 0.0s
 => ERROR [linux/arm64 2/2] RUN yarn --version                                                                                                                                                                  0.3s
------
 > [linux/arm64 2/2] RUN yarn --version:
#0 0.222 Error while loading /usr/local/sbin/node: No such file or directory
------
Dockerfile:2
--------------------
   1 |     FROM node:16-alpine
   2 | >>> RUN yarn --version
   3 |     
   4 |     # RUN mkdir /usr/local/sbin; ln -ns /usr/local/bin/node /usr/local/sbin/node || true
--------------------
error: failed to solve: process "/dev/.buildkit_qemu_emulator /bin/sh -c yarn --version" did not complete successfully: exit code: 1
```
From this output, we can see that the problem appears only on arm64 arch.

I started to research this problem and found that everything was fine except for, well, there is no either `/usr/local/sbin`, neither `/usr/local/sbin/node`

I checked both arm64 and amd64 images of `node:16-alpine` and both of them doesn't have `/usr/local/sbin` directory. I don't know why but it becomes a problem only for arm64 build.

I changed my Dockerfile to 
```
FROM node:16-alpine
RUN node --version

# RUN mkdir /usr/local/sbin; ln -ns /usr/local/bin/node /usr/local/sbin/node || true

RUN ls -AlF --group-directories-first /usr/local/ && \
  echo -e '\n' &&\
  ls -AlF --group-directories-first /usr/local/bin && \
  echo -e '\n' &&\
  printenv && \
  echo -e '\n' &&\
  which node && \
  echo -e '\n' &&\
  cat /opt/yarn-v1.22.18/bin/yarn &&\
  echo -e '\n' &&\
  yarn --version
```

Output was like that:

```
[+] Building 13.1s (11/11) FINISHED                                                                                                                                                                                  
 => [internal] load build definition from Dockerfile                                                                                                                                                            0.0s
 => => transferring dockerfile: 1.66kB                                                                                                                                                                          0.0s
 => [internal] load .dockerignore                                                                                                                                                                               0.0s
 => => transferring context: 76B                                                                                                                                                                                0.0s
 => [linux/arm64 internal] load metadata for docker.io/library/node:16-alpine                                                                                                                                  12.5s
 => [auth] library/node:pull token for registry-1.docker.io                                                                                                                                                     0.0s
 => [linux/amd64 internal] load metadata for docker.io/library/node:16-alpine                                                                                                                                   6.6s
 => [linux/arm64 1/3] FROM docker.io/library/node:16-alpine@sha256:1a9a71ea86aad332aa7740316d4111ee1bd4e890df47d3b5eff3e5bded3b3d10                                                                             0.0s
 => => resolve docker.io/library/node:16-alpine@sha256:1a9a71ea86aad332aa7740316d4111ee1bd4e890df47d3b5eff3e5bded3b3d10                                                                                         0.0s
 => [linux/amd64 1/3] FROM docker.io/library/node:16-alpine@sha256:1a9a71ea86aad332aa7740316d4111ee1bd4e890df47d3b5eff3e5bded3b3d10                                                                             0.0s
 => => resolve docker.io/library/node:16-alpine@sha256:1a9a71ea86aad332aa7740316d4111ee1bd4e890df47d3b5eff3e5bded3b3d10                                                                                         0.0s
 => CACHED [linux/amd64 2/3] RUN node --version                                                                                                                                                                 0.0s
 => [linux/amd64 3/3] RUN ls -AlF --group-directories-first /usr/local/ &&   echo -e '\n' &&  ls -AlF --group-directories-first /usr/local/bin &&   echo -e '\n' &&  printenv &&   echo -e '\n' &&  which node  0.4s
 => CACHED [linux/arm64 2/3] RUN node --version                                                                                                                                                                 0.0s
 => ERROR [linux/arm64 3/3] RUN ls -AlF --group-directories-first /usr/local/ &&   echo -e '\n' &&  ls -AlF --group-directories-first /usr/local/bin &&   echo -e '\n' &&  printenv &&   echo -e '\n' &&  whic  0.5s
------                                                                                                                                                                                                               
 > [linux/arm64 3/3] RUN ls -AlF --group-directories-first /usr/local/ &&   echo -e '\n' &&  ls -AlF --group-directories-first /usr/local/bin &&   echo -e '\n' &&  printenv &&   echo -e '\n' &&  which node &&   echo -e '\n' &&  cat /opt/yarn-v1.22.18/bin/yarn &&  echo -e '\n' &&  yarn --version:                                                                                                                                  
#0 0.139 total 0                                                                                                                                                                                                     
#0 0.144 drwxr-xr-x    1 root     root            40 Apr 27 22:35 bin/                                                                                                                                               
#0 0.144 drwxr-xr-x    1 root     root             8 Apr 27 22:35 include/                                                                                                                                           
#0 0.144 drwxr-xr-x    1 root     root            24 Apr 27 22:35 lib/                                                                                                                                               
#0 0.144 drwxr-xr-x    1 root     root            30 Apr 27 22:35 share/                                                                                                                                             
#0 0.148                                                                                                                                                                                                             
#0 0.148                                                                                                                                                                                                             
#0 0.163 total 80464                                                                                                                                                                                                 
#0 0.169 lrwxrwxrwx    1 root     root            45 Apr 27 22:35 corepack -> ../lib/node_modules/corepack/dist/corepack.js*                                                                                         
#0 0.169 -rwxrwxr-x    1 root     root           388 Apr 27 21:55 docker-entrypoint.sh*
#0 0.169 -rwxr-xr-x    1 root     root      82368064 Apr 27 22:35 node*
#0 0.169 lrwxrwxrwx    1 root     root            38 Apr 27 22:35 npm -> ../lib/node_modules/npm/bin/npm-cli.js*
#0 0.169 lrwxrwxrwx    1 root     root            38 Apr 27 22:35 npx -> ../lib/node_modules/npm/bin/npx-cli.js*
#0 0.169 lrwxrwxrwx    1 root     root            27 Apr 27 22:35 yarn -> /opt/yarn-v1.22.18/bin/yarn*
#0 0.169 lrwxrwxrwx    1 root     root            30 Apr 27 22:35 yarnpkg -> /opt/yarn-v1.22.18/bin/yarnpkg*
#0 0.169 
#0 0.169 
#0 0.178 PWD=/
#0 0.178 PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
#0 0.178 HOME=/root
#0 0.178 SHLVL=1
#0 0.178 YARN_VERSION=1.22.18
#0 0.178 NODE_VERSION=16.15.0
#0 0.179 
#0 0.179 
#0 0.190 /usr/local/bin/node
#0 0.191 
#0 0.191 
#0 0.201 #!/bin/sh
#0 0.201 argv0=$(echo "$0" | sed -e 's,\\,/,g')
#0 0.201 basedir=$(dirname "$(readlink "$0" || echo "$argv0")")
#0 0.201 
#0 0.201 case "$(uname -s)" in
#0 0.201   Darwin) basedir="$( cd "$( dirname "$argv0" )" && pwd )";;
#0 0.201   Linux) basedir=$(dirname "$(readlink -f "$0" || echo "$argv0")");;
#0 0.201   *CYGWIN*) basedir=`cygpath -w "$basedir"`;;
#0 0.201   *MSYS*) basedir=`cygpath -w "$basedir"`;;
#0 0.201 esac
#0 0.201 
#0 0.201 command_exists() {
#0 0.201   command -v "$1" >/dev/null 2>&1;
#0 0.201 }
#0 0.201 
#0 0.201 if command_exists node; then
#0 0.201   if [ "$YARN_FORCE_WINPTY" = 1 ] || command_exists winpty && test -t 1; then
#0 0.201     winpty node "$basedir/yarn.js" "$@"
#0 0.201   else
#0 0.201     exec node "$basedir/yarn.js" "$@"
#0 0.201   fi
#0 0.201   ret=$?
#0 0.201 # Debian and Ubuntu use "nodejs" as the name of the binary, not "node", so we
#0 0.201 # search for that too. See:
#0 0.201 # https://lists.debian.org/debian-devel-announce/2012/07/msg00002.html
#0 0.201 # https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=614907
#0 0.201 elif command_exists nodejs; then
#0 0.201   exec nodejs "$basedir/yarn.js" "$@"
#0 0.201   ret=$?
#0 0.201 else
#0 0.201   >&2 echo 'Yarn requires Node.js 4.0 or higher to be installed.'
#0 0.201   ret=1
#0 0.201 fi
#0 0.201 
#0 0.201 exit $ret
#0 0.202 
#0 0.202 
#0 0.316 Error while loading /usr/local/sbin/node: No such file or directory
------
Dockerfile:6
--------------------
   5 |     
   6 | >>> RUN ls -AlF --group-directories-first /usr/local/ && \
   7 | >>>   echo -e '\n' &&\
   8 | >>>   ls -AlF --group-directories-first /usr/local/bin && \
   9 | >>>   echo -e '\n' &&\
  10 | >>>   printenv && \
  11 | >>>   echo -e '\n' &&\
  12 | >>>   which node && \
  13 | >>>   echo -e '\n' &&\
  14 | >>>   cat /opt/yarn-v1.22.18/bin/yarn &&\
  15 | >>>   echo -e '\n' &&\
  16 | >>>   yarn --version
  17 |     
--------------------
error: failed to solve: process "/dev/.buildkit_qemu_emulator /bin/sh -c ls -AlF --group-directories-first /usr/local/ &&   echo -e '\\n' &&  ls -AlF --group-directories-first /usr/local/bin &&   echo -e '\\n' &&  printenv &&   echo -e '\\n' &&  which node &&   echo -e '\\n' &&  cat /opt/yarn-v1.22.18/bin/yarn &&  echo -e '\\n' &&  yarn --version" did not complete successfully: exit code: 1
```

I want to pay attention to `which node` because it shows that node.js is placed in `/usr/local/bin/node`


`mkdir /usr/local/sbin` will throw an error when alpine team will create this directory, but the error will be ignored because of `; `.
Then I added a link to node js and then everything started work fine

## Testing Details

I tried to build this Dockerfile
```
FROM node:16-alpine

RUN mkdir /usr/local/sbin; ln -ns /usr/local/bin/node /usr/local/sbin/node || true

RUN yarn --version
```

And build was successfull on both architectures
```
[+] Building 18.1s (12/12) FINISHED                                                                                                                                                                                  
 => [internal] load build definition from Dockerfile                                                                                                                                                            0.0s
 => => transferring dockerfile: 1.75kB                                                                                                                                                                          0.0s
 => [internal] load .dockerignore                                                                                                                                                                               0.0s
 => => transferring context: 76B                                                                                                                                                                                0.0s
 => [linux/amd64 internal] load metadata for docker.io/library/node:16-alpine                                                                                                                                   5.9s
 => [linux/arm64 internal] load metadata for docker.io/library/node:16-alpine                                                                                                                                   5.9s
 => [linux/amd64 1/3] FROM docker.io/library/node:16-alpine@sha256:1a9a71ea86aad332aa7740316d4111ee1bd4e890df47d3b5eff3e5bded3b3d10                                                                             0.0s
 => => resolve docker.io/library/node:16-alpine@sha256:1a9a71ea86aad332aa7740316d4111ee1bd4e890df47d3b5eff3e5bded3b3d10                                                                                         0.0s
 => [linux/arm64 1/3] FROM docker.io/library/node:16-alpine@sha256:1a9a71ea86aad332aa7740316d4111ee1bd4e890df47d3b5eff3e5bded3b3d10                                                                             0.0s
 => => resolve docker.io/library/node:16-alpine@sha256:1a9a71ea86aad332aa7740316d4111ee1bd4e890df47d3b5eff3e5bded3b3d10                                                                                         0.0s
 => CACHED [linux/amd64 2/3] RUN mkdir /usr/local/sbin; ln -ns /usr/local/bin/node /usr/local/sbin/node || true                                                                                                 0.0s
 => [linux/amd64 3/3] RUN yarn --version                                                                                                                                                                        0.3s
 => CACHED [linux/arm64 2/3] RUN mkdir /usr/local/sbin; ln -ns /usr/local/bin/node /usr/local/sbin/node || true                                                                                                 0.0s
 => [linux/arm64 3/3] RUN yarn --version                                                                                                                                                                        2.2s
 => exporting to image                                                                                                                                                                                          9.8s 
 => => exporting layers                                                                                                                                                                                         0.2s
 => => exporting manifest sha256:b9e63431b07e3bf6c4bf59920f3f3db7a9d5f0a4f0fa290a5ce6da54baa1956d                                                                                                               0.0s
 => => exporting config sha256:03e246e65cfe367ce6aa3b9eeb12673a929550bb7fd5bc5c6168a9dc0b362b1d                                                                                                                 0.0s
 => => exporting manifest sha256:24d43aa5a2cf3db2c969d11dc10b999c438bbba2397cde8dfef519d4cee43047                                                                                                               0.0s
 => => exporting config sha256:81fc4f39c6d7f5b73afeefbb573730818e500e94121400f5a9f0cc603106de4e                                                                                                                 0.0s
 => => exporting manifest list sha256:ddf36e57a8475ce1788380562cd83ade49085d9e7aface46260b80e1e252d0c2                                                                                                          0.0s
 => => pushing layers                                                                                                                                                                                           8.1s
 => => pushing manifest for docker.io/nikelborm/home:front-latest@sha256:ddf36e57a8475ce1788380562cd83ade49085d9e7aface46260b80e1e252d0c2                                                                       1.5s
 => [auth] nikelborm/home:pull,push token for registry-1.docker.io                                                                                                                                              0.0s
```

So I decided to add this little fix right into the original `node:16-alpine` image

## Types of changes

<!--
What types of changes does your code introduce? Put an `x` in all the boxes that apply.
-->

- [ ] Documentation
- [ ] Version change (Update, remove or add more Node.js versions)
- [ ] Variant change (Update, remove or add more variants, or versions of variants)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Others (non of above)

## Checklist

- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING.md** document.
- [x] All new and existing tests passed.

