### PR TITLE
Fix the gap between the start of a maintenance period for an LTS and the new LTS start

### DIFF
--- a/stackbrew.js
+++ b/stackbrew.js
@@ -38,7 +38,7 @@ for (version of versions) {
   let maintenance = new Date(`${config[version].maintenance}T00:00:00.00`).getTime();
   let isCurrent = foundCurrent ? false : isNaN(lts) || lts >= now;
   foundCurrent = isCurrent || foundCurrent;
-  let isLTS = foundLTS ? false : (maintenance >= now) && (now >= lts);
+  let isLTS = foundLTS ? false : (now >= lts);
   foundLTS = isLTS || foundLTS;
   let codename = config[version].codename
   let defaultAlpine = config[version]['alpine-default']


### PR DESCRIPTION
There's a few days between the start of the maintenance window if a previous LTS and the start date of a new LTS

Example:

Node 18 went on maintenance on October 18th but Node 20 doesn't become LTS until October 24th.

This lets a version in maintenance mode fill in the gap until the new LTS is active.

