### PR TITLE
chore: remove review request from auto PR

### DIFF
--- a/.github/workflows/automatic-updates.yml
+++ b/.github/workflows/automatic-updates.yml
@@ -32,5 +32,3 @@ jobs:
           commit-message: "feat: Node.js ${{ steps.updt.outputs.result }}"
           title: "feat: Node.js ${{ steps.updt.outputs.result }}"
           delete-branch: true
-          team-reviewers: |
-            @nodejs/docker


### PR DESCRIPTION
It fails, see https://github.com/nodejs/docker-node/actions/runs/4203120195/jobs/7292123473

`Reviews may only be requested from collaborators. One or more of the teams you specified is not a collaborator of the nodejs/docker-node repository.`