### PR TITLE
Replace obsolete ENV VAR VALUE with ENV VAR=VALUE

### DIFF
--- a/20/alpine3.21/Dockerfile
+++ b/20/alpine3.21/Dockerfile
@@ -1,6 +1,6 @@
 FROM alpine:3.21
 
-ENV NODE_VERSION 20.19.5
+ENV NODE_VERSION=20.19.5
 
 RUN addgroup -g 1000 node \
     && adduser -u 1000 -G node -s /bin/sh -D node \
@@ -78,7 +78,7 @@ RUN addgroup -g 1000 node \
   && npm --version \
   && rm -rf /tmp/*
 
-ENV YARN_VERSION 1.22.22
+ENV YARN_VERSION=1.22.22
 
 RUN apk add --no-cache --virtual .build-deps-yarn curl gnupg tar \
   # use pre-existing gpg directory, see https://github.com/nodejs/docker-node/pull/1895#issuecomment-1550389150

--- a/20/alpine3.22/Dockerfile
+++ b/20/alpine3.22/Dockerfile
@@ -1,6 +1,6 @@
 FROM alpine:3.22
 
-ENV NODE_VERSION 20.19.5
+ENV NODE_VERSION=20.19.5
 
 RUN addgroup -g 1000 node \
     && adduser -u 1000 -G node -s /bin/sh -D node \
@@ -78,7 +78,7 @@ RUN addgroup -g 1000 node \
   && npm --version \
   && rm -rf /tmp/*
 
-ENV YARN_VERSION 1.22.22
+ENV YARN_VERSION=1.22.22
 
 RUN apk add --no-cache --virtual .build-deps-yarn curl gnupg tar \
   # use pre-existing gpg directory, see https://github.com/nodejs/docker-node/pull/1895#issuecomment-1550389150

--- a/20/bookworm-slim/Dockerfile
+++ b/20/bookworm-slim/Dockerfile
@@ -3,7 +3,7 @@ FROM debian:bookworm-slim
 RUN groupadd --gid 1000 node \
   && useradd --uid 1000 --gid node --shell /bin/bash --create-home node
 
-ENV NODE_VERSION 20.19.5
+ENV NODE_VERSION=20.19.5
 
 RUN ARCH= OPENSSL_ARCH= && dpkgArch="$(dpkg --print-architecture)" \
     && case "${dpkgArch##*-}" in \
@@ -60,7 +60,7 @@ RUN ARCH= OPENSSL_ARCH= && dpkgArch="$(dpkg --print-architecture)" \
     && npm --version \
     && rm -rf /tmp/*
 
-ENV YARN_VERSION 1.22.22
+ENV YARN_VERSION=1.22.22
 
 RUN set -ex \
   && savedAptMark="$(apt-mark showmanual)" \

--- a/20/bookworm/Dockerfile
+++ b/20/bookworm/Dockerfile
@@ -3,7 +3,7 @@ FROM buildpack-deps:bookworm
 RUN groupadd --gid 1000 node \
   && useradd --uid 1000 --gid node --shell /bin/bash --create-home node
 
-ENV NODE_VERSION 20.19.5
+ENV NODE_VERSION=20.19.5
 
 RUN ARCH= && dpkgArch="$(dpkg --print-architecture)" \
   && case "${dpkgArch##*-}" in \
@@ -46,7 +46,7 @@ RUN ARCH= && dpkgArch="$(dpkg --print-architecture)" \
   && npm --version \
   && rm -rf /tmp/*
 
-ENV YARN_VERSION 1.22.22
+ENV YARN_VERSION=1.22.22
 
 RUN set -ex \
   # use pre-existing gpg directory, see https://github.com/nodejs/docker-node/pull/1895#issuecomment-1550389150

--- a/20/bullseye-slim/Dockerfile
+++ b/20/bullseye-slim/Dockerfile
@@ -3,7 +3,7 @@ FROM debian:bullseye-slim
 RUN groupadd --gid 1000 node \
   && useradd --uid 1000 --gid node --shell /bin/bash --create-home node
 
-ENV NODE_VERSION 20.19.5
+ENV NODE_VERSION=20.19.5
 
 RUN ARCH= OPENSSL_ARCH= && dpkgArch="$(dpkg --print-architecture)" \
     && case "${dpkgArch##*-}" in \
@@ -60,7 +60,7 @@ RUN ARCH= OPENSSL_ARCH= && dpkgArch="$(dpkg --print-architecture)" \
     && npm --version \
     && rm -rf /tmp/*
 
-ENV YARN_VERSION 1.22.22
+ENV YARN_VERSION=1.22.22
 
 RUN set -ex \
   && savedAptMark="$(apt-mark showmanual)" \

--- a/20/bullseye/Dockerfile
+++ b/20/bullseye/Dockerfile
@@ -3,7 +3,7 @@ FROM buildpack-deps:bullseye
 RUN groupadd --gid 1000 node \
   && useradd --uid 1000 --gid node --shell /bin/bash --create-home node
 
-ENV NODE_VERSION 20.19.5
+ENV NODE_VERSION=20.19.5
 
 RUN ARCH= && dpkgArch="$(dpkg --print-architecture)" \
   && case "${dpkgArch##*-}" in \
@@ -46,7 +46,7 @@ RUN ARCH= && dpkgArch="$(dpkg --print-architecture)" \
   && npm --version \
   && rm -rf /tmp/*
 
-ENV YARN_VERSION 1.22.22
+ENV YARN_VERSION=1.22.22
 
 RUN set -ex \
   # use pre-existing gpg directory, see https://github.com/nodejs/docker-node/pull/1895#issuecomment-1550389150

--- a/20/trixie-slim/Dockerfile
+++ b/20/trixie-slim/Dockerfile
@@ -3,7 +3,7 @@ FROM debian:trixie-slim
 RUN groupadd --gid 1000 node \
   && useradd --uid 1000 --gid node --shell /bin/bash --create-home node
 
-ENV NODE_VERSION 20.19.5
+ENV NODE_VERSION=20.19.5
 
 RUN ARCH= OPENSSL_ARCH= && dpkgArch="$(dpkg --print-architecture)" \
     && case "${dpkgArch##*-}" in \
@@ -60,7 +60,7 @@ RUN ARCH= OPENSSL_ARCH= && dpkgArch="$(dpkg --print-architecture)" \
     && npm --version \
     && rm -rf /tmp/*
 
-ENV YARN_VERSION 1.22.22
+ENV YARN_VERSION=1.22.22
 
 RUN set -ex \
   && savedAptMark="$(apt-mark showmanual)" \

--- a/20/trixie/Dockerfile
+++ b/20/trixie/Dockerfile
@@ -3,7 +3,7 @@ FROM buildpack-deps:trixie
 RUN groupadd --gid 1000 node \
   && useradd --uid 1000 --gid node --shell /bin/bash --create-home node
 
-ENV NODE_VERSION 20.19.5
+ENV NODE_VERSION=20.19.5
 
 RUN ARCH= && dpkgArch="$(dpkg --print-architecture)" \
   && case "${dpkgArch##*-}" in \
@@ -46,7 +46,7 @@ RUN ARCH= && dpkgArch="$(dpkg --print-architecture)" \
   && npm --version \
   && rm -rf /tmp/*
 
-ENV YARN_VERSION 1.22.22
+ENV YARN_VERSION=1.22.22
 
 RUN set -ex \
   # use pre-existing gpg directory, see https://github.com/nodejs/docker-node/pull/1895#issuecomment-1550389150

--- a/22/alpine3.21/Dockerfile
+++ b/22/alpine3.21/Dockerfile
@@ -1,6 +1,6 @@
 FROM alpine:3.21
 
-ENV NODE_VERSION 22.20.0
+ENV NODE_VERSION=22.20.0
 
 RUN addgroup -g 1000 node \
     && adduser -u 1000 -G node -s /bin/sh -D node \
@@ -78,7 +78,7 @@ RUN addgroup -g 1000 node \
   && npm --version \
   && rm -rf /tmp/*
 
-ENV YARN_VERSION 1.22.22
+ENV YARN_VERSION=1.22.22
 
 RUN apk add --no-cache --virtual .build-deps-yarn curl gnupg tar \
   # use pre-existing gpg directory, see https://github.com/nodejs/docker-node/pull/1895#issuecomment-1550389150

--- a/22/alpine3.22/Dockerfile
+++ b/22/alpine3.22/Dockerfile
@@ -1,6 +1,6 @@
 FROM alpine:3.22
 
-ENV NODE_VERSION 22.20.0
+ENV NODE_VERSION=22.20.0
 
 RUN addgroup -g 1000 node \
     && adduser -u 1000 -G node -s /bin/sh -D node \
@@ -78,7 +78,7 @@ RUN addgroup -g 1000 node \
   && npm --version \
   && rm -rf /tmp/*
 
-ENV YARN_VERSION 1.22.22
+ENV YARN_VERSION=1.22.22
 
 RUN apk add --no-cache --virtual .build-deps-yarn curl gnupg tar \
   # use pre-existing gpg directory, see https://github.com/nodejs/docker-node/pull/1895#issuecomment-1550389150

--- a/22/bookworm-slim/Dockerfile
+++ b/22/bookworm-slim/Dockerfile
@@ -3,7 +3,7 @@ FROM debian:bookworm-slim
 RUN groupadd --gid 1000 node \
   && useradd --uid 1000 --gid node --shell /bin/bash --create-home node
 
-ENV NODE_VERSION 22.20.0
+ENV NODE_VERSION=22.20.0
 
 RUN ARCH= OPENSSL_ARCH= && dpkgArch="$(dpkg --print-architecture)" \
     && case "${dpkgArch##*-}" in \
@@ -60,7 +60,7 @@ RUN ARCH= OPENSSL_ARCH= && dpkgArch="$(dpkg --print-architecture)" \
     && npm --version \
     && rm -rf /tmp/*
 
-ENV YARN_VERSION 1.22.22
+ENV YARN_VERSION=1.22.22
 
 RUN set -ex \
   && savedAptMark="$(apt-mark showmanual)" \

--- a/22/bookworm/Dockerfile
+++ b/22/bookworm/Dockerfile
@@ -3,7 +3,7 @@ FROM buildpack-deps:bookworm
 RUN groupadd --gid 1000 node \
   && useradd --uid 1000 --gid node --shell /bin/bash --create-home node
 
-ENV NODE_VERSION 22.20.0
+ENV NODE_VERSION=22.20.0
 
 RUN ARCH= && dpkgArch="$(dpkg --print-architecture)" \
   && case "${dpkgArch##*-}" in \
@@ -46,7 +46,7 @@ RUN ARCH= && dpkgArch="$(dpkg --print-architecture)" \
   && npm --version \
   && rm -rf /tmp/*
 
-ENV YARN_VERSION 1.22.22
+ENV YARN_VERSION=1.22.22
 
 RUN set -ex \
   # use pre-existing gpg directory, see https://github.com/nodejs/docker-node/pull/1895#issuecomment-1550389150

--- a/22/bullseye-slim/Dockerfile
+++ b/22/bullseye-slim/Dockerfile
@@ -3,7 +3,7 @@ FROM debian:bullseye-slim
 RUN groupadd --gid 1000 node \
   && useradd --uid 1000 --gid node --shell /bin/bash --create-home node
 
-ENV NODE_VERSION 22.20.0
+ENV NODE_VERSION=22.20.0
 
 RUN ARCH= OPENSSL_ARCH= && dpkgArch="$(dpkg --print-architecture)" \
     && case "${dpkgArch##*-}" in \
@@ -60,7 +60,7 @@ RUN ARCH= OPENSSL_ARCH= && dpkgArch="$(dpkg --print-architecture)" \
     && npm --version \
     && rm -rf /tmp/*
 
-ENV YARN_VERSION 1.22.22
+ENV YARN_VERSION=1.22.22
 
 RUN set -ex \
   && savedAptMark="$(apt-mark showmanual)" \

--- a/22/bullseye/Dockerfile
+++ b/22/bullseye/Dockerfile
@@ -3,7 +3,7 @@ FROM buildpack-deps:bullseye
 RUN groupadd --gid 1000 node \
   && useradd --uid 1000 --gid node --shell /bin/bash --create-home node
 
-ENV NODE_VERSION 22.20.0
+ENV NODE_VERSION=22.20.0
 
 RUN ARCH= && dpkgArch="$(dpkg --print-architecture)" \
   && case "${dpkgArch##*-}" in \
@@ -46,7 +46,7 @@ RUN ARCH= && dpkgArch="$(dpkg --print-architecture)" \
   && npm --version \
   && rm -rf /tmp/*
 
-ENV YARN_VERSION 1.22.22
+ENV YARN_VERSION=1.22.22
 
 RUN set -ex \
   # use pre-existing gpg directory, see https://github.com/nodejs/docker-node/pull/1895#issuecomment-1550389150

--- a/22/trixie-slim/Dockerfile
+++ b/22/trixie-slim/Dockerfile
@@ -3,7 +3,7 @@ FROM debian:trixie-slim
 RUN groupadd --gid 1000 node \
   && useradd --uid 1000 --gid node --shell /bin/bash --create-home node
 
-ENV NODE_VERSION 22.20.0
+ENV NODE_VERSION=22.20.0
 
 RUN ARCH= OPENSSL_ARCH= && dpkgArch="$(dpkg --print-architecture)" \
     && case "${dpkgArch##*-}" in \
@@ -60,7 +60,7 @@ RUN ARCH= OPENSSL_ARCH= && dpkgArch="$(dpkg --print-architecture)" \
     && npm --version \
     && rm -rf /tmp/*
 
-ENV YARN_VERSION 1.22.22
+ENV YARN_VERSION=1.22.22
 
 RUN set -ex \
   && savedAptMark="$(apt-mark showmanual)" \

--- a/22/trixie/Dockerfile
+++ b/22/trixie/Dockerfile
@@ -3,7 +3,7 @@ FROM buildpack-deps:trixie
 RUN groupadd --gid 1000 node \
   && useradd --uid 1000 --gid node --shell /bin/bash --create-home node
 
-ENV NODE_VERSION 22.20.0
+ENV NODE_VERSION=22.20.0
 
 RUN ARCH= && dpkgArch="$(dpkg --print-architecture)" \
   && case "${dpkgArch##*-}" in \
@@ -46,7 +46,7 @@ RUN ARCH= && dpkgArch="$(dpkg --print-architecture)" \
   && npm --version \
   && rm -rf /tmp/*
 
-ENV YARN_VERSION 1.22.22
+ENV YARN_VERSION=1.22.22
 
 RUN set -ex \
   # use pre-existing gpg directory, see https://github.com/nodejs/docker-node/pull/1895#issuecomment-1550389150

--- a/24/alpine3.21/Dockerfile
+++ b/24/alpine3.21/Dockerfile
@@ -1,6 +1,6 @@
 FROM alpine:3.21
 
-ENV NODE_VERSION 24.10.0
+ENV NODE_VERSION=24.10.0
 
 RUN addgroup -g 1000 node \
     && adduser -u 1000 -G node -s /bin/sh -D node \
@@ -78,7 +78,7 @@ RUN addgroup -g 1000 node \
   && npm --version \
   && rm -rf /tmp/*
 
-ENV YARN_VERSION 1.22.22
+ENV YARN_VERSION=1.22.22
 
 RUN apk add --no-cache --virtual .build-deps-yarn curl gnupg tar \
   # use pre-existing gpg directory, see https://github.com/nodejs/docker-node/pull/1895#issuecomment-1550389150

--- a/24/alpine3.22/Dockerfile
+++ b/24/alpine3.22/Dockerfile
@@ -1,6 +1,6 @@
 FROM alpine:3.22
 
-ENV NODE_VERSION 24.10.0
+ENV NODE_VERSION=24.10.0
 
 RUN addgroup -g 1000 node \
     && adduser -u 1000 -G node -s /bin/sh -D node \
@@ -78,7 +78,7 @@ RUN addgroup -g 1000 node \
   && npm --version \
   && rm -rf /tmp/*
 
-ENV YARN_VERSION 1.22.22
+ENV YARN_VERSION=1.22.22
 
 RUN apk add --no-cache --virtual .build-deps-yarn curl gnupg tar \
   # use pre-existing gpg directory, see https://github.com/nodejs/docker-node/pull/1895#issuecomment-1550389150

--- a/24/bookworm-slim/Dockerfile
+++ b/24/bookworm-slim/Dockerfile
@@ -3,7 +3,7 @@ FROM debian:bookworm-slim
 RUN groupadd --gid 1000 node \
   && useradd --uid 1000 --gid node --shell /bin/bash --create-home node
 
-ENV NODE_VERSION 24.10.0
+ENV NODE_VERSION=24.10.0
 
 RUN ARCH= OPENSSL_ARCH= && dpkgArch="$(dpkg --print-architecture)" \
     && case "${dpkgArch##*-}" in \
@@ -60,7 +60,7 @@ RUN ARCH= OPENSSL_ARCH= && dpkgArch="$(dpkg --print-architecture)" \
     && npm --version \
     && rm -rf /tmp/*
 
-ENV YARN_VERSION 1.22.22
+ENV YARN_VERSION=1.22.22
 
 RUN set -ex \
   && savedAptMark="$(apt-mark showmanual)" \

--- a/24/bookworm/Dockerfile
+++ b/24/bookworm/Dockerfile
@@ -3,7 +3,7 @@ FROM buildpack-deps:bookworm
 RUN groupadd --gid 1000 node \
   && useradd --uid 1000 --gid node --shell /bin/bash --create-home node
 
-ENV NODE_VERSION 24.10.0
+ENV NODE_VERSION=24.10.0
 
 RUN ARCH= && dpkgArch="$(dpkg --print-architecture)" \
   && case "${dpkgArch##*-}" in \
@@ -46,7 +46,7 @@ RUN ARCH= && dpkgArch="$(dpkg --print-architecture)" \
   && npm --version \
   && rm -rf /tmp/*
 
-ENV YARN_VERSION 1.22.22
+ENV YARN_VERSION=1.22.22
 
 RUN set -ex \
   # use pre-existing gpg directory, see https://github.com/nodejs/docker-node/pull/1895#issuecomment-1550389150

--- a/24/bullseye-slim/Dockerfile
+++ b/24/bullseye-slim/Dockerfile
@@ -3,7 +3,7 @@ FROM debian:bullseye-slim
 RUN groupadd --gid 1000 node \
   && useradd --uid 1000 --gid node --shell /bin/bash --create-home node
 
-ENV NODE_VERSION 24.10.0
+ENV NODE_VERSION=24.10.0
 
 RUN ARCH= OPENSSL_ARCH= && dpkgArch="$(dpkg --print-architecture)" \
     && case "${dpkgArch##*-}" in \
@@ -60,7 +60,7 @@ RUN ARCH= OPENSSL_ARCH= && dpkgArch="$(dpkg --print-architecture)" \
     && npm --version \
     && rm -rf /tmp/*
 
-ENV YARN_VERSION 1.22.22
+ENV YARN_VERSION=1.22.22
 
 RUN set -ex \
   && savedAptMark="$(apt-mark showmanual)" \

--- a/24/bullseye/Dockerfile
+++ b/24/bullseye/Dockerfile
@@ -3,7 +3,7 @@ FROM buildpack-deps:bullseye
 RUN groupadd --gid 1000 node \
   && useradd --uid 1000 --gid node --shell /bin/bash --create-home node
 
-ENV NODE_VERSION 24.10.0
+ENV NODE_VERSION=24.10.0
 
 RUN ARCH= && dpkgArch="$(dpkg --print-architecture)" \
   && case "${dpkgArch##*-}" in \
@@ -46,7 +46,7 @@ RUN ARCH= && dpkgArch="$(dpkg --print-architecture)" \
   && npm --version \
   && rm -rf /tmp/*
 
-ENV YARN_VERSION 1.22.22
+ENV YARN_VERSION=1.22.22
 
 RUN set -ex \
   # use pre-existing gpg directory, see https://github.com/nodejs/docker-node/pull/1895#issuecomment-1550389150

--- a/24/trixie-slim/Dockerfile
+++ b/24/trixie-slim/Dockerfile
@@ -3,7 +3,7 @@ FROM debian:trixie-slim
 RUN groupadd --gid 1000 node \
   && useradd --uid 1000 --gid node --shell /bin/bash --create-home node
 
-ENV NODE_VERSION 24.10.0
+ENV NODE_VERSION=24.10.0
 
 RUN ARCH= OPENSSL_ARCH= && dpkgArch="$(dpkg --print-architecture)" \
     && case "${dpkgArch##*-}" in \
@@ -60,7 +60,7 @@ RUN ARCH= OPENSSL_ARCH= && dpkgArch="$(dpkg --print-architecture)" \
     && npm --version \
     && rm -rf /tmp/*
 
-ENV YARN_VERSION 1.22.22
+ENV YARN_VERSION=1.22.22
 
 RUN set -ex \
   && savedAptMark="$(apt-mark showmanual)" \

--- a/24/trixie/Dockerfile
+++ b/24/trixie/Dockerfile
@@ -3,7 +3,7 @@ FROM buildpack-deps:trixie
 RUN groupadd --gid 1000 node \
   && useradd --uid 1000 --gid node --shell /bin/bash --create-home node
 
-ENV NODE_VERSION 24.10.0
+ENV NODE_VERSION=24.10.0
 
 RUN ARCH= && dpkgArch="$(dpkg --print-architecture)" \
   && case "${dpkgArch##*-}" in \
@@ -46,7 +46,7 @@ RUN ARCH= && dpkgArch="$(dpkg --print-architecture)" \
   && npm --version \
   && rm -rf /tmp/*
 
-ENV YARN_VERSION 1.22.22
+ENV YARN_VERSION=1.22.22
 
 RUN set -ex \
   # use pre-existing gpg directory, see https://github.com/nodejs/docker-node/pull/1895#issuecomment-1550389150

--- a/25/alpine3.21/Dockerfile
+++ b/25/alpine3.21/Dockerfile
@@ -1,6 +1,6 @@
 FROM alpine:3.21
 
-ENV NODE_VERSION 25.0.0
+ENV NODE_VERSION=25.0.0
 
 RUN addgroup -g 1000 node \
     && adduser -u 1000 -G node -s /bin/sh -D node \
@@ -78,7 +78,7 @@ RUN addgroup -g 1000 node \
   && npm --version \
   && rm -rf /tmp/*
 
-ENV YARN_VERSION 1.22.22
+ENV YARN_VERSION=1.22.22
 
 RUN apk add --no-cache --virtual .build-deps-yarn curl gnupg tar \
   # use pre-existing gpg directory, see https://github.com/nodejs/docker-node/pull/1895#issuecomment-1550389150

--- a/25/alpine3.22/Dockerfile
+++ b/25/alpine3.22/Dockerfile
@@ -1,6 +1,6 @@
 FROM alpine:3.22
 
-ENV NODE_VERSION 25.0.0
+ENV NODE_VERSION=25.0.0
 
 RUN addgroup -g 1000 node \
     && adduser -u 1000 -G node -s /bin/sh -D node \
@@ -78,7 +78,7 @@ RUN addgroup -g 1000 node \
   && npm --version \
   && rm -rf /tmp/*
 
-ENV YARN_VERSION 1.22.22
+ENV YARN_VERSION=1.22.22
 
 RUN apk add --no-cache --virtual .build-deps-yarn curl gnupg tar \
   # use pre-existing gpg directory, see https://github.com/nodejs/docker-node/pull/1895#issuecomment-1550389150

--- a/25/bookworm-slim/Dockerfile
+++ b/25/bookworm-slim/Dockerfile
@@ -3,7 +3,7 @@ FROM debian:bookworm-slim
 RUN groupadd --gid 1000 node \
   && useradd --uid 1000 --gid node --shell /bin/bash --create-home node
 
-ENV NODE_VERSION 25.0.0
+ENV NODE_VERSION=25.0.0
 
 RUN ARCH= OPENSSL_ARCH= && dpkgArch="$(dpkg --print-architecture)" \
     && case "${dpkgArch##*-}" in \
@@ -60,7 +60,7 @@ RUN ARCH= OPENSSL_ARCH= && dpkgArch="$(dpkg --print-architecture)" \
     && npm --version \
     && rm -rf /tmp/*
 
-ENV YARN_VERSION 1.22.22
+ENV YARN_VERSION=1.22.22
 
 RUN set -ex \
   && savedAptMark="$(apt-mark showmanual)" \

--- a/25/bookworm/Dockerfile
+++ b/25/bookworm/Dockerfile
@@ -3,7 +3,7 @@ FROM buildpack-deps:bookworm
 RUN groupadd --gid 1000 node \
   && useradd --uid 1000 --gid node --shell /bin/bash --create-home node
 
-ENV NODE_VERSION 25.0.0
+ENV NODE_VERSION=25.0.0
 
 RUN ARCH= && dpkgArch="$(dpkg --print-architecture)" \
   && case "${dpkgArch##*-}" in \
@@ -46,7 +46,7 @@ RUN ARCH= && dpkgArch="$(dpkg --print-architecture)" \
   && npm --version \
   && rm -rf /tmp/*
 
-ENV YARN_VERSION 1.22.22
+ENV YARN_VERSION=1.22.22
 
 RUN set -ex \
   # use pre-existing gpg directory, see https://github.com/nodejs/docker-node/pull/1895#issuecomment-1550389150

--- a/25/bullseye-slim/Dockerfile
+++ b/25/bullseye-slim/Dockerfile
@@ -3,7 +3,7 @@ FROM debian:bullseye-slim
 RUN groupadd --gid 1000 node \
   && useradd --uid 1000 --gid node --shell /bin/bash --create-home node
 
-ENV NODE_VERSION 25.0.0
+ENV NODE_VERSION=25.0.0
 
 RUN ARCH= OPENSSL_ARCH= && dpkgArch="$(dpkg --print-architecture)" \
     && case "${dpkgArch##*-}" in \
@@ -60,7 +60,7 @@ RUN ARCH= OPENSSL_ARCH= && dpkgArch="$(dpkg --print-architecture)" \
     && npm --version \
     && rm -rf /tmp/*
 
-ENV YARN_VERSION 1.22.22
+ENV YARN_VERSION=1.22.22
 
 RUN set -ex \
   && savedAptMark="$(apt-mark showmanual)" \

--- a/25/bullseye/Dockerfile
+++ b/25/bullseye/Dockerfile
@@ -3,7 +3,7 @@ FROM buildpack-deps:bullseye
 RUN groupadd --gid 1000 node \
   && useradd --uid 1000 --gid node --shell /bin/bash --create-home node
 
-ENV NODE_VERSION 25.0.0
+ENV NODE_VERSION=25.0.0
 
 RUN ARCH= && dpkgArch="$(dpkg --print-architecture)" \
   && case "${dpkgArch##*-}" in \
@@ -46,7 +46,7 @@ RUN ARCH= && dpkgArch="$(dpkg --print-architecture)" \
   && npm --version \
   && rm -rf /tmp/*
 
-ENV YARN_VERSION 1.22.22
+ENV YARN_VERSION=1.22.22
 
 RUN set -ex \
   # use pre-existing gpg directory, see https://github.com/nodejs/docker-node/pull/1895#issuecomment-1550389150

--- a/25/trixie-slim/Dockerfile
+++ b/25/trixie-slim/Dockerfile
@@ -3,7 +3,7 @@ FROM debian:trixie-slim
 RUN groupadd --gid 1000 node \
   && useradd --uid 1000 --gid node --shell /bin/bash --create-home node
 
-ENV NODE_VERSION 25.0.0
+ENV NODE_VERSION=25.0.0
 
 RUN ARCH= OPENSSL_ARCH= && dpkgArch="$(dpkg --print-architecture)" \
     && case "${dpkgArch##*-}" in \
@@ -60,7 +60,7 @@ RUN ARCH= OPENSSL_ARCH= && dpkgArch="$(dpkg --print-architecture)" \
     && npm --version \
     && rm -rf /tmp/*
 
-ENV YARN_VERSION 1.22.22
+ENV YARN_VERSION=1.22.22
 
 RUN set -ex \
   && savedAptMark="$(apt-mark showmanual)" \

--- a/25/trixie/Dockerfile
+++ b/25/trixie/Dockerfile
@@ -3,7 +3,7 @@ FROM buildpack-deps:trixie
 RUN groupadd --gid 1000 node \
   && useradd --uid 1000 --gid node --shell /bin/bash --create-home node
 
-ENV NODE_VERSION 25.0.0
+ENV NODE_VERSION=25.0.0
 
 RUN ARCH= && dpkgArch="$(dpkg --print-architecture)" \
   && case "${dpkgArch##*-}" in \
@@ -46,7 +46,7 @@ RUN ARCH= && dpkgArch="$(dpkg --print-architecture)" \
   && npm --version \
   && rm -rf /tmp/*
 
-ENV YARN_VERSION 1.22.22
+ENV YARN_VERSION=1.22.22
 
 RUN set -ex \
   # use pre-existing gpg directory, see https://github.com/nodejs/docker-node/pull/1895#issuecomment-1550389150

--- a/Dockerfile-alpine.template
+++ b/Dockerfile-alpine.template
@@ -1,6 +1,6 @@
 FROM alpine:0.0
 
-ENV NODE_VERSION 0.0.0
+ENV NODE_VERSION=0.0.0
 
 RUN addgroup -g 1000 node \
     && adduser -u 1000 -G node -s /bin/sh -D node \
@@ -71,7 +71,7 @@ RUN addgroup -g 1000 node \
   && npm --version \
   && rm -rf /tmp/*
 
-ENV YARN_VERSION 0.0.0
+ENV YARN_VERSION=0.0.0
 
 RUN apk add --no-cache --virtual .build-deps-yarn curl gnupg tar \
   # use pre-existing gpg directory, see https://github.com/nodejs/docker-node/pull/1895#issuecomment-1550389150

--- a/Dockerfile-debian.template
+++ b/Dockerfile-debian.template
@@ -3,7 +3,7 @@ FROM buildpack-deps:name
 RUN groupadd --gid 1000 node \
   && useradd --uid 1000 --gid node --shell /bin/bash --create-home node
 
-ENV NODE_VERSION 0.0.0
+ENV NODE_VERSION=0.0.0
 
 RUN ARCH= && dpkgArch="$(dpkg --print-architecture)" \
   && case "${dpkgArch##*-}" in \
@@ -39,7 +39,7 @@ RUN ARCH= && dpkgArch="$(dpkg --print-architecture)" \
   && npm --version \
   && rm -rf /tmp/*
 
-ENV YARN_VERSION 0.0.0
+ENV YARN_VERSION=0.0.0
 
 RUN set -ex \
   # use pre-existing gpg directory, see https://github.com/nodejs/docker-node/pull/1895#issuecomment-1550389150

--- a/Dockerfile-slim.template
+++ b/Dockerfile-slim.template
@@ -3,7 +3,7 @@ FROM debian:name-slim
 RUN groupadd --gid 1000 node \
   && useradd --uid 1000 --gid node --shell /bin/bash --create-home node
 
-ENV NODE_VERSION 0.0.0
+ENV NODE_VERSION=0.0.0
 
 RUN ARCH= OPENSSL_ARCH= && dpkgArch="$(dpkg --print-architecture)" \
     && case "${dpkgArch##*-}" in \
@@ -53,7 +53,7 @@ RUN ARCH= OPENSSL_ARCH= && dpkgArch="$(dpkg --print-architecture)" \
     && npm --version \
     && rm -rf /tmp/*
 
-ENV YARN_VERSION 0.0.0
+ENV YARN_VERSION=0.0.0
 
 RUN set -ex \
   && savedAptMark="$(apt-mark showmanual)" \

--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ simply use `ENV` to override `NPM_CONFIG_LOGLEVEL`.
 
 ```dockerfile
 FROM node
-ENV NPM_CONFIG_LOGLEVEL info
+ENV NPM_CONFIG_LOGLEVEL=info
 ...
 ```
 

--- a/docs/BestPractices.md
+++ b/docs/BestPractices.md
@@ -51,7 +51,7 @@ If you need to upgrade/downgrade `yarn` for a local install, you can do so by is
 ```Dockerfile
 FROM node:6
 
-ENV YARN_VERSION 1.16.0
+ENV YARN_VERSION=1.16.0
 
 RUN yarn policies set-version $YARN_VERSION
 ```
@@ -61,7 +61,7 @@ RUN yarn policies set-version $YARN_VERSION
 ```Dockerfile
 FROM node:6
 
-ENV YARN_VERSION 1.16.0
+ENV YARN_VERSION=1.16.0
 
 RUN curl -fSLO --compressed "https://yarnpkg.com/downloads/$YARN_VERSION/yarn-v$YARN_VERSION.tar.gz" \
     && tar -xzf yarn-v$YARN_VERSION.tar.gz -C /opt/ \
@@ -75,7 +75,7 @@ If you're using an Alpine-based image, `curl` won't be present, so you'll need t
 ```Dockerfile
 FROM node:6-alpine
 
-ENV YARN_VERSION 1.5.1
+ENV YARN_VERSION=1.5.1
 
 RUN apk add --no-cache --virtual .build-deps-yarn curl \
     && curl -fSLO --compressed "https://yarnpkg.com/downloads/$YARN_VERSION/yarn-v$YARN_VERSION.tar.gz" \

--- a/functions.sh
+++ b/functions.sh
@@ -239,7 +239,7 @@ function get_full_version() {
     default_dockerfile="${version}/Dockerfile"
   fi
 
-  grep -m1 'ENV NODE_VERSION ' "${default_dockerfile}" | cut -d' ' -f3
+  grep -m1 'ENV NODE_VERSION=' "${default_dockerfile}" | cut -d= -f2
 }
 
 function get_major_minor_version() {

--- a/genMatrix.js
+++ b/genMatrix.js
@@ -53,7 +53,7 @@ const getAffectedDockerfiles = (filesAdded, filesModified, filesRenamed) => {
 };
 
 const getFullNodeVersionFromDockerfile = (file) => fs.readFileSync(file, 'utf8')
-  .match(/^ENV NODE_VERSION (\d*\.*\d*\.\d*)/m)[1];
+  .match(/^ENV NODE_VERSION=(\d*\.*\d*\.\d*)/m)[1];
 
 const getDockerfileMatrixEntry = (file) => {
   const [variant] = path.dirname(file).split(path.sep).slice(-1);

--- a/stackbrew.js
+++ b/stackbrew.js
@@ -54,7 +54,7 @@ for (version of versions) {
     // Get full version from the first Dockerfile
     if (!fullversion) {
       let dockerfile = fs.readFileSync(dockerfilePath, 'utf-8')
-      fullversion = dockerfile.match(/ENV NODE_VERSION (?<major>\d+)\.(?<minor>\d+)\.(?<patch>\d+)/)
+      fullversion = dockerfile.match(/ENV NODE_VERSION=(?<major>\d+)\.(?<minor>\d+)\.(?<patch>\d+)/)
     }
     let tags = [
       `${fullversion.groups.major}.${fullversion.groups.minor}.${fullversion.groups.patch}-${variant}`,

--- a/update.sh
+++ b/update.sh
@@ -132,7 +132,7 @@ function update_node_version() {
     nodeVersion="${version}.${fullVersion:-0}"
 
     sed -Ei -e 's/^FROM (.*)/FROM '"$fromprefix"'\1/' "${dockerfile}-tmp"
-    sed -Ei -e 's/^(ENV NODE_VERSION ).*/\1'"${nodeVersion}"'/' "${dockerfile}-tmp"
+    sed -Ei -e 's/^(ENV NODE_VERSION)=.*/\1='"${nodeVersion}"'/' "${dockerfile}-tmp"
 
     # shellcheck disable=SC1004
     new_line=' \\\
@@ -169,7 +169,7 @@ function update_node_version() {
       echo "${dockerfile} is already up to date!"
     else
       if [ "${SKIP}" != true ]; then
-        sed -Ei -e 's/^(ENV YARN_VERSION ).*/\1'"${yarnVersion}"'/' "${dockerfile}-tmp"
+        sed -Ei -e 's/^(ENV YARN_VERSION)=.*/\1='"${yarnVersion}"'/' "${dockerfile}-tmp"
       fi
       echo "${dockerfile} updated!"
     fi


### PR DESCRIPTION
## Description

Fixes these warnings:
```
- LegacyKeyValueFormat: "ENV key=value" should be used instead of legacy "ENV key value" format
```

## Testing Details

Build passed.

## Types of changes

<!--
What types of changes does your code introduce? Put an `x` in all the boxes that apply.
-->

- [ ] Documentation
- [ ] Version change (Update, remove or add more Node.js versions)
- [ ] Variant change (Update, remove or add more variants, or versions of variants)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other (none of the above)

## Checklist

- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING.md** document.
- [X] All new and existing tests passed.
