### PR TITLE
chore: avoid extra request when checking for MUSL builds

### DIFF
--- a/build-automation.mjs
+++ b/build-automation.mjs
@@ -62,10 +62,10 @@ const checkForMuslVersionsAndSecurityReleases = async (github, versions) => {
     const { data: unofficialBuildsIndexText } = await github.request('https://unofficial-builds.nodejs.org/download/release/index.json');
 
     for (let version of Object.keys(versions)) {
-      const { data: unofficialBuildsWebsiteText } = await github.request(`https://unofficial-builds.nodejs.org/download/release/v${versions[version].fullVersion}`);
+      const buildVersion = unofficialBuildsIndexText.find(indexVersion => indexVersion.version === `v${versions[version].fullVersion}`);
 
-      versions[version].muslBuildExists = unofficialBuildsWebsiteText.includes("musl");
-      versions[version].isSecurityRelease = unofficialBuildsIndexText.find(indexVersion => indexVersion.version === `v${versions[version].fullVersion}`)?.security;
+      versions[version].muslBuildExists = buildVersion?.files.includes("linux-x64-musl") ?? false;
+      versions[version].isSecurityRelease = buildVersion?.security ?? false;
     }
     return versions;
   } catch (error) {


### PR DESCRIPTION
<!--
Provide a general summary of your changes in the Title above.
-->

## Description

Avoid the extra network call per version as we have all the info needed from the `index.json` file.

<!--
Describe your changes in detail.
-->

## Motivation and Context

See #2031

## Testing Details

```js
// tested in repl which has TLA
const { Octokit } = require('@octokit/rest');

const github = new Octokit();

const { data: unofficialBuildsIndexText } = await github.request('https://unofficial-builds.nodejs.org/download/release/index.json');

const buildVersion = unofficialBuildsIndexText.find(indexVersion => indexVersion.version === 'v20.0.0');

console.log(buildVersion?.files.includes('linux-x64-musl'));
console.log(buildVersion?.security);
```

<!--
Please describe in detail how you tested your changes. Include details of
your testing environment, and the tests you ran to see how your change
affects other areas of the code, etc.
-->

## Example Output(if appropriate)

## Types of changes

<!--
What types of changes does your code introduce? Put an `x` in all the boxes that apply.
-->

- [ ] Documentation
- [ ] Version change (Update, remove or add more Node.js versions)
- [ ] Variant change (Update, remove or add more variants, or versions of variants)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Other (none of the above)

## Checklist

<!--
Go over all the following points, and put an `x` in all the boxes that apply.
If you're unsure about any of these, don't hesitate to ask. We're here to help!
-->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING.md** document.
- [x] All new and existing tests passed.