### PR TITLE
Deprecate Yarn v1

### DIFF
--- a/README.md
+++ b/README.md
@@ -258,7 +258,7 @@ variants. Because Yarn v1 is [frozen](https://github.com/yarnpkg/yarn) and no lo
 bundling plans have been revised.
 
 As of Node.js 26.0.0 it is planned to no longer bundle Yarn v1 into `node` images.
-`node` images for lower versions of Node.js (<26) will continue to bundle Yarn v1.
+For lower versions of Node.js (<26) `node` images will continue to bundle Yarn v1.
 
 Users with legacy requirements for Yarn v1 under Node.js 26 and above may be able
 to follow [Yarn v1 installation instructions](https://classic.yarnpkg.com/en/docs/install)


### PR DESCRIPTION
Refs: https://github.com/nodejs/docker-node/issues/2264

## Description

Deprecation information for (un)bundling of Yarn v1 Classic is added to the [README](https://github.com/nodejs/docker-node/blob/main/README.md).

Users with legacy needs are also advised that Yarn v1 can be installed with the following commands, according to [Yarn installation instructions](https://classic.yarnpkg.com/en/docs/install):

```shell
npm install --global yarn
```

This is possible, since Node.js [bundles](https://github.com/nodejs/node/blob/main/doc/contributing/distribution.md) the [npm package manager](https://www.npmjs.com/package/npm) and so provides the prerequisites to use npm to install Yarn v1.

## Motivation and Context

- Node.js Docker images bundle the Yarn v1 Classic package manager into each published image. This has been the case since Feb 2017
- Yarn v1 Classic package manager has been [frozen](https://github.com/yarnpkg/yarn) since the release of Yarn 2 in January 2020 and is unsupported since then.
- https://yarnpkg.com/latest-version has remained at release [yarn@1.22.22](https://github.com/yarnpkg/yarn/releases/tag/v1.22.22) since March 2024 in line with the frozen and unsupported status of this version
- Removal of Yarn v1 from Node.js Docker images has been proposed again and again over the years
- Yarn is not included in the [Node.js distribution](https://github.com/nodejs/node/blob/main/doc/contributing/distribution.md) itself and so it is an exceptional addition into the Docker images

### Assumption

According to the discussion in https://github.com/nodejs/docker-node/issues/2264 it's assumed here that Node.js Docker images will stop bundling Yarn v1 for Node.js release lines 26 and above, starting with the release of Node.js 26.0.0 ([planned](https://github.com/nodejs/Release/blob/main/schedule.json) for 2026-04-22).

It's also assumed that Yarn v1 will continue to be bundled with currently supported Node.js release lines for legacy reasons. The end of availability  of Docker images with Yarn v1 would then be when Node.js 24.x transitions into [end-of-life](https://github.com/nodejs/Release/blob/main/README.md#release-schedule) planned for 2028-04-30.

## Testing Details

N/A

## Types of changes

- [X] Documentation
- [ ] Version change (Update, remove or add more Node.js versions)
- [ ] Variant change (Update, remove or add more variants, or versions of variants)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other (none of the above)

## Checklist

- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING.md** document.
- [x] All new and existing tests passed. 
