### PR TITLE
fix: Build with a correct OpenSSL config on loongarch64

### DIFF
--- a/Dockerfile-alpine.template
+++ b/Dockerfile-alpine.template
@@ -16,6 +16,7 @@ RUN addgroup -g 1000 node \
         arm*) OPENSSL_ARCH=linux-armv4;; \
         ppc64le) OPENSSL_ARCH=linux-ppc64le;; \
         s390x) OPENSSL_ARCH=linux-s390x;; \
+        loongarch64) CONFIGURE_OPENSSL_NO_ASM="--openssl-no-asm" OPENSSL_ARCH=linux64-loongarch64;; \
         *) ;; \
       esac \
   && if [ -n "${CHECKSUM}" ]; then \
@@ -54,7 +55,7 @@ RUN addgroup -g 1000 node \
     && grep " node-v$NODE_VERSION.tar.xz\$" SHASUMS256.txt | sha256sum -c - \
     && tar -xf "node-v$NODE_VERSION.tar.xz" \
     && cd "node-v$NODE_VERSION" \
-    && ./configure \
+    && ./configure $CONFIGURE_OPENSSL_NO_ASM \
     && make -j$(getconf _NPROCESSORS_ONLN) V= \
     && make install \
     && apk del .build-deps-full \


### PR DESCRIPTION
## Description

This change sets OPENSSL_ARCH to a correct value for loongarch64 and also passes --openssl-no-asm to the configure script, because there is no asm configuration in gyp files for loongarch64.

## Motivation and Context

Trying to use asm config makes gyp pick up the fallback x86-64 config instead of loongarch64 one. This in turn leads to -m64 being passed to the compiler, which finally leads to compilation errors.

## Testing Details

`docker image build` successfully creates a corresponding image.

## Types of changes

<!--
What types of changes does your code introduce? Put an `x` in all the boxes that apply.
-->

- [ ] Documentation
- [ ] Version change (Update, remove or add more Node.js versions)
- [X] Variant change (Update, remove or add more variants, or versions of variants)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other (none of the above)

## Checklist

<!--
Go over all the following points, and put an `x` in all the boxes that apply.
If you're unsure about any of these, don't hesitate to ask. We're here to help!
-->

- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING.md** document.
- [ ] All new and existing tests passed.

