### PR TITLE
fix: Drop ppc64le and x390x from Bullseye

### DIFF
--- a/architectures
+++ b/architectures
@@ -4,5 +4,5 @@ arm32v6        alpine3.19,alpine3.20
 arm32v7        alpine3.19,alpine3.20,bookworm,bookworm-slim,bullseye,bullseye-slim
 arm64v8        alpine3.19,alpine3.20,bookworm,bookworm-slim,bullseye,bullseye-slim
 i386           alpine3.19,alpine3.20
-ppc64le        alpine3.19,alpine3.20,bookworm,bookworm-slim,bullseye,bullseye-slim
-s390x          alpine3.19,alpine3.20,bookworm,bookworm-slim,bullseye,bullseye-slim
+ppc64le        alpine3.19,alpine3.20,bookworm,bookworm-slim
+s390x          alpine3.19,alpine3.20,bookworm,bookworm-slim

--- a/versions.json
+++ b/versions.json
@@ -39,16 +39,12 @@
       "bullseye": [
         "amd64",
         "arm32v7",
-        "arm64v8",
-        "ppc64le",
-        "s390x"
+        "arm64v8"
       ],
       "bullseye-slim": [
         "amd64",
         "arm32v7",
-        "arm64v8",
-        "ppc64le",
-        "s390x"
+        "arm64v8"
       ]
     }
   },
@@ -94,16 +90,12 @@
       "bullseye": [
         "amd64",
         "arm32v7",
-        "arm64v8",
-        "ppc64le",
-        "s390x"
+        "arm64v8"
       ],
       "bullseye-slim": [
         "amd64",
         "arm32v7",
-        "arm64v8",
-        "ppc64le",
-        "s390x"
+        "arm64v8"
       ]
     }
   },
@@ -149,16 +141,12 @@
       "bullseye": [
         "amd64",
         "arm32v7",
-        "arm64v8",
-        "ppc64le",
-        "s390x"
+        "arm64v8"
       ],
       "bullseye-slim": [
         "amd64",
         "arm32v7",
-        "arm64v8",
-        "ppc64le",
-        "s390x"
+        "arm64v8"
       ]
     }
   }


### PR DESCRIPTION
When the latest Official PR was opened https://github.com/docker-library/official-images/pull/17676 there was a failure on the "naughty" CI job. It seems like these architectures are no longer supported on their infrastructure