### PR TITLE
docs: remove Yarn upgrade/downgrade best practices

### DIFF
--- a/docs/BestPractices.md
+++ b/docs/BestPractices.md
@@ -6,9 +6,6 @@
 
 - [Environment Variables](#environment-variables)
 - [Global npm dependencies](#global-npm-dependencies)
-- [Upgrading/downgrading Yarn](#upgradingdowngrading-yarn)
-  - [Local](#local)
-  - [Global](#global)
 - [Handling Kernel Signals](#handling-kernel-signals)
 - [Non-root User](#non-root-user)
 - [Memory](#memory)
@@ -36,54 +33,6 @@ If you need to install global npm dependencies, it is recommended to place those
 ENV NPM_CONFIG_PREFIX=/home/node/.npm-global
 
 ENV PATH=$PATH:/home/node/.npm-global/bin # optionally if you want to run npm global bin without specifying path
-```
-
-## Upgrading/downgrading Yarn
-
-### Local
-
-If you need to upgrade/downgrade `yarn` for a local install, you can do so by issuing the following commands in your `Dockerfile`:
-
-> Note that if you create some other directory which is not a descendant one from where you ran the command, you will end up using the global (dated) version. If you wish to upgrade `yarn` globally, follow the instructions in the next section.
-
-> When following the local install instructions, due to duplicated yarn the image will end up being bigger.
-
-```Dockerfile
-FROM node:6
-
-ENV YARN_VERSION=1.16.0
-
-RUN yarn policies set-version $YARN_VERSION
-```
-
-### Global
-
-```Dockerfile
-FROM node:6
-
-ENV YARN_VERSION=1.16.0
-
-RUN curl -fSLO --compressed "https://yarnpkg.com/downloads/$YARN_VERSION/yarn-v$YARN_VERSION.tar.gz" \
-    && tar -xzf yarn-v$YARN_VERSION.tar.gz -C /opt/ \
-    && ln -snf /opt/yarn-v$YARN_VERSION/bin/yarn /usr/local/bin/yarn \
-    && ln -snf /opt/yarn-v$YARN_VERSION/bin/yarnpkg /usr/local/bin/yarnpkg \
-    && rm yarn-v$YARN_VERSION.tar.gz
-```
-
-If you're using an Alpine-based image, `curl` won't be present, so you'll need to make sure it's installed while using it:
-
-```Dockerfile
-FROM node:6-alpine
-
-ENV YARN_VERSION=1.5.1
-
-RUN apk add --no-cache --virtual .build-deps-yarn curl \
-    && curl -fSLO --compressed "https://yarnpkg.com/downloads/$YARN_VERSION/yarn-v$YARN_VERSION.tar.gz" \
-    && tar -xzf yarn-v$YARN_VERSION.tar.gz -C /opt/ \
-    && ln -snf /opt/yarn-v$YARN_VERSION/bin/yarn /usr/local/bin/yarn \
-    && ln -snf /opt/yarn-v$YARN_VERSION/bin/yarnpkg /usr/local/bin/yarnpkg \
-    && rm yarn-v$YARN_VERSION.tar.gz \
-    && apk del .build-deps-yarn
 ```
 
 ## Handling Kernel Signals


### PR DESCRIPTION
## Description

Remove the outdated section [Upgrading/downgrading Yarn](https://github.com/nodejs/docker-node/blob/main/docs/BestPractices.md#upgradingdowngrading-yarn) from the [Docker and Node.js Best Practices](https://github.com/nodejs/docker-node/blob/main/docs/BestPractices.md) document.

## Motivation and Context

The section describes [Upgrading/downgrading Yarn](https://github.com/nodejs/docker-node/blob/main/docs/BestPractices.md#upgradingdowngrading-yarn) for Node.js 6 and Yarn 1.16.0, referring to an end-of-life Node.js version and the unsupported Yarn v1 Classic module.

Yarn v1 is no longer being bundled for Docker images based on Node.js >=26.

For new Docker images based on Node.js <=25, the Yarn v1 version is set to [yarn@1.22.22](https://github.com/yarnpkg/yarn/releases/tag/v1.22.22) (released March 2024) and is not expected to change. The version itself is frozen and no longer supported.

The instructions can no longer be maintained, since Yarn v1 Classic is now unsupported. The instructions are outdated and only partially work.

In the meantime [yarn@1.22.22](https://github.com/yarnpkg/yarn/releases/tag/v1.22.22) is the most viable Yarn v1 Classic version, so there would be no need to downgrade. It's also the highest version for Yarn v1, so there is nothing to upgrade to, apart from migrating to a higher major version, such as Yarn Modern (v4), which is out-of-scope for this description in any case.

## Testing Details

N/A - documentation change only

## Types of changes

- [X] Documentation
- [ ] Version change (Update, remove or add more Node.js versions)
- [ ] Variant change (Update, remove or add more variants, or versions of variants)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other (none of the above)

## Checklist

<!--
Go over all the following points, and put an `x` in all the boxes that apply.
If you're unsure about any of these, don't hesitate to ask. We're here to help!
-->

- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING.md** document.
- [X] All new and existing tests passed.
