### PR TITLE
fix: enable non-root corepack usage

### DIFF
--- a/18/alpine3.17/Dockerfile
+++ b/18/alpine3.17/Dockerfile
@@ -95,6 +95,7 @@ RUN apk add --no-cache --virtual .build-deps-yarn curl gnupg tar \
   && tar -xzf yarn-v$YARN_VERSION.tar.gz -C /opt/ \
   && ln -s /opt/yarn-v$YARN_VERSION/bin/yarn /usr/local/bin/yarn \
   && ln -s /opt/yarn-v$YARN_VERSION/bin/yarnpkg /usr/local/bin/yarnpkg \
+  && chgrp 1000 /usr/local/bin && chmod g+w /usr/local/bin \
   && rm yarn-v$YARN_VERSION.tar.gz.asc yarn-v$YARN_VERSION.tar.gz \
   && apk del .build-deps-yarn \
   # smoke test

--- a/18/alpine3.18/Dockerfile
+++ b/18/alpine3.18/Dockerfile
@@ -95,6 +95,7 @@ RUN apk add --no-cache --virtual .build-deps-yarn curl gnupg tar \
   && tar -xzf yarn-v$YARN_VERSION.tar.gz -C /opt/ \
   && ln -s /opt/yarn-v$YARN_VERSION/bin/yarn /usr/local/bin/yarn \
   && ln -s /opt/yarn-v$YARN_VERSION/bin/yarnpkg /usr/local/bin/yarnpkg \
+  && chgrp 1000 /usr/local/bin && chmod g+w /usr/local/bin \
   && rm yarn-v$YARN_VERSION.tar.gz.asc yarn-v$YARN_VERSION.tar.gz \
   && apk del .build-deps-yarn \
   # smoke test

--- a/18/bookworm-slim/Dockerfile
+++ b/18/bookworm-slim/Dockerfile
@@ -83,6 +83,7 @@ RUN set -ex \
   && tar -xzf yarn-v$YARN_VERSION.tar.gz -C /opt/ \
   && ln -s /opt/yarn-v$YARN_VERSION/bin/yarn /usr/local/bin/yarn \
   && ln -s /opt/yarn-v$YARN_VERSION/bin/yarnpkg /usr/local/bin/yarnpkg \
+  && chgrp 1000 /usr/local/bin && chmod g+w /usr/local/bin \
   && rm yarn-v$YARN_VERSION.tar.gz.asc yarn-v$YARN_VERSION.tar.gz \
   && apt-mark auto '.*' > /dev/null \
   && { [ -z "$savedAptMark" ] || apt-mark manual $savedAptMark > /dev/null; } \

--- a/18/bookworm/Dockerfile
+++ b/18/bookworm/Dockerfile
@@ -69,6 +69,7 @@ RUN set -ex \
   && ln -s /opt/yarn-v$YARN_VERSION/bin/yarn /usr/local/bin/yarn \
   && ln -s /opt/yarn-v$YARN_VERSION/bin/yarnpkg /usr/local/bin/yarnpkg \
   && rm yarn-v$YARN_VERSION.tar.gz.asc yarn-v$YARN_VERSION.tar.gz \
+  && chgrp 1000 /usr/local/bin && chmod g+w /usr/local/bin \
   # smoke test
   && yarn --version
 

--- a/18/bullseye-slim/Dockerfile
+++ b/18/bullseye-slim/Dockerfile
@@ -83,6 +83,7 @@ RUN set -ex \
   && tar -xzf yarn-v$YARN_VERSION.tar.gz -C /opt/ \
   && ln -s /opt/yarn-v$YARN_VERSION/bin/yarn /usr/local/bin/yarn \
   && ln -s /opt/yarn-v$YARN_VERSION/bin/yarnpkg /usr/local/bin/yarnpkg \
+  && chgrp 1000 /usr/local/bin && chmod g+w /usr/local/bin \
   && rm yarn-v$YARN_VERSION.tar.gz.asc yarn-v$YARN_VERSION.tar.gz \
   && apt-mark auto '.*' > /dev/null \
   && { [ -z "$savedAptMark" ] || apt-mark manual $savedAptMark > /dev/null; } \

