### PR TITLE
Pin markdown-link-check to v3.11.0 on GitHub Actions

### DIFF
--- a/.github/workflows/markdown-link-check.yml
+++ b/.github/workflows/markdown-link-check.yml
@@ -18,6 +18,6 @@ jobs:
         with:
           node-version: 'lts/*'
       - name: Install markdown-link-check
-        run: npm i -g markdown-link-check
+        run: npm i -g markdown-link-check@3.11.0
       - name: Run markdown-link-check on MD files
         run: find . -name "*.md" | xargs -n 1 markdown-link-check -c markdown_link_check_config.json -q


### PR DESCRIPTION
## Description

Pin markdown-link-check to v3.11.0 in the GitHub Actions workflow to avoid incorrect 404 errors on existing section links.

## Motivation and Context

Starting from markdown-link-check v3.12.1, there is a bug where it incorrectly reports 404 errors for valid existing section links in Markdown files, while v3.11.2 and older do not have this issue, as seen in the CI log:

https://github.com/nodejs/docker-node/actions/runs/8650084895/job/23717794438?pr=2066

To ensure our CI continues to function correctly without these false positive 404 errors, this PR pins the markdown-link-check version to v3.11.0 in the GitHub Actions workflow file.

## Testing Details

The changes in this PR were tested by running the updated GitHub Actions workflow on a test branch. The previously occurring false positive 404 errors no longer appear after pinning markdown-link-check to v3.11.0.

## Types of changes

- [ ] Documentation
- [ ] Version change (Update, remove or add more Node.js versions)
- [ ] Variant change (Update, remove or add more variants, or versions of variants) 
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Other (none of the above)

## Checklist

- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING.md** document.
- [x] All new and existing tests passed.