### PR TITLE
fix: remove ppc64le and s390x for buster

### DIFF
--- a/versions.json
+++ b/versions.json
@@ -41,16 +41,12 @@
       "buster": [
         "amd64",
         "arm32v7",
-        "arm64v8",
-        "ppc64le",
-        "s390x"
+        "arm64v8"
       ],
       "buster-slim": [
         "amd64",
         "arm32v7",
-        "arm64v8",
-        "ppc64le",
-        "s390x"
+        "arm64v8"
       ]
     }
   },
@@ -96,16 +92,12 @@
       "buster": [
         "amd64",
         "arm32v7",
-        "arm64v8",
-        "ppc64le",
-        "s390x"
+        "arm64v8"
       ],
       "buster-slim": [
         "amd64",
         "arm32v7",
-        "arm64v8",
-        "ppc64le",
-        "s390x"
+        "arm64v8"
       ]
     }
   },
@@ -151,16 +143,12 @@
       "buster": [
         "amd64",
         "arm32v7",
-        "arm64v8",
-        "ppc64le",
-        "s390x"
+        "arm64v8"
       ],
       "buster-slim": [
         "amd64",
         "arm32v7",
-        "arm64v8",
-        "ppc64le",
-        "s390x"
+        "arm64v8"
       ]
     }
   }


### PR DESCRIPTION
Buster is now LTS, so the supported architectures has been reduced by the official images