### PR TITLE
Update version of the alpine image to 3.17.1

### DIFF
--- a/14/alpine3.17/Dockerfile
+++ b/14/alpine3.17/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.17
+FROM alpine:3.17.1
 
 ENV NODE_VERSION 14.21.2
 


### PR DESCRIPTION

## Description

Update version of alpine being used on the Dockerfile from 3.17 to 3.17.1

## Motivation and Context

This change is required to update the base image version for a new one that includes a fix for the CVE-2022-3996 vulnerability.

## Testing Details
Just tried to build an image from it.
## Types of changes

<!--
What types of changes does your code introduce? Put an `x` in all the boxes that apply.
-->

- [ ] Documentation
- [ ] Version change (Update, remove or add more Node.js versions)
- [ ] Variant change (Update, remove or add more variants, or versions of variants)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x ] Others (non of above)

## Checklist

<!--
Go over all the following points, and put an `x` in all the boxes that apply.
If you're unsure about any of these, don't hesitate to ask. We're here to help!
-->

- [ x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ x] I have read the **CONTRIBUTING.md** document.
- [ ] All new and existing tests passed.

