### PR TITLE
Remove arm32v7 from bullseye variants of Node 23

### DIFF
--- a/versions.json
+++ b/versions.json
@@ -38,12 +38,10 @@
       ],
       "bullseye": [
         "amd64",
-        "arm32v7",
         "arm64v8"
       ],
       "bullseye-slim": [
         "amd64",
-        "arm32v7",
         "arm64v8"
       ]
     }


### PR DESCRIPTION
(as reported in https://github.com/nodejs/docker-node/issues/1885#issuecomment-2427264372)

    + node --version
    node: /usr/lib/arm-linux-gnueabihf/libstdc++.so.6: version `GLIBCXX_3.4.30' not found (required by node)
    node: /usr/lib/arm-linux-gnueabihf/libstdc++.so.6: version `GLIBCXX_3.4.29' not found (required by node)

I *believe* this is the correct change, but I'm not 100% sure -- I don't see anything in this repository that writes to `versions.json`, so it appears to be hand-maintained and thus this is the correct change for `stackbrew.js` to generate the appropriate contents.
