### PR TITLE
fix: Drop ppc64le from Node 22 Alpine builds

### DIFF
--- a/versions.json
+++ b/versions.json
@@ -13,7 +13,6 @@
         "arm32v6",
         "arm32v7",
         "arm64v8",
-        "ppc64le",
         "s390x"
       ],
       "alpine3.20": [
@@ -21,7 +20,6 @@
         "arm32v6",
         "arm32v7",
         "arm64v8",
-        "ppc64le",
         "s390x"
       ],
       "bookworm": [


### PR DESCRIPTION
Has not worked since 22 was released.

Closes #2107

<!--
Provide a general summary of your changes in the Title above.
-->

## Description

<!--
Describe your changes in detail.
-->

## Motivation and Context

<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
-->

## Testing Details

<!--
Please describe in detail how you tested your changes. Include details of
your testing environment, and the tests you ran to see how your change
affects other areas of the code, etc.
-->

## Example Output(if appropriate)

## Types of changes

<!--
What types of changes does your code introduce? Put an `x` in all the boxes that apply.
-->

- [ ] Documentation
- [ ] Version change (Update, remove or add more Node.js versions)
- [ ] Variant change (Update, remove or add more variants, or versions of variants)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other (none of the above)

## Checklist

<!--
Go over all the following points, and put an `x` in all the boxes that apply.
If you're unsure about any of these, don't hesitate to ask. We're here to help!
-->

- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING.md** document.
- [ ] All new and existing tests passed.

