### PR TITLE
docs: update description for Yarn updates

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,7 +19,11 @@ New **Node.js** releases are released as soon as possible.
 
 New **NPM** releases are not tracked. We simply use the NPM version bundled in the corresponding Node.js release.
 
-**Yarn** is updated to the latest version only when there is a new Node.js SemVer PATCH release (unless Yarn has received a security update), and it's updated only in the branch with the new release, preferably in the same PR. The `update.sh` script does this automatically when invoked with a specific branch, e.g. `./update.sh 6.10`.
+**Yarn v1 Classic** is updated using the [update.sh](https://github.com/nodejs/docker-node/blob/main/update.sh) script
+which checks for the contents of https://yarnpkg.com/latest-version.
+Yarn v1 Classic is frozen according to the notice on the https://github.com/yarnpkg/yarn repo and so no further updates are expected.
+Modifications to the [update.sh](https://github.com/nodejs/docker-node/blob/main/update.sh) script are planned to prevent
+future bundling of Yarn v1 in images for Node.js >=26 (see also [Yarn v1 Classic Bundling](README.md#yarn-v1-classic-bundling)).
 
 ### Submitting a PR for a version update
 


### PR DESCRIPTION
## Description

Reformulate the description for Yarn updates in the [CONTRIBUTING](https://github.com/nodejs/docker-node/blob/main/CONTRIBUTING.md) document.

## Motivation and Context

- The [CONTRIBUTING](https://github.com/nodejs/docker-node/blob/main/CONTRIBUTING.md) document describes updating Yarn v1 Classic versions. The details are no longer needed as Yarn v1 is frozen at 1.22.22 and hasn't had an update since 2024.
- Yarn v1 is planned for removal with Node.js 26
- The example `./update.sh 6.10` is incorrect, as the script only accepts Node.js major versions as a parameter. See [update.sh](https://github.com/nodejs/docker-node/blob/main/update.sh). Possibly `6,10` was intended, as a list of major versions.

## Testing Details

N/A - documentation only

## Types of changes

- [X] Documentation
- [ ] Version change (Update, remove or add more Node.js versions)
- [ ] Variant change (Update, remove or add more variants, or versions of variants)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other (none of the above)

## Checklist

- [X] My code follows the code style of this project.
- [X] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING.md** document.
- [X] All new and existing tests passed.
