### PR TITLE
docs: Replace duplicate Maintainer list

### DIFF
--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -20,7 +20,7 @@ Anyone who proposes changes, reports issues, reviews code, or helps users.
 
 ### Collaborators
 
-Collaborators have write access and help with day-to-day maintenance:
+[Collaborators](README.md#collaborators) have write access and help with day-to-day maintenance:
 
 - review and merge pull requests
 - triage issues
@@ -31,20 +31,12 @@ consensus.
 
 ### Maintainers
 
-Maintainers are responsible for long-term stewardship of the project:
+[Maintainers](README.md#docker-maintainers) are responsible for long-term stewardship of the project:
 
 - facilitate consensus and escalate unresolved final decisions to the Node.js TSC
 - governance and membership updates
 - release/publishing policy and automation oversight
 - security and incident handling for this repository
-
-Current maintainers:
-
-- Laurent Goderre ([LaurentGoderre](https://github.com/LaurentGoderre))
-- Simen Bekkhus ([SimenB](https://github.com/SimenB))
-- Peter Dave Hello ([PeterDaveHello](https://github.com/PeterDaveHello))
-- Rafael Gonzaga ([rafaelgss](https://github.com/rafaelgss))
-- Matteo Collina ([mcollina](https://github.com/mcollina))
 
 ## Decision making
 
@@ -78,8 +70,9 @@ publicly in this repository.
 
 ## Membership changes
 
-Collaborator and maintainer changes are proposed via pull request to `README.md`
-and/or this file, with rationale included in the PR description.
+Collaborator and maintainer changes are proposed via pull request to
+[`README.md`](README.md), with rationale included in the PR
+description.
 
 Project access should be managed via the
 [@nodejs/docker team](https://github.com/orgs/nodejs/teams/docker) and kept in


### PR DESCRIPTION
<!--
Provide a general summary of your changes in the Title above.
-->

## Description

Keep the README.md as the central spot for any list memberships.

## Motivation and Context

Currently the Maintainers list is in both the README and GOVERNANCE, which could lead to sync issues if one is updated.
I was going to add myself to the Maintainers (since I've had that Team permission for some time), but thought this cleanup made sense to do first.

## Testing Details

<!--
Please describe in detail how you tested your changes. Include details of
your testing environment, and the tests you ran to see how your change
affects other areas of the code, etc.
-->

## Example Output(if appropriate)

## Types of changes

<!--
What types of changes does your code introduce? Put an `x` in all the boxes that apply.
-->

- [x] Documentation
- [ ] Version change (Update, remove or add more Node.js versions)
- [ ] Variant change (Update, remove or add more variants, or versions of variants)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other (none of the above)

## Checklist

<!--
Go over all the following points, and put an `x` in all the boxes that apply.
If you're unsure about any of these, don't hesitate to ask. We're here to help!
-->

- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING.md** document.
- [ ] All new and existing tests passed.

