### PR TITLE
fix: prevent automation from producing broken PRs

### DIFF
--- a/.github/workflows/automatic-updates.yml
+++ b/.github/workflows/automatic-updates.yml
@@ -25,6 +25,7 @@ jobs:
 
       - name: Create update PR
         id: cpr
+        if: steps.updt.outputs.result != ''
         uses: peter-evans/create-pull-request@c0f553fe549906ede9cf27b5156039d195d2ece0 # v8.1.0
         with:
           token: ${{ secrets.GH_API_TOKEN }}

--- a/.github/workflows/automatic-updates.yml
+++ b/.github/workflows/automatic-updates.yml
@@ -26,6 +26,7 @@ jobs:
 
       - name: Create update PR
         id: cpr
+        if: steps.updt.outputs.result != ''
         uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
         with:
           token: ${{ secrets.GH_API_TOKEN }}

--- a/build-automation.mjs
+++ b/build-automation.mjs
@@ -93,10 +93,15 @@ export default async function(github) {
         console.log(stdout);
         updatedVersions.push(newVersion.fullVersion);
       } else {
-        console.log(`There's no musl build for version ${newVersion.fullVersion} yet.`);
-        process.exit(0);
+        console.log(`Skipping version ${newVersion.fullVersion} - no musl build available yet.`);
       }
     }
+
+    if (updatedVersions.length === 0) {
+      console.log("No versions with musl builds were updated.");
+      process.exit(0);
+    }
+
     const { stdout } = (await exec(`git diff`));
     console.log(stdout);
 

--- a/build-automation.mjs
+++ b/build-automation.mjs
@@ -128,11 +128,16 @@ export default async function (github) {
         updatedVersions.push(newVersion.fullVersion);
       } else {
         console.log(
-          `There's no musl build for version ${newVersion.fullVersion} yet.`,
+          `Skipping version ${newVersion.fullVersion} - no musl build available yet.`,
         );
-        process.exit(0);
       }
     }
+
+    if (updatedVersions.length === 0) {
+      console.log('No versions with musl builds were updated.');
+      process.exit(0);
+    }
+
     const { stdout } = await exec(`git diff`);
     console.log(stdout);
 

--- a/update.sh
+++ b/update.sh
@@ -170,6 +170,12 @@ function update_node_version() {
     else
       if [ "${SKIP}" != true ]; then
         sed -Ei -e 's/^(ENV YARN_VERSION)=.*/\1='"${yarnVersion}"'/' "${dockerfile}-tmp"
+      else
+        # Preserve existing YARN_VERSION from current Dockerfile when SKIP=true
+        existingYarnVersion=$(sed -n 's/^ENV YARN_VERSION=//p' "${dockerfile}")
+        if [ -n "${existingYarnVersion}" ]; then
+          sed -Ei -e 's/^(ENV YARN_VERSION)=.*/\1='"${existingYarnVersion}"'/' "${dockerfile}-tmp"
+        fi
       fi
       echo "${dockerfile} updated!"
     fi


### PR DESCRIPTION
## Description

Fixes issues in the automatic update workflow that caused broken PRs with `YARN_VERSION=0.0.0` and empty PR titles.

Changes:
1. `update.sh`: Preserve existing `YARN_VERSION` from current Dockerfile when `SKIP=true` instead of leaving template placeholder
2. `build-automation.mjs`: Skip versions without musl builds instead of exiting early; only exit after loop if no versions were updated
3. `automatic-updates.yml`: Add condition to skip PR creation when result is empty

## Motivation and Context

The automatic update workflow was producing broken PRs:

- **YARN_VERSION=0.0.0 bug**: When running `update.sh -s` (security update), the template placeholder `0.0.0` was written to Dockerfiles instead of preserving the existing yarn version. This was a regression from commit 61380fa1.

- **Partial updates / empty PR titles**: `build-automation.mjs` would `process.exit(0)` when encountering a version without musl builds, leaving partial changes and causing empty PR titles.

Related issues seen in PRs #2341, #2347, #2350.

## Testing Details

- Ran `./update.sh -s 24 bookworm` - verified YARN_VERSION preserved (not 0.0.0)
- `node --check build-automation.mjs` - syntax valid
- `shellcheck update.sh` - no errors
- `shfmt -d -sr -i 2 -ci update.sh` - formatting check passed

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING.md** document.
- [x] All new and existing tests passed.