### PR TITLE
chore: fix update script for mac silicon

### DIFF
--- a/functions.sh
+++ b/functions.sh
@@ -32,17 +32,14 @@ function get_arch() {
     s390x)
       arch="s390x"
       ;;
-    arm64)
-      arch="amd64"
-      ;;
-    aarch64)
+    aarch64 | arm64)
       arch="arm64"
       ;;
     armv7l)
       arch="arm32v7"
       ;;
     *)
-      echo "$0 does not support architecture ${arch} ... aborting"
+      echo "$0 does not support architecture ${arch:-unknown} ... aborting"
       exit 1
       ;;
   esac

--- a/functions.sh
+++ b/functions.sh
@@ -32,6 +32,9 @@ function get_arch() {
     s390x)
       arch="s390x"
       ;;
+    arm64)
+      arch="amd64"
+      ;;
     aarch64)
       arch="arm64"
       ;;

--- a/update.sh
+++ b/update.sh
@@ -126,7 +126,7 @@ function update_node_version() {
   (
     cp "${template}" "${dockerfile}-tmp"
     local fromprefix=""
-    if [ "${arch}" != "amd64" ]; then
+    if [ "${arch}" != "amd64" ] && [ "${arch}" != "arm64" ]; then
       fromprefix="${arch}\\/"
     fi
 


### PR DESCRIPTION
Fixes #1848, but I'm not sure if it's the _correct_ fix.

If I set `arch` as `arm64`, I get this diff:

```diff
diff --git i/18/alpine3.18/Dockerfile w/18/alpine3.18/Dockerfile
index fb8836d..065cb4a 100644
--- i/18/alpine3.18/Dockerfile
+++ w/18/alpine3.18/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.18
+FROM arm64/alpine:3.18
 
 ENV NODE_VERSION 18.20.2
 
diff --git i/18/alpine3.19/Dockerfile w/18/alpine3.19/Dockerfile
index 22a2c85..4652a8f 100644
--- i/18/alpine3.19/Dockerfile
+++ w/18/alpine3.19/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.19
+FROM arm64/alpine:3.19
 
 ENV NODE_VERSION 18.20.2
 
diff --git i/18/bookworm-slim/Dockerfile w/18/bookworm-slim/Dockerfile
index 83f954b..be12682 100644
--- i/18/bookworm-slim/Dockerfile
+++ w/18/bookworm-slim/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:bookworm-slim
+FROM arm64/debian:bookworm-slim
 
 RUN groupadd --gid 1000 node \
   && useradd --uid 1000 --gid node --shell /bin/bash --create-home node
diff --git i/18/bookworm/Dockerfile w/18/bookworm/Dockerfile
index cd31775..9108880 100644
--- i/18/bookworm/Dockerfile
+++ w/18/bookworm/Dockerfile
@@ -1,4 +1,4 @@
-FROM buildpack-deps:bookworm
+FROM arm64/buildpack-deps:bookworm
 
 RUN groupadd --gid 1000 node \
   && useradd --uid 1000 --gid node --shell /bin/bash --create-home node
diff --git i/18/bullseye-slim/Dockerfile w/18/bullseye-slim/Dockerfile
index aa58ba9..ca21112 100644
--- i/18/bullseye-slim/Dockerfile
+++ w/18/bullseye-slim/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:bullseye-slim
+FROM arm64/debian:bullseye-slim
 
 RUN groupadd --gid 1000 node \
   && useradd --uid 1000 --gid node --shell /bin/bash --create-home node
diff --git i/18/bullseye/Dockerfile w/18/bullseye/Dockerfile
index a6e6dfc..8fa4e6e 100644
--- i/18/bullseye/Dockerfile
+++ w/18/bullseye/Dockerfile
@@ -1,4 +1,4 @@
-FROM buildpack-deps:bullseye
+FROM arm64/buildpack-deps:bullseye
 
 RUN groupadd --gid 1000 node \
   && useradd --uid 1000 --gid node --shell /bin/bash --create-home node
diff --git i/18/buster-slim/Dockerfile w/18/buster-slim/Dockerfile
index 48b0f11..711f523 100644
--- i/18/buster-slim/Dockerfile
+++ w/18/buster-slim/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:buster-slim
+FROM arm64/debian:buster-slim
 
 RUN groupadd --gid 1000 node \
   && useradd --uid 1000 --gid node --shell /bin/bash --create-home node
diff --git i/18/buster/Dockerfile w/18/buster/Dockerfile
index 51590c3..7bb1d5b 100644
--- i/18/buster/Dockerfile
+++ w/18/buster/Dockerfile
@@ -1,4 +1,4 @@
-FROM buildpack-deps:buster
+FROM arm64/buildpack-deps:buster
 
 RUN groupadd --gid 1000 node \
   && useradd --uid 1000 --gid node --shell /bin/bash --create-home node
diff --git i/20/alpine3.18/Dockerfile w/20/alpine3.18/Dockerfile
index faa5209..99d9034 100644
--- i/20/alpine3.18/Dockerfile
+++ w/20/alpine3.18/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.18
+FROM arm64/alpine:3.18
 
 ENV NODE_VERSION 20.12.2
 
diff --git i/20/alpine3.19/Dockerfile w/20/alpine3.19/Dockerfile
index c915d57..ef08e64 100644
--- i/20/alpine3.19/Dockerfile
+++ w/20/alpine3.19/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.19
+FROM arm64/alpine:3.19
 
 ENV NODE_VERSION 20.12.2
 
diff --git i/20/bookworm-slim/Dockerfile w/20/bookworm-slim/Dockerfile
index 9b357c6..66e4563 100644
--- i/20/bookworm-slim/Dockerfile
+++ w/20/bookworm-slim/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:bookworm-slim
+FROM arm64/debian:bookworm-slim
 
 RUN groupadd --gid 1000 node \
   && useradd --uid 1000 --gid node --shell /bin/bash --create-home node
diff --git i/20/bookworm/Dockerfile w/20/bookworm/Dockerfile
index 21e6f06..4fa1e06 100644
--- i/20/bookworm/Dockerfile
+++ w/20/bookworm/Dockerfile
@@ -1,4 +1,4 @@
-FROM buildpack-deps:bookworm
+FROM arm64/buildpack-deps:bookworm
 
 RUN groupadd --gid 1000 node \
   && useradd --uid 1000 --gid node --shell /bin/bash --create-home node
diff --git i/20/bullseye-slim/Dockerfile w/20/bullseye-slim/Dockerfile
index 3cd6cef..cf5c35a 100644
--- i/20/bullseye-slim/Dockerfile
+++ w/20/bullseye-slim/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:bullseye-slim
+FROM arm64/debian:bullseye-slim
 
 RUN groupadd --gid 1000 node \
   && useradd --uid 1000 --gid node --shell /bin/bash --create-home node
diff --git i/20/bullseye/Dockerfile w/20/bullseye/Dockerfile
index 6aae693..891cee1 100644
--- i/20/bullseye/Dockerfile
+++ w/20/bullseye/Dockerfile
@@ -1,4 +1,4 @@
-FROM buildpack-deps:bullseye
+FROM arm64/buildpack-deps:bullseye
 
 RUN groupadd --gid 1000 node \
   && useradd --uid 1000 --gid node --shell /bin/bash --create-home node
diff --git i/20/buster-slim/Dockerfile w/20/buster-slim/Dockerfile
index dcb2bc2..5b9a0fe 100644
--- i/20/buster-slim/Dockerfile
+++ w/20/buster-slim/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:buster-slim
+FROM arm64/debian:buster-slim
 
 RUN groupadd --gid 1000 node \
   && useradd --uid 1000 --gid node --shell /bin/bash --create-home node
diff --git i/20/buster/Dockerfile w/20/buster/Dockerfile
index b1fae95..7f08c96 100644
--- i/20/buster/Dockerfile
+++ w/20/buster/Dockerfile
@@ -1,4 +1,4 @@
-FROM buildpack-deps:buster
+FROM arm64/buildpack-deps:buster
 
 RUN groupadd --gid 1000 node \
   && useradd --uid 1000 --gid node --shell /bin/bash --create-home node
diff --git i/21/alpine3.18/Dockerfile w/21/alpine3.18/Dockerfile
index 4150fb1..4235a64 100644
--- i/21/alpine3.18/Dockerfile
+++ w/21/alpine3.18/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.18
+FROM arm64/alpine:3.18
 
 ENV NODE_VERSION 21.7.3
 
diff --git i/21/alpine3.19/Dockerfile w/21/alpine3.19/Dockerfile
index 87cdabe..ecc2166 100644
--- i/21/alpine3.19/Dockerfile
+++ w/21/alpine3.19/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.19
+FROM arm64/alpine:3.19
 
 ENV NODE_VERSION 21.7.3
 
diff --git i/21/bookworm-slim/Dockerfile w/21/bookworm-slim/Dockerfile
index 6e502c6..a0687d4 100644
--- i/21/bookworm-slim/Dockerfile
+++ w/21/bookworm-slim/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:bookworm-slim
+FROM arm64/debian:bookworm-slim
 
 RUN groupadd --gid 1000 node \
   && useradd --uid 1000 --gid node --shell /bin/bash --create-home node
diff --git i/21/bookworm/Dockerfile w/21/bookworm/Dockerfile
index 51a91cd..195e551 100644
--- i/21/bookworm/Dockerfile
+++ w/21/bookworm/Dockerfile
@@ -1,4 +1,4 @@
-FROM buildpack-deps:bookworm
+FROM arm64/buildpack-deps:bookworm
 
 RUN groupadd --gid 1000 node \
   && useradd --uid 1000 --gid node --shell /bin/bash --create-home node
diff --git i/21/bullseye-slim/Dockerfile w/21/bullseye-slim/Dockerfile
index fac738b..44ad73d 100644
--- i/21/bullseye-slim/Dockerfile
+++ w/21/bullseye-slim/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:bullseye-slim
+FROM arm64/debian:bullseye-slim
 
 RUN groupadd --gid 1000 node \
   && useradd --uid 1000 --gid node --shell /bin/bash --create-home node
diff --git i/21/bullseye/Dockerfile w/21/bullseye/Dockerfile
index e0842c0..e0a7ec7 100644
--- i/21/bullseye/Dockerfile
+++ w/21/bullseye/Dockerfile
@@ -1,4 +1,4 @@
-FROM buildpack-deps:bullseye
+FROM arm64/buildpack-deps:bullseye
 
 RUN groupadd --gid 1000 node \
   && useradd --uid 1000 --gid node --shell /bin/bash --create-home node
```

which seems wrong 😀 