### PR TITLE
Clean cache after smoke test

### DIFF
--- a/Dockerfile-alpine.template
+++ b/Dockerfile-alpine.template
@@ -68,7 +68,8 @@ RUN addgroup -g 1000 node \
   && apk del .build-deps \
   # smoke tests
   && node --version \
-  && npm --version
+  && npm --version \
+  && rm -rf /tmp/*
 
 ENV YARN_VERSION 0.0.0
 

--- a/Dockerfile-debian.template
+++ b/Dockerfile-debian.template
@@ -36,7 +36,8 @@ RUN ARCH= && dpkgArch="$(dpkg --print-architecture)" \
   && ln -s /usr/local/bin/node /usr/local/bin/nodejs \
   # smoke tests
   && node --version \
-  && npm --version
+  && npm --version \
+  && rm -rf /tmp/*
 
 ENV YARN_VERSION 0.0.0
 

--- a/Dockerfile-slim.template
+++ b/Dockerfile-slim.template
@@ -50,7 +50,8 @@ RUN ARCH= OPENSSL_ARCH= && dpkgArch="$(dpkg --print-architecture)" \
     && ln -s /usr/local/bin/node /usr/local/bin/nodejs \
     # smoke tests
     && node --version \
-    && npm --version
+    && npm --version \
+    && rm -rf /tmp/*
 
 ENV YARN_VERSION 0.0.0
 


### PR DESCRIPTION
<!--
Provide a general summary of your changes in the Title above.
-->

## Description
Remove /tmp/node-compile-cache after smoke tests


## Motivation and Context
The Node.js image, during the build process in the RUN layer, executed Node.js and generated the /tmp/node-compile-cache directory without deleting it. According to subsequent build steps, this directory was deleted in the next RUN, therefore it doesn't exist in the final image (though it's only marked as deleted in the current RUN layer - the original files still reside in the historical layers).

## Testing Details

<!--
Please describe in detail how you tested your changes. Include details of
your testing environment, and the tests you ran to see how your change
affects other areas of the code, etc.
-->

## Example Output(if appropriate)

## Types of changes

<!--
What types of changes does your code introduce? Put an `x` in all the boxes that apply.
-->

- [ ] Documentation
- [ ] Version change (Update, remove or add more Node.js versions)
- [ ] Variant change (Update, remove or add more variants, or versions of variants)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other (none of the above)

## Checklist

<!--
Go over all the following points, and put an `x` in all the boxes that apply.
If you're unsure about any of these, don't hesitate to ask. We're here to help!
-->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING.md** document.
- [x] All new and existing tests passed.