--- a/18/bullseye/Dockerfile
+++ b/18/bullseye/Dockerfile
@@ -69,6 +69,7 @@ RUN set -ex \
   && ln -s /opt/yarn-v$YARN_VERSION/bin/yarn /usr/local/bin/yarn \
   && ln -s /opt/yarn-v$YARN_VERSION/bin/yarnpkg /usr/local/bin/yarnpkg \
   && rm yarn-v$YARN_VERSION.tar.gz.asc yarn-v$YARN_VERSION.tar.gz \
+  && chgrp 1000 /usr/local/bin && chmod g+w /usr/local/bin \
   # smoke test
   && yarn --version
 

--- a/18/buster-slim/Dockerfile
+++ b/18/buster-slim/Dockerfile
@@ -83,6 +83,7 @@ RUN set -ex \
   && tar -xzf yarn-v$YARN_VERSION.tar.gz -C /opt/ \
   && ln -s /opt/yarn-v$YARN_VERSION/bin/yarn /usr/local/bin/yarn \
   && ln -s /opt/yarn-v$YARN_VERSION/bin/yarnpkg /usr/local/bin/yarnpkg \
+  && chgrp 1000 /usr/local/bin && chmod g+w /usr/local/bin \
   && rm yarn-v$YARN_VERSION.tar.gz.asc yarn-v$YARN_VERSION.tar.gz \
   && apt-mark auto '.*' > /dev/null \
   && { [ -z "$savedAptMark" ] || apt-mark manual $savedAptMark > /dev/null; } \

--- a/18/buster/Dockerfile
+++ b/18/buster/Dockerfile
@@ -69,6 +69,7 @@ RUN set -ex \
   && ln -s /opt/yarn-v$YARN_VERSION/bin/yarn /usr/local/bin/yarn \
   && ln -s /opt/yarn-v$YARN_VERSION/bin/yarnpkg /usr/local/bin/yarnpkg \
   && rm yarn-v$YARN_VERSION.tar.gz.asc yarn-v$YARN_VERSION.tar.gz \
+  && chgrp 1000 /usr/local/bin && chmod g+w /usr/local/bin \
   # smoke test
   && yarn --version
 

--- a/20/alpine3.17/Dockerfile
+++ b/20/alpine3.17/Dockerfile
@@ -95,6 +95,7 @@ RUN apk add --no-cache --virtual .build-deps-yarn curl gnupg tar \
   && tar -xzf yarn-v$YARN_VERSION.tar.gz -C /opt/ \
   && ln -s /opt/yarn-v$YARN_VERSION/bin/yarn /usr/local/bin/yarn \
   && ln -s /opt/yarn-v$YARN_VERSION/bin/yarnpkg /usr/local/bin/yarnpkg \
+  && chgrp 1000 /usr/local/bin && chmod g+w /usr/local/bin \
   && rm yarn-v$YARN_VERSION.tar.gz.asc yarn-v$YARN_VERSION.tar.gz \
   && apk del .build-deps-yarn \
   # smoke test

--- a/20/alpine3.18/Dockerfile
+++ b/20/alpine3.18/Dockerfile
@@ -95,6 +95,7 @@ RUN apk add --no-cache --virtual .build-deps-yarn curl gnupg tar \
   && tar -xzf yarn-v$YARN_VERSION.tar.gz -C /opt/ \
   && ln -s /opt/yarn-v$YARN_VERSION/bin/yarn /usr/local/bin/yarn \
   && ln -s /opt/yarn-v$YARN_VERSION/bin/yarnpkg /usr/local/bin/yarnpkg \
+  && chgrp 1000 /usr/local/bin && chmod g+w /usr/local/bin \
   && rm yarn-v$YARN_VERSION.tar.gz.asc yarn-v$YARN_VERSION.tar.gz \
   && apk del .build-deps-yarn \
   # smoke test

--- a/20/bookworm-slim/Dockerfile
+++ b/20/bookworm-slim/Dockerfile
@@ -83,6 +83,7 @@ RUN set -ex \
   && tar -xzf yarn-v$YARN_VERSION.tar.gz -C /opt/ \
   && ln -s /opt/yarn-v$YARN_VERSION/bin/yarn /usr/local/bin/yarn \
   && ln -s /opt/yarn-v$YARN_VERSION/bin/yarnpkg /usr/local/bin/yarnpkg \
