### PR TITLE
add docker-entrypoint as a executable file

### DIFF
--- a/18/alpine3.18/Dockerfile
+++ b/18/alpine3.18/Dockerfile
@@ -107,6 +107,8 @@ RUN apk add --no-cache --virtual .build-deps-yarn curl gnupg tar \
   && rm -rf /tmp/*
 
 COPY docker-entrypoint.sh /usr/local/bin/
+RUN chmod +x /usr/local/bin/docker-entrypoint.sh
+
 ENTRYPOINT ["docker-entrypoint.sh"]
 
 CMD [ "node" ]


### PR DESCRIPTION
<!--
Provide a general summary of your changes in the Title above.
-->

## Description

Use the docker-entrypoint.sh need to be executable to start the file


<!--
Describe your changes in detail.
-->

Added 
```
RUN chmod +x /usr/local/bin/docker-entrypoint.sh
```

## Motivation and Context

After to use in my CI I got the error
ERROR: Job failed (system failure): Error response from daemon: failed to create shim task: OCI runtime create failed: runc create failed: unable to start container process: exec: "docker-entrypoint.sh": executable file not found in $PATH: unknown (exec.go:57:0s)

So I did the change

<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
-->
After to use in my CI I got the error
ERROR: Job failed (system failure): Error response from daemon: failed to create shim task: OCI runtime create failed: runc create failed: unable to start container process: exec: "docker-entrypoint.sh": executable file not found in $PATH: unknown (exec.go:57:0s)

So I did the change

## Testing Details
After the change, worked fine in my CI build.

<!--
Please describe in detail how you tested your changes. Include details of
your testing environment, and the tests you ran to see how your change
affects other areas of the code, etc.
-->

## Example Output(if appropriate)

## Types of changes

<!--
What types of changes does your code introduce? Put an `x` in all the boxes that apply.
-->

- [ ] Documentation
- [ ] Version change (Update, remove or add more Node.js versions)
- [ ] Variant change (Update, remove or add more variants, or versions of variants)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other (none of the above)

## Checklist

<!--
Go over all the following points, and put an `x` in all the boxes that apply.
If you're unsure about any of these, don't hesitate to ask. We're here to help!
-->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING.md** document.
- [x] All new and existing tests passed.

