### PR TITLE
fix(GHSA-3xgq-45jj-v27): force cross-spawn version

### DIFF
--- a/20/alpine3.20/Dockerfile
+++ b/20/alpine3.20/Dockerfile
@@ -75,7 +75,17 @@ RUN addgroup -g 1000 node \
   && apk del .build-deps \
   # smoke tests
   && node --version \
-  && npm --version
+  && npm --version \
+  # FORCE correct version of cross-spawn in system
+  && mkdir /tmp/npm-install \
+  && cd /tmp/npm-install \
+  && npm init -y \
+  && npm install cross-spawn@7.0.6 \
+  # Now move the installed cross-spawn to the target directory
+  && cp -R node_modules/cross-spawn /usr/local/lib/node_modules/npm/node_modules/ \
+  # Clean up
+  && cd / \
+  && rm -rf /tmp/npm-install
 
 ENV YARN_VERSION 1.22.22
 


### PR DESCRIPTION
Fixes GHSA-3xgq-45jj-v27
https://osv.dev/vulnerability/GHSA-3xgq-45jj-v275

Created image with:
```
#!/bin/bash

# Check if an image name parameter is passed
if [ -z "$1" ]; then
  echo "Error: No image name provided."
  echo "Usage: $0 <image-name>"
  exit 1
fi

# Use the parameter as the image name
IMAGE_NAME="$1"

# Create a new builder instance
docker buildx create --name mybuilder --use

# Start up the builder instance, this ensures it is ready to use
docker buildx inspect --bootstrap

# Define variables
CONTEXT="."
DOCKERFILE="Dockerfile"
PLATFORMS="linux/amd64,linux/arm64"

# Login to Docker Hub (Optional here, should be handled securely)
echo "Logging into Docker Hub..."
docker logout
docker login

# Build and push the image
echo "Building and pushing the image..."
cd ./20/alpine3.20/
docker buildx build --platform $PLATFORMS \
                    --tag $IMAGE_NAME \
                    --file $DOCKERFILE \
                    --no-cache \
                    --push \
                    $CONTEXT

# Clean up the builder
echo "Cleaning up builder..."
docker buildx rm mybuilder
```

Note: Manual login steps in above script