+  && chgrp 1000 /usr/local/bin && chmod g+w /usr/local/bin \
   && rm yarn-v$YARN_VERSION.tar.gz.asc yarn-v$YARN_VERSION.tar.gz \
   && apt-mark auto '.*' > /dev/null \
   && { [ -z "$savedAptMark" ] || apt-mark manual $savedAptMark > /dev/null; } \

--- a/20/bookworm/Dockerfile
+++ b/20/bookworm/Dockerfile
@@ -69,6 +69,7 @@ RUN set -ex \
   && ln -s /opt/yarn-v$YARN_VERSION/bin/yarn /usr/local/bin/yarn \
   && ln -s /opt/yarn-v$YARN_VERSION/bin/yarnpkg /usr/local/bin/yarnpkg \
   && rm yarn-v$YARN_VERSION.tar.gz.asc yarn-v$YARN_VERSION.tar.gz \
+  && chgrp 1000 /usr/local/bin && chmod g+w /usr/local/bin \
   # smoke test
   && yarn --version
 

--- a/20/bullseye-slim/Dockerfile
+++ b/20/bullseye-slim/Dockerfile
@@ -83,6 +83,7 @@ RUN set -ex \
   && tar -xzf yarn-v$YARN_VERSION.tar.gz -C /opt/ \
   && ln -s /opt/yarn-v$YARN_VERSION/bin/yarn /usr/local/bin/yarn \
   && ln -s /opt/yarn-v$YARN_VERSION/bin/yarnpkg /usr/local/bin/yarnpkg \
+  && chgrp 1000 /usr/local/bin && chmod g+w /usr/local/bin \
   && rm yarn-v$YARN_VERSION.tar.gz.asc yarn-v$YARN_VERSION.tar.gz \
   && apt-mark auto '.*' > /dev/null \
   && { [ -z "$savedAptMark" ] || apt-mark manual $savedAptMark > /dev/null; } \

--- a/20/bullseye/Dockerfile
+++ b/20/bullseye/Dockerfile
@@ -69,6 +69,7 @@ RUN set -ex \
   && ln -s /opt/yarn-v$YARN_VERSION/bin/yarn /usr/local/bin/yarn \
   && ln -s /opt/yarn-v$YARN_VERSION/bin/yarnpkg /usr/local/bin/yarnpkg \
   && rm yarn-v$YARN_VERSION.tar.gz.asc yarn-v$YARN_VERSION.tar.gz \
+  && chgrp 1000 /usr/local/bin && chmod g+w /usr/local/bin \
   # smoke test
   && yarn --version
 

--- a/20/buster-slim/Dockerfile
+++ b/20/buster-slim/Dockerfile
@@ -83,6 +83,7 @@ RUN set -ex \
   && tar -xzf yarn-v$YARN_VERSION.tar.gz -C /opt/ \
   && ln -s /opt/yarn-v$YARN_VERSION/bin/yarn /usr/local/bin/yarn \
   && ln -s /opt/yarn-v$YARN_VERSION/bin/yarnpkg /usr/local/bin/yarnpkg \
+  && chgrp 1000 /usr/local/bin && chmod g+w /usr/local/bin \
   && rm yarn-v$YARN_VERSION.tar.gz.asc yarn-v$YARN_VERSION.tar.gz \
   && apt-mark auto '.*' > /dev/null \
   && { [ -z "$savedAptMark" ] || apt-mark manual $savedAptMark > /dev/null; } \

--- a/20/buster/Dockerfile
+++ b/20/buster/Dockerfile
@@ -69,6 +69,7 @@ RUN set -ex \
   && ln -s /opt/yarn-v$YARN_VERSION/bin/yarn /usr/local/bin/yarn \
   && ln -s /opt/yarn-v$YARN_VERSION/bin/yarnpkg /usr/local/bin/yarnpkg \
   && rm yarn-v$YARN_VERSION.tar.gz.asc yarn-v$YARN_VERSION.tar.gz \
