### PR TITLE
fix: Don't fail on Alpine checksums for Security releases

### DIFF
--- a/update.sh
+++ b/update.sh
@@ -12,11 +12,11 @@ function usage() {
 
   Examples:
     - update.sh                      # Update all images
-    - update.sh -s                   # Update all images, skip updating Alpine
+    - update.sh -s                   # Update all images, skip updating Alpine if the musl build isn't available
     - update.sh 8,10                 # Update all variants of version 8 and 10
-    - update.sh -s 8                 # Update version 8 and variants, skip updating Alpine
+    - update.sh -s 8                 # Update version 8 and variants, skip updating Alpine if the musl build isn't available
     - update.sh 8 alpine             # Update only alpine's variants for version 8
-    - update.sh -s 8 bullseye        # Update only bullseye variant for version 8, skip updating Alpine
+    - update.sh -s 8 bullseye        # Update only bullseye variant for version 8, skip updating Alpine if the musl build isn't available
     - update.sh . alpine             # Update the alpine variant for all versions
 
   OPTIONS:
@@ -26,9 +26,11 @@ function usage() {
 EOF
 }
 
+SKIP_ALPINE=false
 while getopts "sh" opt; do
   case "${opt}" in
     s)
+      SKIP_ALPINE=true
       shift
       ;;
     h)
@@ -57,7 +59,7 @@ if [ ${#versions[@]} -eq 0 ]; then
 fi
 
 # Global variables
-# Get architecure and use this as target architecture for docker image
+# Get architecture and use this as target architecture for docker image
 # See details in function.sh
 # TODO: Should be able to specify target architecture manually
 arch=$(get_arch)
@@ -145,11 +147,15 @@ function update_node_version() {
       )
       if [ -z "$checksum" ]; then
         rm -f "${dockerfile}-tmp"
-        fatal "Failed to fetch checksum for version ${nodeVersion}"
+        if [ "${SKIP_ALPINE}" = true ]; then
+          echo "${nodeVersion} is missing the musl build for ${variant}, but skipping for security release!"
+        else
+          fatal "Failed to fetch checksum for musl build version ${nodeVersion}"
+        fi
+      else
+        sed -Ei -e "s/(alpine:)0.0/\\1${alpine_version}/" "${dockerfile}-tmp"
+        sed -Ei -e "s/CHECKSUM=CHECKSUM_x64/CHECKSUM=\"${checksum}\"/" "${dockerfile}-tmp"
       fi
-      sed -Ei -e "s/(alpine:)0.0/\\1${alpine_version}/" "${dockerfile}-tmp"
-      sed -Ei -e "s/CHECKSUM=CHECKSUM_x64/CHECKSUM=\"${checksum}\"/" "${dockerfile}-tmp"
-
     elif is_debian "${variant}"; then
       sed -Ei -e "s/(buildpack-deps:)name/\\1${variant}/" "${dockerfile}-tmp"
     elif is_debian_slim "${variant}"; then
@@ -173,7 +179,10 @@ function update_node_version() {
       rm "${dockerfile}-tmp-e"
     fi
 
-    mv -f "${dockerfile}-tmp" "${dockerfile}"
+    # Guard the move because Alpine sometimes will be missing
+    if [ -f "${dockerfile}-tmp" ]; then
+      mv -f "${dockerfile}-tmp" "${dockerfile}"
+    fi
   )
 }
 


### PR DESCRIPTION
<!--
Provide a general summary of your changes in the Title above.
-->

## Description

Added back the recent "skip" concept for the Apline checksums falling over, but still allow Alpine to try and update itself if the checksum is available.

## Motivation and Context

<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
-->

## Testing Details

<!--
Please describe in detail how you tested your changes. Include details of
your testing environment, and the tests you ran to see how your change
affects other areas of the code, etc.
-->

## Example Output(if appropriate)

## Types of changes

<!--
What types of changes does your code introduce? Put an `x` in all the boxes that apply.
-->

- [ ] Documentation
- [ ] Version change (Update, remove or add more Node.js versions)
- [ ] Variant change (Update, remove or add more variants, or versions of variants)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other (none of the above)

## Checklist

<!--
Go over all the following points, and put an `x` in all the boxes that apply.
If you're unsure about any of these, don't hesitate to ask. We're here to help!
-->

- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING.md** document.
- [ ] All new and existing tests passed.

