### PR TITLE
docs: correct npm branding - use lower case

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -17,7 +17,7 @@ the Node.js TSC as final arbiter.
 
 New **Node.js** releases are released as soon as possible.
 
-New **NPM** releases are not tracked. We simply use the NPM version bundled in the corresponding Node.js release.
+New **npm** releases are not tracked. We simply use the npm version bundled in the corresponding Node.js release.
 
 **Yarn** is updated to the latest version only when there is a new Node.js SemVer PATCH release (unless Yarn has received a security update), and it's updated only in the branch with the new release, preferably in the same PR. The `update.sh` script does this automatically when invoked with a specific branch, e.g. `./update.sh 6.10`.
 

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ The official Node.js docker image, made with love by the node community.
   - [Verbosity](#verbosity)
     - [Dockerfile](#dockerfile)
     - [Docker Run](#docker-run)
-    - [NPM run](#npm-run)
+    - [npm run](#npm-run)
 - [Image Variants](#image-variants)
   - [`node:<version>`](#nodeversion)
   - [`node:alpine`](#nodealpine)
@@ -135,7 +135,7 @@ override `NPM_CONFIG_LOGLEVEL`.
 $ docker run -e NPM_CONFIG_LOGLEVEL=info node ...
 ```
 
-#### NPM run
+#### npm run
 
 If you are running npm commands, you can use `--loglevel` to control the
 verbosity of the output.


### PR DESCRIPTION
## Description

Change text references in [README](https://github.com/nodejs/docker-node/blob/main/README.md) and [CONTRIBUTING](https://github.com/nodejs/docker-node/blob/main/CONTRIBUTING.md) to use lower case "npm"

## Motivation and Context

https://github.com/npm/cli#faq-on-branding notes:

> **Is it "npm" or "NPM" or "Npm"?**
>
> **`npm`** should never be capitalized unless it is being displayed in a location that is customarily all-capitals (ex. titles on `man` pages).

## Testing Details

N/A 

## Types of changes

- [X] Documentation
- [ ] Version change (Update, remove or add more Node.js versions)
- [ ] Variant change (Update, remove or add more variants, or versions of variants)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other (none of the above)

## Checklist

- [X] My code follows the code style of this project.
- [X] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING.md** document.
- [X] All new and existing tests passed.

