### PR TITLE
Update Dockerfile to correctly set ENV variables using the '=' sign.

### DIFF
--- a/16/alpine3.18/Dockerfile
+++ b/16/alpine3.18/Dockerfile
@@ -1,6 +1,6 @@
 FROM alpine:3.18
 
-ENV NODE_VERSION 16.20.1
+ENV NODE_VERSION=16.20.1
 
 RUN addgroup -g 1000 node \
     && adduser -u 1000 -G node -s /bin/sh -D node \
@@ -74,7 +74,7 @@ RUN addgroup -g 1000 node \
   && node --version \
   && npm --version
 
-ENV YARN_VERSION 1.22.19
+ENV YARN_VERSION=1.22.19
 
 RUN apk add --no-cache --virtual .build-deps-yarn curl gnupg tar \
   # use pre-existing gpg directory, see https://github.com/nodejs/docker-node/pull/1895#issuecomment-1550389150


### PR DESCRIPTION

## Description
Added '=' for setting ENV values

## Motivation and Context
When trying to build with podman, version 20 is always getting built. I then noticed the ENV line in the Containerfile is not set correctly. Using ENV the correct way solves the problem of the wrong node package being downloaded and installed.
https://docs.docker.com/engine/reference/builder/#environment-replacement

