### PR TITLE
Revert "Remove stray * for linux*-s390x in slim images"

### DIFF
--- a/20/bookworm-slim/Dockerfile
+++ b/20/bookworm-slim/Dockerfile
@@ -9,7 +9,7 @@ RUN ARCH= OPENSSL_ARCH= && dpkgArch="$(dpkg --print-architecture)" \
     && case "${dpkgArch##*-}" in \
       amd64) ARCH='x64' OPENSSL_ARCH='linux-x86_64';; \
       ppc64el) ARCH='ppc64le' OPENSSL_ARCH='linux-ppc64le';; \
-      s390x) ARCH='s390x' OPENSSL_ARCH='linux-s390x';; \
+      s390x) ARCH='s390x' OPENSSL_ARCH='linux*-s390x';; \
       arm64) ARCH='arm64' OPENSSL_ARCH='linux-aarch64';; \
       armhf) ARCH='armv7l' OPENSSL_ARCH='linux-armv4';; \
       i386) ARCH='x86' OPENSSL_ARCH='linux-elf';; \

--- a/20/bullseye-slim/Dockerfile
+++ b/20/bullseye-slim/Dockerfile
@@ -9,7 +9,7 @@ RUN ARCH= OPENSSL_ARCH= && dpkgArch="$(dpkg --print-architecture)" \
     && case "${dpkgArch##*-}" in \
       amd64) ARCH='x64' OPENSSL_ARCH='linux-x86_64';; \
       ppc64el) ARCH='ppc64le' OPENSSL_ARCH='linux-ppc64le';; \
-      s390x) ARCH='s390x' OPENSSL_ARCH='linux-s390x';; \
+      s390x) ARCH='s390x' OPENSSL_ARCH='linux*-s390x';; \
       arm64) ARCH='arm64' OPENSSL_ARCH='linux-aarch64';; \
       armhf) ARCH='armv7l' OPENSSL_ARCH='linux-armv4';; \
       i386) ARCH='x86' OPENSSL_ARCH='linux-elf';; \

--- a/22/bookworm-slim/Dockerfile
+++ b/22/bookworm-slim/Dockerfile
@@ -9,7 +9,7 @@ RUN ARCH= OPENSSL_ARCH= && dpkgArch="$(dpkg --print-architecture)" \
     && case "${dpkgArch##*-}" in \
       amd64) ARCH='x64' OPENSSL_ARCH='linux-x86_64';; \
       ppc64el) ARCH='ppc64le' OPENSSL_ARCH='linux-ppc64le';; \
-      s390x) ARCH='s390x' OPENSSL_ARCH='linux-s390x';; \
+      s390x) ARCH='s390x' OPENSSL_ARCH='linux*-s390x';; \
       arm64) ARCH='arm64' OPENSSL_ARCH='linux-aarch64';; \
       armhf) ARCH='armv7l' OPENSSL_ARCH='linux-armv4';; \
       i386) ARCH='x86' OPENSSL_ARCH='linux-elf';; \

--- a/22/bullseye-slim/Dockerfile
+++ b/22/bullseye-slim/Dockerfile
@@ -9,7 +9,7 @@ RUN ARCH= OPENSSL_ARCH= && dpkgArch="$(dpkg --print-architecture)" \
     && case "${dpkgArch##*-}" in \
       amd64) ARCH='x64' OPENSSL_ARCH='linux-x86_64';; \
       ppc64el) ARCH='ppc64le' OPENSSL_ARCH='linux-ppc64le';; \
-      s390x) ARCH='s390x' OPENSSL_ARCH='linux-s390x';; \
+      s390x) ARCH='s390x' OPENSSL_ARCH='linux*-s390x';; \
       arm64) ARCH='arm64' OPENSSL_ARCH='linux-aarch64';; \
       armhf) ARCH='armv7l' OPENSSL_ARCH='linux-armv4';; \
       i386) ARCH='x86' OPENSSL_ARCH='linux-elf';; \

--- a/24/bookworm-slim/Dockerfile
+++ b/24/bookworm-slim/Dockerfile
@@ -9,7 +9,7 @@ RUN ARCH= OPENSSL_ARCH= && dpkgArch="$(dpkg --print-architecture)" \
     && case "${dpkgArch##*-}" in \
       amd64) ARCH='x64' OPENSSL_ARCH='linux-x86_64';; \
       ppc64el) ARCH='ppc64le' OPENSSL_ARCH='linux-ppc64le';; \
-      s390x) ARCH='s390x' OPENSSL_ARCH='linux-s390x';; \
+      s390x) ARCH='s390x' OPENSSL_ARCH='linux*-s390x';; \
       arm64) ARCH='arm64' OPENSSL_ARCH='linux-aarch64';; \
       armhf) ARCH='armv7l' OPENSSL_ARCH='linux-armv4';; \
       i386) ARCH='x86' OPENSSL_ARCH='linux-elf';; \

--- a/24/bullseye-slim/Dockerfile
+++ b/24/bullseye-slim/Dockerfile
@@ -9,7 +9,7 @@ RUN ARCH= OPENSSL_ARCH= && dpkgArch="$(dpkg --print-architecture)" \
     && case "${dpkgArch##*-}" in \
       amd64) ARCH='x64' OPENSSL_ARCH='linux-x86_64';; \
       ppc64el) ARCH='ppc64le' OPENSSL_ARCH='linux-ppc64le';; \
-      s390x) ARCH='s390x' OPENSSL_ARCH='linux-s390x';; \
+      s390x) ARCH='s390x' OPENSSL_ARCH='linux*-s390x';; \
       arm64) ARCH='arm64' OPENSSL_ARCH='linux-aarch64';; \
       armhf) ARCH='armv7l' OPENSSL_ARCH='linux-armv4';; \
       i386) ARCH='x86' OPENSSL_ARCH='linux-elf';; \

--- a/Dockerfile-slim.template
+++ b/Dockerfile-slim.template
@@ -9,7 +9,7 @@ RUN ARCH= OPENSSL_ARCH= && dpkgArch="$(dpkg --print-architecture)" \
     && case "${dpkgArch##*-}" in \
       amd64) ARCH='x64' OPENSSL_ARCH='linux-x86_64';; \
       ppc64el) ARCH='ppc64le' OPENSSL_ARCH='linux-ppc64le';; \
-      s390x) ARCH='s390x' OPENSSL_ARCH='linux-s390x';; \
+      s390x) ARCH='s390x' OPENSSL_ARCH='linux*-s390x';; \
       arm64) ARCH='arm64' OPENSSL_ARCH='linux-aarch64';; \
       armhf) ARCH='armv7l' OPENSSL_ARCH='linux-armv4';; \
       i386) ARCH='x86' OPENSSL_ARCH='linux-elf';; \


### PR DESCRIPTION
There are linux32-s390x and linux64-s390x[1].

Copilot review was misleading.

This reverts commit ec45cd2793290799a8a2c806d8301e2fe6e625ec.

[1] https://github.com/nodejs/node/tree/main/deps/openssl/config/archs
