### PR TITLE
ci: Add PR Write permission for official PR

### DIFF
--- a/.github/workflows/automatic-updates.yml
+++ b/.github/workflows/automatic-updates.yml
@@ -8,6 +8,8 @@ jobs:
   build:
     runs-on: ubuntu-latest
     if: github.repository_owner == 'nodejs'
+    permissions:
+      pull-requests: write
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/official-pr.yml
+++ b/.github/workflows/official-pr.yml
@@ -16,6 +16,8 @@ jobs:
   pr:
     runs-on: ubuntu-latest
     if: github.repository_owner == 'nodejs' && github.event.pull_request.merged_by != ''
+    permissions:
+      pull-requests: write
 
     steps:
       - name: Checkout the docker-node repo


### PR DESCRIPTION
The comment for the bot when it creates the PR isn't working since the Enterprise migration. Trying to set the permissions explicitly to see if that addresses it.