### PR TITLE
Remove arm32 from Node 24

### DIFF
--- a/versions.json
+++ b/versions.json
@@ -10,28 +10,22 @@
     "variants": {
       "alpine3.20": [
         "amd64",
-        "arm32v6",
-        "arm32v7",
         "arm64v8",
         "s390x"
       ],
       "alpine3.21": [
         "amd64",
-        "arm32v6",
-        "arm32v7",
         "arm64v8",
         "s390x"
       ],
       "bookworm": [
         "amd64",
-        "arm32v7",
         "arm64v8",
         "ppc64le",
         "s390x"
       ],
       "bookworm-slim": [
         "amd64",
-        "arm32v7",
         "arm64v8",
         "ppc64le",
         "s390x"


### PR DESCRIPTION
It is no longer supported:
- https://github.com/nodejs/docker-node/issues/2232#issuecomment-2867510141
- https://github.com/nodejs/node/pull/58071

I have no idea if I need to update `architectures` too, but I believe `versions.json` is enough?  Happy to update with pointers though.