### PR TITLE
fix(stackbrew): read the fullversion for each image

### DIFF
--- a/stackbrew.js
+++ b/stackbrew.js
@@ -51,11 +51,10 @@ for (version of versions) {
     let isSlim = slimRE.test(variant)
     let isDefaultSlim = new RegExp(`${defaultDebian}-slim`).test(variant)
 
-    // Get full version from the first Dockerfile
-    if (!fullversion) {
-      let dockerfile = fs.readFileSync(dockerfilePath, 'utf-8')
-      fullversion = dockerfile.match(/ENV NODE_VERSION=(?<major>\d+)\.(?<minor>\d+)\.(?<patch>\d+)/)
-    }
+    // Get full version from the Dockerfile
+    let dockerfile = fs.readFileSync(dockerfilePath, 'utf-8')
+    fullversion = dockerfile.match(/ENV NODE_VERSION=(?<major>\d+)\.(?<minor>\d+)\.(?<patch>\d+)/)
+
     let tags = [
       `${fullversion.groups.major}.${fullversion.groups.minor}.${fullversion.groups.patch}-${variant}`,
       `${fullversion.groups.major}.${fullversion.groups.minor}-${variant}`,


### PR DESCRIPTION
<!--
Provide a general summary of your changes in the Title above.
-->

## Description

When we land a manual PR without the Alpine image bump, the stackbrew output uses the old version number, and doesn't have the correct diff. 
There are other PRs that are looking at better fixes for the security releases, but this unblocks the current 24/25 releases.

## Motivation and Context

<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
-->

## Testing Details

<!--
Please describe in detail how you tested your changes. Include details of
your testing environment, and the tests you ran to see how your change
affects other areas of the code, etc.
-->

## Example Output(if appropriate)

## Types of changes

<!--
What types of changes does your code introduce? Put an `x` in all the boxes that apply.
-->

- [ ] Documentation
- [ ] Version change (Update, remove or add more Node.js versions)
- [ ] Variant change (Update, remove or add more variants, or versions of variants)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other (none of the above)

## Checklist

<!--
Go over all the following points, and put an `x` in all the boxes that apply.
If you're unsure about any of these, don't hesitate to ask. We're here to help!
-->

- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING.md** document.
- [ ] All new and existing tests passed.

