### PR TITLE
Revert "Hide auto-generated files in code reviews and format Dockerfile templates"

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,2 @@
 * text=auto eol=lf
+/Dockerfile*.template        linguist-language=Dockerfile

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,5 +1,1 @@
 * text=auto eol=lf
-/*/**/Dockerfile            linguist-generated
-/*/**/docker-entrypoint.sh  linguist-generated
-/Dockerfile*.template        linguist-language=Dockerfile
-


### PR DESCRIPTION
Reverts nodejs/docker-node#2062

This means we need to click the "load diff" everywhere in the UI including the Commit view to see the actual changes. These files may be auto-generated in some cases, but we we need to verify the changes visually to ensure there are no intentional or unintentional malicious changes.