### PR TITLE
fix: modify update.sh script

### DIFF
--- a/update.sh
+++ b/update.sh
@@ -11,29 +11,21 @@ function usage() {
     $0 [-s] [MAJOR_VERSION(S)] [VARIANT(S)]
 
   Examples:
-    - update.sh                      # Update all images
-    - update.sh -s                   # Update all images, skip updating Alpine and Yarn
-    - update.sh 8,10                 # Update all variants of version 8 and 10
-    - update.sh -s 8                 # Update version 8 and variants, skip updating Alpine and Yarn
-    - update.sh 8 alpine             # Update only alpine's variants for version 8
-    - update.sh -s 8 bullseye        # Update only bullseye variant for version 8, skip updating Alpine and Yarn
-    - update.sh . alpine             # Update the alpine variant for all versions
+    - update.sh                         # Update all images
+    - update.sh 24                      # Update all variants of version 24
+    - update.sh 22,24                   # Update all variants of version 22 and 24
+    - update.sh 24 alpine3.23           # Update only alpine3.23's variants for version 24
+    - update.sh 24 trixie,trixie-slim   # Update only trixie & trixie-slim variants for version 24
+    - update.sh . trixie                # Update the trixie variant for all versions
 
   OPTIONS:
-    -s Security update; skip updating the yarn and alpine versions.
-    -b CI config update only
     -h Show this message
 
 EOF
 }
 
-SKIP=false
-while getopts "sh" opt; do
+while getopts "h" opt; do
   case "${opt}" in
-    s)
-      SKIP=true
-      shift
-      ;;
     h)
       usage
       exit
@@ -65,9 +57,7 @@ fi
 # TODO: Should be able to specify target architecture manually
 arch=$(get_arch)
 
-if [ "${SKIP}" != true ]; then
-  yarnVersion="$(curl -sSL --compressed https://yarnpkg.com/latest-version)"
-fi
+yarnVersion="$(curl -sSL --compressed https://yarnpkg.com/latest-version)"
 
 function in_versions_to_update() {
   local version=$1
@@ -134,6 +124,9 @@ function update_node_version() {
     sed -Ei -e 's/^FROM (.*)/FROM '"$fromprefix"'\1/' "${dockerfile}-tmp"
     sed -Ei -e 's/^(ENV NODE_VERSION)=.*/\1='"${nodeVersion}"'/' "${dockerfile}-tmp"
 
+    currentYarnVersion="$(grep "ENV YARN_VERSION" "${dockerfile}" | cut -d'=' -f2)"
+    sed -Ei -e 's/^(ENV YARN_VERSION=).*/\1'"${currentYarnVersion}"'/' "${dockerfile}-tmp"
+
     # shellcheck disable=SC1004
     new_line=' \\\
 '
@@ -168,9 +161,7 @@ function update_node_version() {
     if diff -q "${dockerfile}-tmp" "${dockerfile}" > /dev/null; then
       echo "${dockerfile} is already up to date!"
     else
-      if [ "${SKIP}" != true ]; then
-        sed -Ei -e 's/^(ENV YARN_VERSION)=.*/\1='"${yarnVersion}"'/' "${dockerfile}-tmp"
-      fi
+      sed -Ei -e 's/^(ENV YARN_VERSION=).*/\1'"${yarnVersion}"'/' "${dockerfile}-tmp"
       echo "${dockerfile} updated!"
     fi
 


### PR DESCRIPTION
- closes https://github.com/nodejs/docker-node/issues/2411
- closes https://github.com/nodejs/docker-node/issues/2412
- closes https://github.com/nodejs/docker-node/issues/2413

## Description

In the [update.sh](https://github.com/nodejs/docker-node/blob/main/update.sh) script:

- restore code which saves the Yarn version from each `Dockerfile`, so that the script can judge whether it has done an update or not. This needs to be changed slightly compared to the original code because the text to be parsed is now "ENV YARN_VERSION=1.22.22" with an "=" delimiter.
- remove the `-s` option
- remove the unavailable `-b` option from help text
- update example options to use current Node.js versions and latest Debian release (trixie) and ensure the accuracy of examples

## Motivation and Context

Multiple interrelated issues described in https://github.com/nodejs/docker-node/issues/2411, https://github.com/nodejs/docker-node/issues/2412 & https://github.com/nodejs/docker-node/issues/2413 need addressing.

Previous changes removed a function of the script that saved the version of Yarn and ensured that the log message "Dockerfile updated!" / "Dockerfile is already up to date!" was correctly output. This also made sure that the version of Yarn was preserved in the `Dockerfile`.

The `-s` option, that according to the help text is supposed to skip updating Alpine and Yarn, has no relation to any Alpine updates and skipping Yarn updates isn't necessary as Yarn v1 is frozen at version 1.22.22. Yarn is also planned for removal in Node.js 26 images and above.

The help text invoked with `./update.sh -h` has several inaccuracies.

- the option `-b` is no longer available
- specifying EOL Node.js versions, such as `8`, attempts to update all current versions
- specifying `. alpine` on its own also attempts to update all variants

## Testing Details

Execute `./update.sh -h` and then invoke each one of the listed examples.

The message should be "Dockerfile is already up to date!""
Check for changes with `git diff`. There should be none.

```shell
git checkout 1c31f1dc # prior to 20.20.1 update
git switch -c test-update
git cherry-pick <commit-from-this-PR>
```

Repeat tests. `NODE_VERSION` in `Dockerfile` in `20` directory should be updated.
Test with explicitly selecting `20`.
Ensure that repeating an update after "Dockerfile updated!" is displayed on the first attempt should then display
"Dockerfile is already up to date!" on subsequent calls.

## Example Output

```text
$ ./update.sh -h

  Update the node docker images.

  Usage:
    ./update.sh [-s] [MAJOR_VERSION(S)] [VARIANT(S)]

  Examples:
    - update.sh                         # Update all images
    - update.sh 24                      # Update all variants of version 24
    - update.sh 22,24                   # Update all variants of version 22 and 24
    - update.sh 24 alpine3.23           # Update only alpine3.23's variants for version 24
    - update.sh 24 trixie,trixie-slim   # Update only trixie & trixie-slim variants for version 24
    - update.sh . trixie                # Update the trixie variant for all versions

  OPTIONS:
    -h Show this message

```

## Types of changes

- [ ] Documentation
- [ ] Version change (Update, remove or add more Node.js versions)
- [ ] Variant change (Update, remove or add more variants, or versions of variants)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other (none of the above)

## Checklist

- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING.md** document.
- [X] All new and existing tests passed.
