### PR TITLE
fix: generate-testing-matrix step when there are no files to pass to the script

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -39,9 +39,9 @@ jobs:
           script: |
             const script = require(`${process.env.GITHUB_WORKSPACE}/genMatrix.js`)
             return script(
-              ${{ steps.diff.outputs.added_files }},
-              ${{ steps.diff.outputs.modified_files }},
-              ${{ steps.diff.outputs.renamed_files }},
+              ${{ steps.diff.outputs.added_files || '[]' }},
+              ${{ steps.diff.outputs.modified_files || '[]' }},
+              ${{ steps.diff.outputs.renamed_files || '[]' }},
             );
 
     outputs:


### PR DESCRIPTION
## Summary
- The latest "Generate testing matrix" workflow step execution is failing on main: https://github.com/nodejs/docker-node/actions/runs/20997554877/job/60358280253
- Fixes this workflow step to handle cases where there are no modified, added, or renamed files
- Adds fallback values (`|| '[]'`) to prevent undefined values from being passed to the genMatrix.js script

## Details
When the diff outputs (added_files, modified_files, renamed_files) are empty, they can cause issues in the GitHub Actions workflow. This PR ensures that empty arrays are passed instead of undefined values.

## Test plan
- Verify that the workflow runs successfully when there are no file changes
- Verify that the workflow continues to work correctly with file changes