### PR TITLE
Evaluate musl build availability for security releases separately for each release line

### DIFF
--- a/build-automation.mjs
+++ b/build-automation.mjs
@@ -88,13 +88,17 @@ export default async function(github) {
     const newVersions = await checkForMuslVersionsAndSecurityReleases(github, versions);
     let updatedVersions = [];
     for (const [version, newVersion] of Object.entries(newVersions)) {
-      if (newVersion.muslBuildExists) {
-        const { stdout } = await exec(`./update.sh ${newVersion.isSecurityRelease ? "-s " : ""}${version}`);
+      if (newVersion.isSecurityRelease) {
+        console.log(`Processing security release ${newVersion.fullVersion}`);
+        const { stdout } = await exec(`./update.sh -s ${version}`);
+        console.log(stdout);
+        updatedVersions.push(newVersion.fullVersion);
+      } else if (newVersion.muslBuildExists) {
+        const { stdout } = await exec(`./update.sh ${version}`);
         console.log(stdout);
         updatedVersions.push(newVersion.fullVersion);
       } else {
-        console.log(`There's no musl build for version ${newVersion.fullVersion} yet.`);
-        process.exit(0);
+        console.log(`There's no musl build for version ${newVersion.fullVersion} yet. Skipping non-security release.`);
       }
     }
     const { stdout } = (await exec(`git diff`));


### PR DESCRIPTION
<!--
Provide a general summary of your changes in the Title above.
-->

## Description

Attempt to separate security releases from experimental musl releases.

## Motivation and Context

See attribution of idea at https://github.com/nodejs/docker-node/issues/2330#issuecomment-3745263346 by @MikeMcC399 

Waiting for musl builds is unnecessary. See impact https://github.com/docker-library/official-images/pull/20637

@mcollina confirmed this may be the source of the bug.

I am no expert in this domain, so special care should be made and I have no hard feelings about suggested improvements.

I did elect for explicit cases here over ternary logic, as I felt it created annoying inline branches in the update arguments and in the console log. Now it's more explicit, at the cost of slight repetition.

<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
-->

## Testing Details

<!--
Please describe in detail how you tested your changes. Include details of
your testing environment, and the tests you ran to see how your change
affects other areas of the code, etc.
-->

## Example Output(if appropriate)

## Types of changes

<!--
What types of changes does your code introduce? Put an `x` in all the boxes that apply.
-->

- [ ] Documentation
- [ ] Version change (Update, remove or add more Node.js versions)
- [ ] Variant change (Update, remove or add more variants, or versions of variants)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other (none of the above)

## Checklist

<!--
Go over all the following points, and put an `x` in all the boxes that apply.
If you're unsure about any of these, don't hesitate to ask. We're here to help!
-->

- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING.md** document.
- [ ] All new and existing tests passed.