+  && chgrp 1000 /usr/local/bin && chmod g+w /usr/local/bin \
   # smoke test
   && yarn --version
 

--- a/21/alpine3.17/Dockerfile
+++ b/21/alpine3.17/Dockerfile
@@ -95,6 +95,7 @@ RUN apk add --no-cache --virtual .build-deps-yarn curl gnupg tar \
   && tar -xzf yarn-v$YARN_VERSION.tar.gz -C /opt/ \
   && ln -s /opt/yarn-v$YARN_VERSION/bin/yarn /usr/local/bin/yarn \
   && ln -s /opt/yarn-v$YARN_VERSION/bin/yarnpkg /usr/local/bin/yarnpkg \
+  && chgrp 1000 /usr/local/bin && chmod g+w /usr/local/bin \
   && rm yarn-v$YARN_VERSION.tar.gz.asc yarn-v$YARN_VERSION.tar.gz \
   && apk del .build-deps-yarn \
   # smoke test

--- a/21/alpine3.18/Dockerfile
+++ b/21/alpine3.18/Dockerfile
@@ -95,6 +95,7 @@ RUN apk add --no-cache --virtual .build-deps-yarn curl gnupg tar \
   && tar -xzf yarn-v$YARN_VERSION.tar.gz -C /opt/ \
   && ln -s /opt/yarn-v$YARN_VERSION/bin/yarn /usr/local/bin/yarn \
   && ln -s /opt/yarn-v$YARN_VERSION/bin/yarnpkg /usr/local/bin/yarnpkg \
+  && chgrp 1000 /usr/local/bin && chmod g+w /usr/local/bin \
   && rm yarn-v$YARN_VERSION.tar.gz.asc yarn-v$YARN_VERSION.tar.gz \
   && apk del .build-deps-yarn \
   # smoke test

--- a/21/bookworm-slim/Dockerfile
+++ b/21/bookworm-slim/Dockerfile
@@ -83,6 +83,7 @@ RUN set -ex \
   && tar -xzf yarn-v$YARN_VERSION.tar.gz -C /opt/ \
   && ln -s /opt/yarn-v$YARN_VERSION/bin/yarn /usr/local/bin/yarn \
   && ln -s /opt/yarn-v$YARN_VERSION/bin/yarnpkg /usr/local/bin/yarnpkg \
+  && chgrp 1000 /usr/local/bin && chmod g+w /usr/local/bin \
   && rm yarn-v$YARN_VERSION.tar.gz.asc yarn-v$YARN_VERSION.tar.gz \
   && apt-mark auto '.*' > /dev/null \
   && { [ -z "$savedAptMark" ] || apt-mark manual $savedAptMark > /dev/null; } \

--- a/21/bookworm/Dockerfile
+++ b/21/bookworm/Dockerfile
@@ -69,6 +69,7 @@ RUN set -ex \
   && ln -s /opt/yarn-v$YARN_VERSION/bin/yarn /usr/local/bin/yarn \
   && ln -s /opt/yarn-v$YARN_VERSION/bin/yarnpkg /usr/local/bin/yarnpkg \
   && rm yarn-v$YARN_VERSION.tar.gz.asc yarn-v$YARN_VERSION.tar.gz \
+  && chgrp 1000 /usr/local/bin && chmod g+w /usr/local/bin \
   # smoke test
   && yarn --version
 

--- a/21/bullseye-slim/Dockerfile
+++ b/21/bullseye-slim/Dockerfile
@@ -83,6 +83,7 @@ RUN set -ex \
   && tar -xzf yarn-v$YARN_VERSION.tar.gz -C /opt/ \
   && ln -s /opt/yarn-v$YARN_VERSION/bin/yarn /usr/local/bin/yarn \
   && ln -s /opt/yarn-v$YARN_VERSION/bin/yarnpkg /usr/local/bin/yarnpkg \
+  && chgrp 1000 /usr/local/bin && chmod g+w /usr/local/bin \
   && rm yarn-v$YARN_VERSION.tar.gz.asc yarn-v$YARN_VERSION.tar.gz \
   && apt-mark auto '.*' > /dev/null \
   && { [ -z "$savedAptMark" ] || apt-mark manual $savedAptMark > /dev/null; } \

