### PR TITLE
Add example for Debian without npm or Yarn

### DIFF
--- a/docs/BestPractices.md
+++ b/docs/BestPractices.md
@@ -207,10 +207,20 @@ FROM node:alpine as app
 COPY --from=builder node_modules .
 ```
 
-
 ## Smaller images without npm/yarn
 
-If you want to achieve an even smaller image size than the `-alpine`, you can omit the npm/yarn like this:
+To remove npm and Yarn package managers, use a multi-stage build.
+In the first stage, the package manager builds the app.
+In the second stage, the `app` and the `node` directories are copied,
+without copying the npm & Yarn package managers.
+In Docker images based on Node.js&nbsp;>=26, Yarn is already removed.
+
+The result is a smaller and hardened final image with no package managers.
+The size savings are typically about 2% or 3%.
+
+The examples below build with npm.
+
+**Alpine example**
 
 ```Dockerfile
 ARG ALPINE_VERSION=3.23
@@ -219,7 +229,7 @@ FROM node:24-alpine${ALPINE_VERSION} AS builder
 WORKDIR /build-stage
 COPY package*.json ./
 RUN npm ci
-# Copy the the files you need
+# Copy the files you need
 COPY . ./
 RUN npm run build
 
@@ -230,6 +240,37 @@ WORKDIR /usr/src/app
 RUN apk add --no-cache libstdc++ dumb-init \
   && addgroup -g 1000 node && adduser -u 1000 -G node -s /bin/sh -D node \
   && chown node:node ./
+COPY --from=builder /usr/local/bin/node /usr/local/bin/
+COPY --from=builder /usr/local/bin/docker-entrypoint.sh /usr/local/bin/
+ENTRYPOINT ["docker-entrypoint.sh"]
+USER node
+# Update the following COPY lines based on your codebase
+COPY --from=builder /build-stage/node_modules ./node_modules
+COPY --from=builder /build-stage/dist ./dist
+# Run with dumb-init to not start node with PID=1, since Node.js was not designed to run as PID 1
+CMD ["dumb-init", "node", "dist/index.js"]
+```
+
+**Debian example**
+
+```Dockerfile
+FROM node:24-trixie-slim AS builder
+WORKDIR /build-stage
+COPY package*.json ./
+RUN npm ci
+# Copy the files you need
+COPY . ./
+RUN npm run build
+
+FROM debian:trixie-slim
+# Create app directory
+WORKDIR /usr/src/app
+# Add required binaries
+RUN apt-get update && apt-get install -y --no-install-recommends dumb-init \
+    && rm -rf /var/lib/apt/lists/* \
+    && groupadd --gid 1000 node \
+    && useradd --uid 1000 --gid node --shell /bin/bash --create-home node \
+    && chown node:node ./
 COPY --from=builder /usr/local/bin/node /usr/local/bin/
 COPY --from=builder /usr/local/bin/docker-entrypoint.sh /usr/local/bin/
 ENTRYPOINT ["docker-entrypoint.sh"]

--- a/docs/BestPractices.md
+++ b/docs/BestPractices.md
@@ -216,7 +216,6 @@ without copying the npm & Yarn package managers.
 In Docker images based on Node.js&nbsp;>=26, Yarn is already removed.
 
 The result is a smaller and hardened final image with no package managers.
-The size savings are typically about 2% or 3%.
 
 The examples below build with npm.
 


### PR DESCRIPTION
- closes: https://github.com/nodejs/docker-node/issues/2453

## Description

A Debian example is added to [Smaller images without npm/yarn](https://github.com/nodejs/docker-node/blob/main/docs/BestPractices.md#smaller-images-without-npmyarn) to complement the existing Alpine example.

## Motivation and Context

Issue https://github.com/nodejs/docker-node/issues/404 requests an image without npm nor Yarn. This is partially achieved by removing Yarn from all future Node.js Docker images based on the upcoming Node.js 26 release and other higher releases.

The npm package manager npm is part of the [official Node.js distribution](https://github.com/nodejs/node/blob/main/doc/contributing/distribution.md). If the role of Node.js Docker images is to package exactly what Node.js bundles in its releases, then npm must also be included.

Nevertheless, some users do not want to run their Docker image with a package manager to achieve a lower Docker image size or to harden their image against package manager vulnerabilities.

The [Docker and Node.js Best Practices](https://github.com/nodejs/docker-node/blob/main/docs/BestPractices.md) document, in the section [Smaller images without npm/yarn](https://github.com/nodejs/docker-node/blob/main/docs/BestPractices.md#smaller-images-without-npmyarn), already provides an example for Alpine images, using a multi-stage build. The first stage builds the app with npm, then in a second run-time only Docker build stage, only the `app` and `node` directory are copied, without copying any `npm` or `yarn` package manager directories.

## Testing Details

```shell
cd $(mktemp -d)
npm init -y
npm install @vercel/ncc
echo 'console.log("Hello world!")' > index.js
```

Add `"build": "ncc build index.js -o dist"` to `package.json` scripts

```shell
cat > Dockerfile2 <<'EOT'
FROM node:24-trixie-slim AS builder
WORKDIR /build-stage
COPY package*.json ./
RUN npm ci
# Copy the files you need
COPY . ./
RUN npm run build

FROM debian:trixie-slim
# Create app directory
WORKDIR /usr/src/app
# Add required binaries
RUN apt-get update && apt-get install -y --no-install-recommends dumb-init \
    && rm -rf /var/lib/apt/lists/* \
    && groupadd --gid 1000 node \
    && useradd --uid 1000 --gid node --shell /bin/bash --create-home node \
    && chown node:node ./
COPY --from=builder /usr/local/bin/node /usr/local/bin/
COPY --from=builder /usr/local/bin/docker-entrypoint.sh /usr/local/bin/
ENTRYPOINT ["docker-entrypoint.sh"]
USER node
# Update the following COPY lines based on your codebase
COPY --from=builder /build-stage/node_modules ./node_modules
COPY --from=builder /build-stage/dist ./dist
# Run with dumb-init to not start node with PID=1, since Node.js was not designed to run as PID 1
CMD ["dumb-init", "node", "dist/index.js"]
EOT

docker build -t test-small-image-trixie .
docker run --rm test-small-image-trixie # Outputs "Hello world!"
docker run --rm --entrypoint node test-small-image-trixie --version # Outputs v24.14.1
docker run --rm --entrypoint which test-small-image-trixie node # Outputs /usr/local/bin/node
docker run --rm --entrypoint which test-small-image-trixie npm # No output (npm not installed)
docker run --rm --entrypoint which test-small-image-trixie yarn # No output (Yarn not installed)
```

## Example Output

```text
Hello world!
v24.14.1
/usr/local/bin/node
```

**Image sizes Debian**

| Image                   | Size (local) | % reduction |
| ----------------------- | ------------ | ----------- |
| node:24-trixie-slim     | 328.25 MB    | 0%          |
| test-small-image-trixie | 312.03 MB    | 3%          |

**Image sizes Alpine** (from PR https://github.com/nodejs/docker-node/pull/2410) testing steps

| Image              | Size (local) | % reduction |
| ------------------ | ------------ | ----------- |
| node:24-alpine3.23 | 225.05 MB    | 0%          |
| test-small-image   | 215.55 MB    | 2%          |

## Types of changes

- [X] Documentation
- [ ] Version change (Update, remove or add more Node.js versions)
- [ ] Variant change (Update, remove or add more variants, or versions of variants)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other (none of the above)

## Checklist

- [X] My code follows the code style of this project.
- [X] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING.md** document.
- [X] All new and existing tests passed.
