### PR TITLE
fix: do not exit automation script if one musl version is missing

### DIFF
--- a/build-automation.mjs
+++ b/build-automation.mjs
@@ -94,7 +94,6 @@ export default async function(github) {
         updatedVersions.push(newVersions[version].fullVersion);
       } else {
         console.log(`There's no musl build for version ${newVersions[version].fullVersion} yet.`);
-        process.exit(0);
       }
     }
     const { stdout } = (await exec(`git diff`));


### PR DESCRIPTION
For some reason, 14.21.1 is missing, but that doesn't mean we don't want the other versions.

https://github.com/nodejs/docker-node/actions/runs/3399467227/jobs/5653234992#step:3:21