### PR TITLE
docs: update shared libs section for Alpine 3.19+

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,10 +184,18 @@ requirements. However, most software doesn't have an issue with this, so this
 variant is usually a very safe choice. See
 [this Hacker News comment thread](https://news.ycombinator.com/item?id=10782897)
 for more discussion of the issues that might arise and some pro/con comparisons
-of using Alpine-based images. One common issue that may arise is a missing shared
-library required for use of `process.dlopen`. To add the missing shared libraries
-to your image, adding the [`libc6-compat`](https://pkgs.alpinelinux.org/package/edge/main/x86/libc6-compat)
+of using Alpine-based images.
+
+One common issue that may arise is a missing shared library required for use of
+`process.dlopen`. To add the missing shared libraries to your image:
+
+- For Alpine v3.18 and earlier, adding the
+[`libc6-compat`](https://pkgs.alpinelinux.org/package/v3.18/main/x86/libc6-compat)
 package in your Dockerfile is recommended: `apk add --no-cache libc6-compat`
+
+- Starting from Alpine v3.19, you can use the
+[`gcompat`](https://pkgs.alpinelinux.org/package/v3.19/main/x86/gcompat) package
+to add the missing shared libraries: `apk add --no-cache gcompat`
 
 To minimize image size, it's uncommon for additional related tools
 (such as `git` or `bash`) to be included in Alpine-based images. Using this


### PR DESCRIPTION
## Description

Starting from Alpine 3.19, the `gcompat` package should be used instead of `libc6-compat` to include missing shared libraries required for `process.dlopen`.

This change is based on the latest Alpine Linux 3.19.0 release notes: https://wiki.alpinelinux.org/wiki/Release_Notes_for_Alpine_3.19.0

## Motivation and Context

The `libc6-compat` package was removed in Alpine Linux 3.19 in favor of `gcompat` from Adélie Linux to provide GNU C library compatibility layer. This change is necessary to keep the documentation up-to-date and provide accurate information for users who need to add missing shared libraries for `process.dlopen` on Alpine 3.19 and later.

## Testing Details

This change does not require additional testing as it only involves updating the documentation. The updated instructions have been verified by referring to the official Alpine Linux 3.19.0 release notes.

## Example Output(if appropriate)

N/A

## Types of changes

- [x] Documentation
- [ ] Version change (Update, remove or add more Node.js versions)
- [ ] Variant change (Update, remove or add more variants, or versions of variants)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other (none of the above)

## Checklist

- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING.md** document.
- [ ] All new and existing tests passed.

