### PR TITLE
docs: upgrade links from http to https

### DIFF
--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -92,7 +92,7 @@ discussion in a non-voting capacity.
 ## Consensus Seeking Process
 
 The WG follows a [Consensus
-Seeking](http://en.wikipedia.org/wiki/Consensus-seeking_decision-making)
+Seeking](https://en.wikipedia.org/wiki/Consensus-seeking_decision-making)
 decision-making model.
 
 All proposed changes to the project must be made in the form of a pull

--- a/README.md
+++ b/README.md
@@ -167,15 +167,15 @@ need to install, thus reducing the overall size of all images on your system.
 ### `node:alpine`
 
 This image is based on the popular
-[Alpine Linux project](http://alpinelinux.org), available in
+[Alpine Linux project](https://alpinelinux.org), available in
 [the `alpine` official image](https://hub.docker.com/_/alpine). Alpine Linux is
 much smaller than most distribution base images (~5MB), and thus leads to much
 slimmer images in general.
 
 This variant is highly recommended when final image size being as small as
 possible is desired. The main caveat to note is that it does use
-[musl libc](http://www.musl-libc.org) instead of
-[glibc and friends](http://www.etalabs.net/compare_libcs.html), so certain
+[musl libc](https://www.musl-libc.org) instead of
+[glibc and friends](https://www.etalabs.net/compare_libcs.html), so certain
 software might run into issues depending on the depth of their libc
 requirements. However, most software doesn't have an issue with this, so this
 variant is usually a very safe choice. See
@@ -205,19 +205,19 @@ To make the image size even smaller, you can [bundle without npm/yarn](./docs/Be
 ### `node:bullseye`
 
 This image is based on version 11 of
-[Debian](http://debian.org), available in
+[Debian](https://debian.org), available in
 [the `debian` official image](https://hub.docker.com/_/debian).
 
 ### `node:bookworm`
 
 This image is based on version 12 of
-[Debian](http://debian.org), available in
+[Debian](https://debian.org), available in
 [the `debian` official image](https://hub.docker.com/_/debian).
 
 ### `node:trixie`
 
 This image is based on version 13 of
-[Debian](http://debian.org), available in
+[Debian](https://debian.org), available in
 [the `debian` official image](https://hub.docker.com/_/debian).
 
 ### `node:slim`


### PR DESCRIPTION
## Description

In documents:

- [GOVERNANCE.md](https://github.com/nodejs/docker-node/blob/main/GOVERNANCE.md)
- [README.md](https://github.com/nodejs/docker-node/blob/main/README.md)

update all link usage from `http` to `https` protocol.

## Motivation and Context

As mentioned in PR https://github.com/nodejs/docker-node/pull/2297, some old links are still using the `http` protocol instead of `https`.

These links were put there 5 to 10 years ago, and in the meantime each of the sites is accessible through the `https` protocol.

Even for read-only website access, `https` is now considered the default protocol choice. Google Chrome, for instance, will automatically upgrade all `http` navigation to `https`. Documentation in this repo should map to this default by ensuring all links use `https`.

## Testing Details

On Ubuntu `24.04.3` LTS, with Node.js `22.20.0` LTS

```shell
npm install markdown-link-check@3.14.1 -g
find . -name "*.md"  ! -path "./.git/*" | xargs -n 1 markdown-link-check -c markdown_link_check_config.json
```

No dead links should be reported.

## Example Output(if appropriate)


## Types of changes

- [X] Documentation
- [ ] Version change (Update, remove or add more Node.js versions)
- [ ] Variant change (Update, remove or add more variants, or versions of variants)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other (none of the above)

## Checklist

- [X] My code follows the code style of this project.
- [X] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING.md** document.
- [X] All new and existing tests passed.
