### PR TITLE
docs: Use numeric uid instead of username in Dockerfile

### DIFF
--- a/docs/BestPractices.md
+++ b/docs/BestPractices.md
@@ -98,7 +98,7 @@ You can also include Tini [directly in your Dockerfile](https://github.com/krall
 
 ## Non-root User
 
-By default, Docker runs commands inside the container as root which violates the [Principle of Least Privilege (PoLP)](https://en.wikipedia.org/wiki/Principle_of_least_privilege) when superuser permissions are not strictly required. You want to run the container as an unprivileged user whenever possible. The node images provide the `node` user for such purpose. The Docker Image can then be run with the `node` user in the following way:
+By default, Docker runs commands inside the container as root which violates the [Principle of Least Privilege (PoLP)](https://en.wikipedia.org/wiki/Principle_of_least_privilege) when superuser permissions are not strictly required. You want to run the container as an unprivileged user whenever possible. The node images provide the `node` user with uid 1000 for such purpose. The Docker Image can then be run with the `node` user in the following way:
 
 ```
 -u "node"
@@ -110,7 +110,7 @@ Alternatively, the user can be activated in the `Dockerfile`:
 FROM node:6.10.3
 ...
 # At the end, set the user to use when running this image
-USER node
+USER 1000  # node
 ```
 
 Note that the `node` user is neither a build-time nor a run-time dependency and it can be removed or altered, as long as the functionality of the application you want to add to the container does not depend on it.


### PR DESCRIPTION


<!--
Provide a general summary of your changes in the Title above.
-->

## Description

Systems configured to disallow running images as root aren't able to run images that use user name string values for the `USER` because they can't validate that a named user isn't root. To allow images to run on such systems, use the uid of the user as the value for `USER` instead of the username.

See: https://github.com/kubernetes/kubernetes/pull/56503

## Motivation and Context

The current advice is to use `USER node` which won't work on k8s clusters configured with `MustRunAsNonRoot`. By changing that advice to use the uid instead of the username, images will run with `MustRunAsNonRoot`.

## Testing Details

<!--
Please describe in detail how you tested your changes. Include details of
your testing environment, and the tests you ran to see how your change
affects other areas of the code, etc.
-->

## Example Output(if appropriate)

## Types of changes

<!--
What types of changes does your code introduce? Put an `x` in all the boxes that apply.
-->

- [X] Documentation
- [ ] Version change (Update, remove or add more Node.js versions)
- [ ] Variant change (Update, remove or add more variants, or versions of variants)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other (none of the above)

## Checklist

<!--
Go over all the following points, and put an `x` in all the boxes that apply.
If you're unsure about any of these, don't hesitate to ask. We're here to help!
-->

- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING.md** document.
- [ ] All new and existing tests passed.

