### PR TITLE
fix: correct update script to support version argument again

### DIFF
--- a/build-automation.mjs
+++ b/build-automation.mjs
@@ -87,13 +87,13 @@ export default async function(github) {
   } else {
     const newVersions = await checkForMuslVersionsAndSecurityReleases(github, versions);
     let updatedVersions = [];
-    for (let version of Object.keys(newVersions)) {
-      if (newVersions[version].muslBuildExists) {
-        const { stdout } = await exec(`./update.sh ${newVersions[version].isSecurityRelease ? "-s " : ""}${version}`);
+    for (const [version, newVersion] of Object.entries(newVersions)) {
+      if (newVersion.muslBuildExists) {
+        const { stdout } = await exec(`./update.sh ${newVersion.isSecurityRelease ? "-s " : ""}${version}`);
         console.log(stdout);
-        updatedVersions.push(newVersions[version].fullVersion);
+        updatedVersions.push(newVersion.fullVersion);
       } else {
-        console.log(`There's no musl build for version ${newVersions[version].fullVersion} yet.`);
+        console.log(`There's no musl build for version ${newVersion.fullVersion} yet.`);
         process.exit(0);
       }
     }

--- a/functions.sh
+++ b/functions.sh
@@ -136,6 +136,7 @@ function get_config() {
 # Get available versions for a given path
 #
 # The result is a list of valid versions.
+# shellcheck disable=SC2120
 function get_versions() {
   shift
 

--- a/functions.sh
+++ b/functions.sh
@@ -137,12 +137,16 @@ function get_config() {
 #
 # The result is a list of valid versions.
 function get_versions() {
+  shift
+
   local versions=()
-  local dirs=()
+  local dirs=("$@")
 
   local default_variant
   default_variant=$(get_config "./" "default_variant")
-  IFS=' ' read -ra dirs <<< "$(echo "./"*/)"
+  if [ ${#dirs[@]} -eq 0 ]; then
+    IFS=' ' read -ra dirs <<< "$(echo "./"*/)"
+  fi
 
   for dir in "${dirs[@]}"; do
     if [ -a "${dir}/Dockerfile" ] || [ -a "${dir}/${default_variant}/Dockerfile" ]; then

--- a/update.sh
+++ b/update.sh
@@ -189,6 +189,8 @@ function update_node_version() {
   )
 }
 
+pids=()
+
 for version in "${versions[@]}"; do
   parentpath=$(dirname "${version}")
   versionnum=$(basename "${version}")
@@ -200,8 +202,6 @@ for version in "${versions[@]}"; do
   # Get supported variants according the target architecture
   # See details in function.sh
   IFS=' ' read -ra variants <<< "$(get_variants "${parentpath}")"
-
-  pids=()
 
   if [ -f "${version}/Dockerfile" ]; then
     if [ "${update_version}" -eq 0 ]; then


### PR DESCRIPTION
We keep getting key updates from the update script for unchanged node versions, even when the script passes e.g. `./update.sh 22`. This is due to a regression in https://github.com/nodejs/docker-node/pull/1307 where the `get_versions` function no longer looked at its arguments for which version directories to load.

I also got `./update.sh: line 240: pids[@]: unbound variable`, so I moved its declaration.

<img width="437" alt="image" src="https://github.com/user-attachments/assets/cbefe0c3-c9f6-4ec3-a63c-5c8d09334056">

I also couldn't resist `Object.keys() -> Object.entires()` since we were accessing the values in the loop

---

This should remove the need for PRs such as https://github.com/nodejs/docker-node/pull/2151, as the script should just update the versions with an actual node version change: https://github.com/nodejs/docker-node/blob/ebd48c9005769889a41fe8b835385d5cab1b485c/build-automation.mjs#L92