--- a/21/bullseye/Dockerfile
+++ b/21/bullseye/Dockerfile
@@ -69,6 +69,7 @@ RUN set -ex \
   && ln -s /opt/yarn-v$YARN_VERSION/bin/yarn /usr/local/bin/yarn \
   && ln -s /opt/yarn-v$YARN_VERSION/bin/yarnpkg /usr/local/bin/yarnpkg \
   && rm yarn-v$YARN_VERSION.tar.gz.asc yarn-v$YARN_VERSION.tar.gz \
+  && chgrp 1000 /usr/local/bin && chmod g+w /usr/local/bin \
   # smoke test
   && yarn --version
 

--- a/Dockerfile-alpine.template
+++ b/Dockerfile-alpine.template
@@ -85,6 +85,7 @@ RUN apk add --no-cache --virtual .build-deps-yarn curl gnupg tar \
   && tar -xzf yarn-v$YARN_VERSION.tar.gz -C /opt/ \
   && ln -s /opt/yarn-v$YARN_VERSION/bin/yarn /usr/local/bin/yarn \
   && ln -s /opt/yarn-v$YARN_VERSION/bin/yarnpkg /usr/local/bin/yarnpkg \
+  && chgrp 1000 /usr/local/bin && chmod g+w /usr/local/bin \
   && rm yarn-v$YARN_VERSION.tar.gz.asc yarn-v$YARN_VERSION.tar.gz \
   && apk del .build-deps-yarn \
   # smoke test

--- a/Dockerfile-debian.template
+++ b/Dockerfile-debian.template
@@ -59,6 +59,7 @@ RUN set -ex \
   && ln -s /opt/yarn-v$YARN_VERSION/bin/yarn /usr/local/bin/yarn \
   && ln -s /opt/yarn-v$YARN_VERSION/bin/yarnpkg /usr/local/bin/yarnpkg \
   && rm yarn-v$YARN_VERSION.tar.gz.asc yarn-v$YARN_VERSION.tar.gz \
+  && chgrp 1000 /usr/local/bin && chmod g+w /usr/local/bin \
   # smoke test
   && yarn --version
 

--- a/Dockerfile-slim.template
+++ b/Dockerfile-slim.template
@@ -73,6 +73,7 @@ RUN set -ex \
   && tar -xzf yarn-v$YARN_VERSION.tar.gz -C /opt/ \
   && ln -s /opt/yarn-v$YARN_VERSION/bin/yarn /usr/local/bin/yarn \
   && ln -s /opt/yarn-v$YARN_VERSION/bin/yarnpkg /usr/local/bin/yarnpkg \
+  && chgrp 1000 /usr/local/bin && chmod g+w /usr/local/bin \
   && rm yarn-v$YARN_VERSION.tar.gz.asc yarn-v$YARN_VERSION.tar.gz \
   && apt-mark auto '.*' > /dev/null \
   && { [ -z "$savedAptMark" ] || apt-mark manual $savedAptMark > /dev/null; } \


### PR DESCRIPTION
## Description

Makes `gid=1000` (the non-root user `node`'s group id) the owning group of `/usr/local/bin`. This enables the non-root user to perform operations like `corepack {enable,prepare,...}` without permission errors.

Closes 1732.

## Testing Details

manual: (see Q about testing in checklist section)

```
cd <major>/<variant>
docker build -t test .
docker run --rm -it -u 1000 -w /home/node test bash

node@3da2bc76ca5b:~$ corepack enable
node@3da2bc76ca5b:~$ corepack prepare 'pnpm@8' --activate
Preparing pnpm@8 for immediate activation...
node@3da2bc76ca5b:~$ pnpm --version
8.10.0
```

<!--
Please describe in detail how you tested your changes. Include details of
your testing environment, and the tests you ran to see how your change
affects other areas of the code, etc.
-->

## Example Output(if appropriate)

## Types of changes

- [ ] Documentation
- [ ] Version change (Update, remove or add more Node.js versions)
- [ ] Variant change (Update, remove or add more variants, or versions of variants)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other (none of the above)

## Checklist

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING.md** document.
- [ ] All new and existing tests passed.

tests? I don't see how to run a suite 
