### PR TITLE
docs: remove reference to EOL Alpine 3.18

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,10 +189,6 @@ of using Alpine-based images.
 One common issue that may arise is a missing shared library required for use of
 `process.dlopen`. To add the missing shared libraries to your image:
 
-- For Alpine v3.18 and earlier, adding the
-[`libc6-compat`](https://pkgs.alpinelinux.org/package/v3.18/main/x86/libc6-compat)
-package in your Dockerfile is recommended: `apk add --no-cache libc6-compat`
-
 - Starting from Alpine v3.19, you can use the
 [`gcompat`](https://pkgs.alpinelinux.org/package/v3.19/main/x86/gcompat) package
 to add the missing shared libraries: `apk add --no-cache gcompat`


### PR DESCRIPTION
## Description

Remove the reference to Alpine 3.18 from the [README > node:alpine](https://github.com/nodejs/docker-node/blob/main/README.md#nodealpine) section.

## Motivation and Context

The [README > node:alpine](https://github.com/nodejs/docker-node/blob/main/README.md#nodealpine) section contains the advice:

> - For Alpine v3.18 and earlier, adding the [`libc6-compat`](https://pkgs.alpinelinux.org/package/v3.18/main/x86/libc6-compat) package in your Dockerfile is recommended: `apk add --no-cache libc6-compat`

Alpine 3.18 reached its [end-of-support](https://alpinelinux.org/releases/) transition on 2025-05-09

PR https://github.com/nodejs/docker-node/pull/2085 previously dropped the Alpine 3.18 variant in May 2024 from Node.js Docker builds.

## Testing Details

N/A

## Types of changes

- [X] Documentation
- [ ] Version change (Update, remove or add more Node.js versions)
- [ ] Variant change (Update, remove or add more variants, or versions of variants)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other (none of the above)

## Checklist

- [X] My code follows the code style of this project.
- [X] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING.md** document.
- [X] All new and existing tests passed.
