### PR TITLE
docs: update nodejs versions to 22 in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ See: http://nodejs.org
 
 ```dockerfile
 # specify the node base image with your desired version node:<version>
-FROM node:16
+FROM node:22
 # replace this with your application's default port
 EXPOSE 8888
 ```
@@ -105,7 +105,7 @@ complete `Dockerfile`. In such cases, you can run a Node.js script by using the
 Node.js Docker image directly:
 
 ```console
-$ docker run -it --rm --name my-running-script -v "$PWD":/usr/src/app -w /usr/src/app node:8 node your-daemon-or-script.js
+$ docker run -it --rm --name my-running-script -v "$PWD":/usr/src/app -w /usr/src/app node:22 node your-daemon-or-script.js
 ```
 
 ### Verbosity


### PR DESCRIPTION
## Description

Updated `node:8` and `node:16` image tags to `node:22` in README.

## Motivation and Context

As a developer, I would like to see latest LTS version in the documentation.

## Types of changes

<!--
What types of changes does your code introduce? Put an `x` in all the boxes that apply.
-->

- [x] Documentation
- [ ] Version change (Update, remove or add more Node.js versions)
- [ ] Variant change (Update, remove or add more variants, or versions of variants)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other (none of the above)

## Checklist

<!--
Go over all the following points, and put an `x` in all the boxes that apply.
If you're unsure about any of these, don't hesitate to ask. We're here to help!
-->

- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING.md** document.
- [ ] All new and existing tests passed.

