### PR TITLE
Drop s390x from Node 25+ Alpine images

### DIFF
--- a/versions.json
+++ b/versions.json
@@ -10,13 +10,11 @@
     "variants": {
       "alpine3.22": [
         "amd64",
-        "arm64v8",
-        "s390x"
+        "arm64v8"
       ],
       "alpine3.23": [
         "amd64",
-        "arm64v8",
-        "s390x"
+        "arm64v8"
       ],
       "bookworm": [
         "amd64",


### PR DESCRIPTION
<!--
Provide a general summary of your changes in the Title above.
-->

## Description

Stop publishing docker images for Alpine on the s390x architecture

<!--
Describe your changes in detail.
-->

## Motivation and Context

Alpine in general is an experimental platform and is only built in our infrastructure as part of the unofficial-builds project. Additionally,  unofficial builds only covers x64 and arm64 architectures, so others are arguably a lower level of support below those experimental platforms which is where Alpine/s390x lies. Since they are not built in the unofficial builds project, the Alpine/s390x node binaries are built by compiling the code on the fly when the docker image is built. (EDIT: As per nschonni's comment below arm64 is also done on the fly due to [the lack of checksum in the dockerfiles](https://github.com/nodejs/docker-node/blob/7cf6ba511225655768c0a17f2c0ce74aa6dac396/24/alpine3.23/Dockerfile#L13) for anything other than x64)  Because of this, I'm not overly comfortable with having these declared as "official" docker images.

We do not currently have explicit download statistics for the Alpine/s390x official dockerhub images (@tianon @yosifkit can we get a breakdown by platform somehow? (Feel free to contact me privately if you'd prefer not to discuss in this issue)

For this reason, and by way of precedent we [also removed Alpine/ppc64le](https://github.com/nodejs/docker-node/pull/2130) by @nschonni)  which is likely at a similar usage level some time ago due to a build break at the time without too much pushback (Noting https://github.com/nodejs/help/issues/5141 recently!) so I would expect Alpine/s390x to be similar.

<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
-->

## Testing Details

<!--
Please describe in detail how you tested your changes. Include details of
your testing environment, and the tests you ran to see how your change
affects other areas of the code, etc.
-->

## Example Output(if appropriate)

## Types of changes

<!--
What types of changes does your code introduce? Put an `x` in all the boxes that apply.
-->

- [ ] Documentation
- [ ] Version change (Update, remove or add more Node.js versions)
- [ ] Variant change (Update, remove or add more variants, or versions of variants)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other (none of the above)

## Checklist

<!--
Go over all the following points, and put an `x` in all the boxes that apply.
If you're unsure about any of these, don't hesitate to ask. We're here to help!
-->

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING.md** document.
- [ ] All new and existing tests passed.

### Alternate options

- Add it to unofficial-builds and use the binary from there as per Alpine on x64 and arm64 (Would need someone willing to maintain it there)
- Re-enable Alpine/ppc64le to bring it in sync with what Alpine/s390x currently does as I believe it does now build (Since there hasn't been much pushback from removing it this doesn't quite feel right with the information we currently have.
- Push this, and any other experimental platforms, to an unofficial dockerhub repository
- Promote Alpine to be a non-experimental platform. While this may happen, I feel it's unlikely that we would include ppc64le or s390x there.

### Notes

Leaving as draft for now so this can be discussed before merging, although I'd like to make sure we do not add it for v26. This PR currently only targets node25 although it could be done for earlier versions too (to put it in line with Alpine/ppc64le) depending on feedback.

Noting also that the functionality to build within the images could be removed if this change gets accepted.