### PR TITLE
fix: remove b option from update.sh help

### DIFF
--- a/update.sh
+++ b/update.sh
@@ -21,7 +21,6 @@ function usage() {
 
   OPTIONS:
     -s Security update; skip updating the yarn and alpine versions.
-    -b CI config update only
     -h Show this message
 
 EOF


### PR DESCRIPTION
Refs: https://github.com/nodejs/docker-node/issues/2412

## Description

In the [update.sh](https://github.com/nodejs/docker-node/blob/main/update.sh) script:

- remove the unavailable `-b` option from help text

## Motivation and Context

The option `-b` is no longer available.

PR https://github.com/nodejs/docker-node/pull/1339 in Oct 2020 removed the `b` option from the list of examples, and from `getopts`. It missed removing it from the help list under the OPTIONS heading, leaving the help text in an inconsistent state.

## Testing Details

Execute `./update.sh -h` and confirm that -b no longer appears in the OPTIONS list.

## Example Output

```text
$ ./update.sh -h

  Update the node docker images.

  Usage:
    ./update.sh [-s] [MAJOR_VERSION(S)] [VARIANT(S)]

  Examples:
    - update.sh                      # Update all images
    - update.sh -s                   # Update all images, skip updating Alpine and Yarn
    - update.sh 8,10                 # Update all variants of version 8 and 10
    - update.sh -s 8                 # Update version 8 and variants, skip updating Alpine and Yarn
    - update.sh 8 alpine             # Update only alpine's variants for version 8
    - update.sh -s 8 bullseye        # Update only bullseye variant for version 8, skip updating Alpine and Yarn
    - update.sh . alpine             # Update the alpine variant for all versions

  OPTIONS:
    -s Security update; skip updating the yarn and alpine versions.
    -h Show this message

```

## Types of changes

- [ ] Documentation
- [ ] Version change (Update, remove or add more Node.js versions)
- [ ] Variant change (Update, remove or add more variants, or versions of variants)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other (none of the above)

## Checklist

- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING.md** document.
- [X] All new and existing tests passed.
