### PR TITLE
fix: correct update.sh script help

### DIFF
--- a/update.sh
+++ b/update.sh
@@ -11,16 +11,15 @@ function usage() {
     $0 [-s] [MAJOR_VERSION(S)] [VARIANT(S)]
 
   Examples:
-    - update.sh                      # Update all images
-    - update.sh -s                   # Update all images, skip updating Alpine if the musl build isn't available
-    - update.sh 8,10                 # Update all variants of version 8 and 10
-    - update.sh -s 8                 # Update version 8 and variants, skip updating Alpine if the musl build isn't available
-    - update.sh 8 alpine             # Update only alpine's variants for version 8
-    - update.sh -s 8 bullseye        # Update only bullseye variant for version 8, skip updating Alpine if the musl build isn't available
-    - update.sh . alpine             # Update the alpine variant for all versions
+    - update.sh                           # Update all images
+    - update.sh -s                        # Update all images, skip updating Alpine if the musl build is unavailable
+    - update.sh 22,24                     # Update all variants of version 22 and 24
+    - update.sh -s 24                     # Update all variants of version 24, except skip updating Alpine if the musl build is unavailable
+    - update.sh 24 alpine3.22,alpine3.23  # Update only alpine3.22 & alpine3.23 variants for version 24
+    - update.sh . trixie,trixie-slim      # Update only trixie & trixie-slim Debian variants for all versions
 
   OPTIONS:
-    -s Security update; skip updating the Alpine versions.
+    -s Security update; allows Debian updates even if musl build for Alpine is unavailable
     -h Show this message
 
 EOF


### PR DESCRIPTION
- closes https://github.com/nodejs/docker-node/issues/2412

## Description

In the [update.sh](https://github.com/nodejs/docker-node/blob/main/update.sh) script, update example options to use current Node.js versions and latest Debian release (trixie) and ensure the accuracy of examples.

## Motivation and Context

The help text invoked with `./update.sh -h` has several inaccuracies.

- specifying EOL Node.js versions, such as `8`, attempts to update all current versions
- specifying `. alpine` on its own also attempts to update all variants
- specifying `-s 8 bullseye` updates all versions

The combination of `-s` and Debian variants is redundant. `./update.sh 24 trixie`, for example, does not fail when the musl checksum is missing, so adding `-s` is not needed.

## Testing Details

Execute `./update.sh -h` and then invoke each one of the listed examples. Confirm that the logs are consistent with the help description.

## Example Output

```text
$ ./update.sh -h

  Update the node docker images.

  Usage:
    ./update.sh [-s] [MAJOR_VERSION(S)] [VARIANT(S)]

  Examples:
    - update.sh                           # Update all images
    - update.sh -s                        # Update all images, skip updating Alpine if the musl build is unavailable
    - update.sh 22,24                     # Update all variants of version 22 and 24
    - update.sh -s 24                     # Update all variants of version 24, except skip updating Alpine if the musl build is unavailable
    - update.sh 24 alpine3.22,alpine3.23  # Update only alpine3.22 & alpine3.23 variants for version 24
    - update.sh . trixie,trixie-slim      # Update only trixie & trixie-slim Debian variants for all versions

  OPTIONS:
    -s Security update; allows Debian updates even if musl build for Alpine is unavailable
    -h Show this message

```

## Types of changes

- [ ] Documentation
- [ ] Version change (Update, remove or add more Node.js versions)
- [ ] Variant change (Update, remove or add more variants, or versions of variants)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other (none of the above)

## Checklist

- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING.md** document.
- [X] All new and existing tests passed.
