### PR TITLE
docs: update to active LTS 24 in README examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ See: https://nodejs.org
 
 ```dockerfile
 # specify the node base image with your desired version node:<version>
-FROM node:22
+FROM node:24
 # replace this with your application's default port
 EXPOSE 8888
 ```
@@ -71,7 +71,7 @@ If you prefer Docker Compose:
 ```yml
 services:
   node:
-    image: "node:22"
+    image: "node:24"
     user: "node"
     working_dir: /home/node/app
     environment:
@@ -104,7 +104,7 @@ complete `Dockerfile`. In such cases, you can run a Node.js script by using the
 Node.js Docker image directly:
 
 ```console
-$ docker run -it --rm --name my-running-script -v "$PWD":/usr/src/app -w /usr/src/app node:22 node your-daemon-or-script.js
+$ docker run -it --rm --name my-running-script -v "$PWD":/usr/src/app -w /usr/src/app node:24 node your-daemon-or-script.js
 ```
 
 ### Verbosity


### PR DESCRIPTION
## Description

Update the examples in [README](https://github.com/nodejs/docker-node#readme) document to use Node.js 24 (Active LTS).

## Motivation and Context

The [README](https://github.com/nodejs/docker-node#readme) document uses the older Node.js 22 (Maintenance LTS) version in examples. To take advantage of newer features and bug fixes, examples should use the best stable version which is Node.js 24, the Active LTS version.

## Testing Details

N/A - documentation only

## Types of changes

- [X] Documentation
- [ ] Version change (Update, remove or add more Node.js versions)
- [ ] Variant change (Update, remove or add more variants, or versions of variants)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other (none of the above)

## Checklist

- [X] My code follows the code style of this project.
- [X] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING.md** document.
- [X] All new and existing tests passed.
