### PR TITLE
bump Node.js version to 20.20.1 skipping Yarn and Alpine

### DIFF
--- a/20/bookworm-slim/Dockerfile
+++ b/20/bookworm-slim/Dockerfile
@@ -3,7 +3,7 @@ FROM debian:bookworm-slim
 RUN groupadd --gid 1000 node \
   && useradd --uid 1000 --gid node --shell /bin/bash --create-home node
 
-ENV NODE_VERSION=20.20.0
+ENV NODE_VERSION=20.20.1
 
 RUN ARCH= OPENSSL_ARCH= && dpkgArch="$(dpkg --print-architecture)" \
     && case "${dpkgArch##*-}" in \

--- a/20/bookworm/Dockerfile
+++ b/20/bookworm/Dockerfile
@@ -3,7 +3,7 @@ FROM buildpack-deps:bookworm
 RUN groupadd --gid 1000 node \
   && useradd --uid 1000 --gid node --shell /bin/bash --create-home node
 
-ENV NODE_VERSION=20.20.0
+ENV NODE_VERSION=20.20.1
 
 RUN ARCH= && dpkgArch="$(dpkg --print-architecture)" \
   && case "${dpkgArch##*-}" in \

--- a/20/bullseye-slim/Dockerfile
+++ b/20/bullseye-slim/Dockerfile
@@ -3,7 +3,7 @@ FROM debian:bullseye-slim
 RUN groupadd --gid 1000 node \
   && useradd --uid 1000 --gid node --shell /bin/bash --create-home node
 
-ENV NODE_VERSION=20.20.0
+ENV NODE_VERSION=20.20.1
 
 RUN ARCH= OPENSSL_ARCH= && dpkgArch="$(dpkg --print-architecture)" \
     && case "${dpkgArch##*-}" in \

--- a/20/bullseye/Dockerfile
+++ b/20/bullseye/Dockerfile
@@ -3,7 +3,7 @@ FROM buildpack-deps:bullseye
 RUN groupadd --gid 1000 node \
   && useradd --uid 1000 --gid node --shell /bin/bash --create-home node
 
-ENV NODE_VERSION=20.20.0
+ENV NODE_VERSION=20.20.1
 
 RUN ARCH= && dpkgArch="$(dpkg --print-architecture)" \
   && case "${dpkgArch##*-}" in \

--- a/20/trixie-slim/Dockerfile
+++ b/20/trixie-slim/Dockerfile
@@ -3,7 +3,7 @@ FROM debian:trixie-slim
 RUN groupadd --gid 1000 node \
   && useradd --uid 1000 --gid node --shell /bin/bash --create-home node
 
-ENV NODE_VERSION=20.20.0
+ENV NODE_VERSION=20.20.1
 
 RUN ARCH= OPENSSL_ARCH= && dpkgArch="$(dpkg --print-architecture)" \
     && case "${dpkgArch##*-}" in \

--- a/20/trixie/Dockerfile
+++ b/20/trixie/Dockerfile
@@ -3,7 +3,7 @@ FROM buildpack-deps:trixie
 RUN groupadd --gid 1000 node \
   && useradd --uid 1000 --gid node --shell /bin/bash --create-home node
 
-ENV NODE_VERSION=20.20.0
+ENV NODE_VERSION=20.20.1
 
 RUN ARCH= && dpkgArch="$(dpkg --print-architecture)" \
   && case "${dpkgArch##*-}" in \


### PR DESCRIPTION


## Description

Bumps the Node version to 20.20.1 using `./update.sh 20 -s`

## Motivation and Context

It is the next step in the process to make 20.20.1 available in the docker library. 20.20.0 contains [CVE-2025-15467](https://github.com/advisories/GHSA-wvhq-3h88-rf6g) https://github.com/nodejs/node/issues/61887

## Testing Details

Tested locally with
```
docker build -t node-20-test 20/bookworm/
docker build -t node-20-bookworm-slim-test 20/bookworm-slim/
docker build -t node-20-bullseye-test 20/bullseye/
docker build -t node-20-bullseye-slim-test 20/bullseye-slim/
docker build -t node-20-trixie-test 20/trixie/
docker build -t node-20-trixie-slim-test 20/trixie-slim/

docker run --rm node-20-test node --version
docker run --rm node-20-bookworm-slim-test node --version
docker run --rm node-20-bullseye-test node --version
docker run --rm node-20-bullseye-slim-test node --version
docker run --rm node-20-trixie-test node --version
docker run --rm node-20-trixie-slim-test node --version
```

## Example Output

All outputted v20.20.1

## Types of changes


- [ ] Documentation
- [X] Version change (Update, remove or add more Node.js versions)
- [ ] Variant change (Update, remove or add more variants, or versions of variants)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other (none of the above)

## Checklist

- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING.md** document.
- [ ] All new and existing tests passed.

