### PR TITLE
docs: add #nodejs-distributions Slack link to CONTRIBUTING

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,6 +13,14 @@ with rationale and allow time for async feedback.
 If a final decision cannot be reached via consensus seeking, escalation goes to
 the Node.js TSC as final arbiter.
 
+## Discussion Areas
+
+You can use Node.js channels (prefixed by `#nodejs-`) in the [OpenJSF Slack](https://slack-invite.openjsf.org/) workspace for discussions.
+
+- [#nodejs-distributions](https://openjs-foundation.slack.com/archives/C0ALS3UDE8G) covers discussions for this repo (`docker-node`).
+
+- [#nodejs-release](https://openjs-foundation.slack.com/archives/C019MGJQ8RH) is linked to the [Node.js Release Working Group](https://github.com/nodejs/release#readme) responsible for the upstream releases of Node.js used by this repo.
+
 ## Version Updates
 
 New **Node.js** releases are released as soon as possible.


### PR DESCRIPTION
## Description

Add the [OpenJS Foundation Slack](https://slack-invite.openjsf.org/) and the new [#nodejs-distributions](https://openjs-foundation.slack.com/archives/C0ALS3UDE8G) channel links to the [CONTRIBUTING](https://github.com/nodejs/docker-node/blob/main/CONTRIBUTING.md) document.

Include also a link to the related [#nodejs-release](https://openjs-foundation.slack.com/archives/C019MGJQ8RH) Slack channel.

## Motivation and Context

The [#nodejs-distributions](https://openjs-foundation.slack.com/archives/C0ALS3UDE8G) Slack channel was created on March 11, 2026. Linking the channel into the [CONTRIBUTING](https://github.com/nodejs/docker-node/blob/main/CONTRIBUTING.md) document allows it to be more easily discovered and used.

Slack extends the ability to conduct discussions that don't directly fit into GitHub Issues / Pull Request spaces.

## Types of changes

- [X] Documentation
- [ ] Version change (Update, remove or add more Node.js versions)
- [ ] Variant change (Update, remove or add more variants, or versions of variants)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other (none of the above)

## Checklist

- [X] My code follows the code style of this project.
- [X] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING.md** document.
- [X] All new and existing tests passed.
