### PR TITLE
Fix update.sh Dockerfile status reporting

### DIFF
--- a/update.sh
+++ b/update.sh
@@ -165,21 +165,21 @@ function update_node_version() {
       sed -Ei -e "s/(debian:)name-slim/\\1${variant}/" "${dockerfile}-tmp"
     fi
 
-    if diff -q "${dockerfile}-tmp" "${dockerfile}" > /dev/null; then
-      echo "${dockerfile} is already up to date!"
-    else
-      if [ "${SKIP}" != true ]; then
-        sed -Ei -e 's/^(ENV YARN_VERSION)=.*/\1='"${yarnVersion}"'/' "${dockerfile}-tmp"
-      fi
-      echo "${dockerfile} updated!"
+    if [ "${SKIP}" != true ]; then
+      sed -Ei -e 's/^(ENV YARN_VERSION)=.*/\1='"${yarnVersion}"'/' "${dockerfile}-tmp"
     fi
 
     # Required for POSIX sed
     if [ -f "${dockerfile}-tmp-e" ]; then
       rm "${dockerfile}-tmp-e"
     fi
-
-    mv -f "${dockerfile}-tmp" "${dockerfile}"
+    if cmp -s "${dockerfile}-tmp" "${dockerfile}"; then
+      rm -f "${dockerfile}-tmp"
+      info "${dockerfile} already up to date."
+    else
+      mv -f "${dockerfile}-tmp" "${dockerfile}"
+      info "${dockerfile} updated."
+    fi
   )
 }
 


### PR DESCRIPTION
## Description

Clarify `update.sh` status messages by comparing each generated Dockerfile with the existing file before replacing it. Move the Yarn version update ahead of the comparison and emit either “updated” when the content changes or “already up to date.” when it does not.

## GitHub Copilot Summary

> This pull request refactors the logic for updating Dockerfiles in the `update_node_version()` function in `update.sh`. The main change is a switch from using `diff` to `cmp` for file comparison, and updating the messaging and cleanup flow for temporary files.
> 
> Improvements to update logic:
> 
> * Replaced the use of `diff -q` with `cmp -s` to compare `${dockerfile}-tmp` and `${dockerfile}`, simplifying the check for file changes.
> * Updated messaging to use the `info` function for consistent output when a Dockerfile is already up to date or has been updated.
> * Improved cleanup by removing the temporary file `${dockerfile}-tmp` if no changes are detected, and only moving it to `${dockerfile}` when updates are made.

## Motivation and Context

Previous runs could print “updated!” even when the final Dockerfile was unchanged, leading to confusing output after `git status` showed no diffs. This change makes the script’s messaging align with the actual state of the files.

## Testing Details

- ./update.sh 20 bookworm
- ./update.sh 22

## Example Output(if appropriate)

```
Updating version 20...
20/bookworm/Dockerfile already up to date.
Done!
```

## Types of changes

- [ ] Documentation
- [ ] Version change (Update, remove or add more Node.js versions)
- [ ] Variant change (Update, remove or add more variants, or versions of variants)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other (none of the above)

## Checklist

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING.md** document.
- [x] All new and existing tests passed.
