### PR TITLE
docs(README): Add ports mapping to Docker Compose example

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,7 +186,7 @@ variant is usually a very safe choice. See
 for more discussion of the issues that might arise and some pro/con comparisons
 of using Alpine-based images. One common issue that may arise is a missing shared
 library required for use of `process.dlopen`. To add the missing shared libraries
-to your image, adding the [`libc6-compat`](https://pkgs.alpinelinux.org/package/edge/main/x86/libc6-compat)
+to your image, adding the [`libc6-compat`](https://pkgs.alpinelinux.org/package/v3.10/main/x86_64/libc6-compat)
 package in your Dockerfile is recommended: `apk add --no-cache libc6-compat`
 
 To minimize image size, it's uncommon for additional related tools

--- a/README.md
+++ b/README.md
@@ -186,7 +186,7 @@ variant is usually a very safe choice. See
 for more discussion of the issues that might arise and some pro/con comparisons
 of using Alpine-based images. One common issue that may arise is a missing shared
 library required for use of `process.dlopen`. To add the missing shared libraries
-to your image, adding the [`libc6-compat`](https://pkgs.alpinelinux.org/package/v3.10/main/x86_64/libc6-compat)
+to your image, adding the [`libc6-compat`](https://pkgs.alpinelinux.org/package/edge/main/x86/libc6-compat)
 package in your Dockerfile is recommended: `apk add --no-cache libc6-compat`
 
 To minimize image size, it's uncommon for additional related tools

--- a/README.md
+++ b/README.md
@@ -78,8 +78,8 @@ services:
       - NODE_ENV=production
     volumes:
       - ./:/home/node/app
-    expose:
-      - "8081"
+    ports:
+      - "8081": "8081"
     command: "npm start"
 ```
 

--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ services:
     expose:
       - "8081"
     ports: # use if it is necessary to expose the container to the host machine
-      - "8081": "8081"
+      - "8001:8001"
     command: "npm start"
 ```
 

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ services:
       - ./:/home/node/app
     expose:
       - "8081"
-    ports: #use if it is necessary to expose the container to the host machine
+    ports: # use if it is necessary to expose the container to the host machine
       - "8081": "8081"
     command: "npm start"
 ```

--- a/README.md
+++ b/README.md
@@ -78,7 +78,9 @@ services:
       - NODE_ENV=production
     volumes:
       - ./:/home/node/app
-    ports:
+    expose:
+      - "8081"
+    ports: #use if it is necessary to expose the container to the host machine
       - "8081": "8081"
     command: "npm start"
 ```


### PR DESCRIPTION
Update Docker Compose example with ports usage, because might be useful.

<!--
Provide a general summary of your changes in the Title above.
-->

## Description


Update Docker Compose example in readme.md with ports usage.


## Motivation and Context


Ports might be useful to expose container to the host machine. This information is very important.


## Testing Details


It's only readme.md update.


## Example Output(if appropriate)

## Types of changes

<!--
What types of changes does your code introduce? Put an `x` in all the boxes that apply.
-->

- [X] Documentation
- [ ] Version change (Update, remove or add more Node.js versions)
- [ ] Variant change (Update, remove or add more variants, or versions of variants)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other (none of the above)

## Checklist

<!--
Go over all the following points, and put an `x` in all the boxes that apply.
If you're unsure about any of these, don't hesitate to ask. We're here to help!
-->

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING.md** document.
- [x] All new and existing tests passed.

