### PR TITLE
fix: try only to PR files with NODE_VERSION change

### DIFF
--- a/build-automation.mjs
+++ b/build-automation.mjs
@@ -97,7 +97,7 @@ export default async function(github) {
         process.exit(0);
       }
     }
-    const { stdout } = (await exec(`git diff`));
+    const { stdout } = (await exec(`git diff -G NODE_VERSION`));
     console.log(stdout);
 
     return updatedVersions.join(', ');

--- a/functions.sh
+++ b/functions.sh
@@ -340,7 +340,7 @@ function images_updated() {
     IFS=','
     get_versions
   )"
-  images_changed=$(git diff --name-only "${commit_range}" "${versions[@]}")
+  images_changed=$(git diff --name-only "${commit_range}" "${versions[@]}" -G NODE_VERSION)
 
   if [ -z "${images_changed}" ]; then
     return 1


### PR DESCRIPTION
Don't think this actually will resolve it, but this diff command will limit it to only the files that have changed versions.
Proper solution probably needs some re-work that would require the migration from SH to JS for `update.sh`

