### PR TITLE
feat: Strip Yarn from 26+ images

### DIFF
--- a/update.sh
+++ b/update.sh
@@ -156,6 +156,12 @@ function update_node_version() {
       sed -Ei -e "s/(debian:)name-slim/\\1${variant}/" "${dockerfile}-tmp"
     fi
 
+    # Strip out Yarn v1 from Node 26+ images https://github.com/nodejs/docker-node/issues/2407
+    # Can be removed from the image templates once Node 24 hits EOL on 2028-04-30
+    if [ "${nodeVersion:0:2}" -ge "26" ]; then
+      sed -Ei -e "/ENV YARN_VERSION/,/rm -rf \/tmp\/\*/d" "${dockerfile}-tmp"
+    fi
+
     if diff -q "${dockerfile}-tmp" "${dockerfile}" > /dev/null; then
       echo "${dockerfile} is already up to date!"
     else


### PR DESCRIPTION
<!--
Provide a general summary of your changes in the Title above.
-->

## Description

When `update.sh` is run on any images for 26+, the Yarn portion of the Dockerfile will be stripped out.

Fixes #2407

## Motivation and Context

<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
-->

## Testing Details

You can locally change the "26" to "24" or "25" in the condition locally, and see the diff created for those previous images.

## Example Output(if appropriate)

## Types of changes

<!--
What types of changes does your code introduce? Put an `x` in all the boxes that apply.
-->

- [ ] Documentation
- [ ] Version change (Update, remove or add more Node.js versions)
- [ ] Variant change (Update, remove or add more variants, or versions of variants)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other (none of the above)

## Checklist

<!--
Go over all the following points, and put an `x` in all the boxes that apply.
If you're unsure about any of these, don't hesitate to ask. We're here to help!
-->

- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING.md** document.
- [ ] All new and existing tests passed.

