### PR TITLE
docs: update smaller images (npm/yarn) example to current versions

### DIFF
--- a/docs/BestPractices.md
+++ b/docs/BestPractices.md
@@ -213,9 +213,9 @@ COPY --from=builder node_modules .
 If you want to achieve an even smaller image size than the `-alpine`, you can omit the npm/yarn like this:
 
 ```Dockerfile
-ARG ALPINE_VERSION=3.16
+ARG ALPINE_VERSION=3.23
 
-FROM node:18-alpine${ALPINE_VERSION} AS builder
+FROM node:24-alpine${ALPINE_VERSION} AS builder
 WORKDIR /build-stage
 COPY package*.json ./
 RUN npm ci
@@ -240,5 +240,3 @@ COPY --from=builder /build-stage/dist ./dist
 # Run with dumb-init to not start node with PID=1, since Node.js was not designed to run as PID 1
 CMD ["dumb-init", "node", "dist/index.js"]
 ```
-
-


### PR DESCRIPTION
## Description

Update the [Smaller images without npm/yarn](https://github.com/nodejs/docker-node/blob/main/docs/BestPractices.md#smaller-images-without-npmyarn) example to use the Node.js 24 (Active LTS) and Alpine 3.23 (current latest stable) versions in the `Dockerfile` example.

## Motivation and Context

The [Smaller images without npm/yarn](https://github.com/nodejs/docker-node/blob/main/docs/BestPractices.md#smaller-images-without-npmyarn) document section in the [Docker and Node.js Best Practices](https://github.com/nodejs/docker-node/blob/main/docs/BestPractices.md) document is outdated and based on:

- Node.js 18 ([EOL](https://github.com/nodejs/Release/blob/main/README.md#end-of-life-releases) 2025-04-30)
- Alpine 3.16 ([EOL](https://alpinelinux.org/releases/) 2024-05-23)

## Testing Details

```shell
cd $(mktemp -d)
npm init -y
npm install @vercel/ncc
echo 'console.log("Hello world!")' > index.js
```

Add `"build": "ncc build index.js -o dist"` to package.json

```shell
cat > Dockerfile <<'EOT'
ARG ALPINE_VERSION=3.23

FROM node:24-alpine${ALPINE_VERSION} AS builder
WORKDIR /build-stage
COPY package*.json ./
RUN npm ci
# Copy the the files you need
COPY . ./
RUN npm run build

FROM alpine:${ALPINE_VERSION}
# Create app directory
WORKDIR /usr/src/app
# Add required binaries
RUN apk add --no-cache libstdc++ dumb-init \
  && addgroup -g 1000 node && adduser -u 1000 -G node -s /bin/sh -D node \
  && chown node:node ./
COPY --from=builder /usr/local/bin/node /usr/local/bin/
COPY --from=builder /usr/local/bin/docker-entrypoint.sh /usr/local/bin/
ENTRYPOINT ["docker-entrypoint.sh"]
USER node
# Update the following COPY lines based on your codebase
COPY --from=builder /build-stage/node_modules ./node_modules
COPY --from=builder /build-stage/dist ./dist
# Run with dumb-init to not start node with PID=1, since Node.js was not designed to run as PID 1
CMD ["dumb-init", "node", "dist/index.js"]
EOT

docker build -t test-small-image .
docker run --rm test-small-image
docker run --rm --entrypoint node test-small-image --version
docker run --rm --entrypoint which test-small-image node
docker run --rm --entrypoint which test-small-image npm
docker run --rm --entrypoint which test-small-image yarn
```

## Example Output

```text
$ docker run --rm test-small-image
docker run --rm --entrypoint node test-small-image --version
docker run --rm --entrypoint which test-small-image node
docker run --rm --entrypoint which test-small-image npm
docker run --rm --entrypoint which test-small-image yarn
Hello world!
v24.14.0
/usr/local/bin/node
```

## Types of changes

- [X] Documentation
- [ ] Version change (Update, remove or add more Node.js versions)
- [ ] Variant change (Update, remove or add more variants, or versions of variants)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other (none of the above)

## Checklist

- [X] My code follows the code style of this project.
- [X] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING.md** document.
- [X] All new and existing tests passed.

