### PR TITLE
Add markdown-link-check GitHub Docs workaround, cc #1739

### DIFF
--- a/.github/workflows/markdown-link-check.yml
+++ b/.github/workflows/markdown-link-check.yml
@@ -4,6 +4,7 @@ on:
   pull_request:
     paths:
       - "**/*.md"
+      - ".markdown-link-check.json"
 
 permissions:
   contents: read
@@ -19,4 +20,4 @@ jobs:
       - name: Install markdown-link-check
         run: npm i -g markdown-link-check
       - name: Run markdown-link-check on MD files
-        run: find . -name "*.md" | xargs -n 1 markdown-link-check -q
+        run: find . -name "*.md" | xargs -n 1 markdown-link-check -c markdown_link_check_config.json -q

--- a/markdown_link_check_config.json
+++ b/markdown_link_check_config.json
@@ -1,0 +1,12 @@
+{
+  "httpHeaders": [
+    {
+      "urls": [
+        "https://docs.github.com"
+      ],
+      "headers": {
+        "Accept-Encoding": "br, gzip, deflate"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
## Description

The workaround for the markdown-link-check lint

## Motivation and Context

According to https://github.com/tcort/markdown-link-check/issues/201, GitHub now requires the behavior to accept compressed content, otherwise will return http 403 error, which caused markdown-link-check failed

## Types of changes

- [ ] Documentation
- [ ] Version change (Update, remove or add more Node.js versions)
- [ ] Variant change (Update, remove or add more variants, or versions of variants)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Others (non of above)

## Checklist

<!--
Go over all the following points, and put an `x` in all the boxes that apply.
If you're unsure about any of these, don't hesitate to ask. We're here to help!
-->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING.md** document.
- [ ] All new and existing tests passed.

