### PR TITLE
docs: reword Yarn v1 bundling descriptions for Node.js 26 release

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -29,7 +29,8 @@ New **Node.js** releases are released as soon as possible.
 
 New **npm** releases are not tracked. We simply use the npm version bundled in the corresponding Node.js release.
 
-**[Yarn v1 Classic](https://classic.yarnpkg.com/)** is no longer maintained upstream, and will be removed starting with the Node 26 images.
+**[Yarn v1 Classic](https://classic.yarnpkg.com/)** is no longer maintained upstream, and it is removed when constructing Dockerfiles
+from templates starting with the Node 26 images.
 
 ### Image Creation Automation
 

--- a/README.md
+++ b/README.md
@@ -148,13 +148,16 @@ $ docker run node npm --loglevel=warn ...
 ## Image Variants
 
 The `node` images come in many flavors, each designed for a specific use case.
-All of the images contain pre-installed versions of `node`,
-[`npm`](https://www.npmjs.com/), and [Yarn v1 Classic](https://classic.yarnpkg.com/). For each
+All of the images contain pre-installed versions of `node` which includes also
+[`npm`](https://www.npmjs.com/). For each
 supported architecture, the supported variants are different. In the file:
 [versions.json](./versions.json), it lists all supported variants for all of
 the architectures that we support now.
-See [Yarn v1 Classic bundling](#yarn-v1-classic-bundling) for future plans to
-remove this legacy version.
+
+The legacy package manager
+[Yarn v1 Classic](https://classic.yarnpkg.com/)
+is included in `node` images with Node.js 25 and below. See
+[Yarn v1 Classic bundling](#yarn-v1-classic-bundling) for details.
 
 ### `node:<version>`
 
@@ -267,12 +270,11 @@ This project will support Node.js versions as still under active support as per 
 
 ## Yarn v1 Classic bundling
 
-[Yarn v1 Classic](https://classic.yarnpkg.com/) is currently bundled in `node` image
-variants. Because Yarn v1 is [frozen](https://github.com/yarnpkg/yarn) and no longer maintained,
-bundling plans have been revised.
+The [Yarn v1 Classic](https://classic.yarnpkg.com/) package manager is bundled in `node` image
+variants that include Node.js versions 25 and below.
 
-As of Node.js 26.0.0 it is planned to no longer bundle Yarn v1 into `node` images.
-For lower versions of Node.js (<26) `node` images will continue to bundle Yarn v1.
+Yarn v1 is not bundled into `node` images as of Node.js 26.0.0.
+This version of the Yarn package manager has been declared as [frozen](https://github.com/yarnpkg/yarn) and is no longer maintained.
 
 Users with legacy requirements for Yarn v1 under Node.js 26 and above may be able
 to follow [Yarn v1 installation instructions](https://classic.yarnpkg.com/en/docs/install)


### PR DESCRIPTION
## Description

Reword bundling descriptions regarding Yarn v1 in the documents:

- [README](https://github.com/nodejs/docker-node#readme)
- [CONTRIBUTING](https://github.com/nodejs/docker-node/blob/main/CONTRIBUTING.md)

## Motivation and Context

The [README](https://github.com/nodejs/docker-node#readme) document, including the section [Yarn v1 Classic bundling](https://github.com/nodejs/docker-node#yarn-v1-classic-bundling) is written as a statement of plans and preparation for Node.js 26 and above.

With the release of Node.js 26, the implementation dropping Yarn v1 Classic is now realized.

## Testing Details

N/A

## Example Output (if appropriate)

N/A

## Types of changes

- [X] Documentation
- [ ] Version change (Update, remove or add more Node.js versions)
- [ ] Variant change (Update, remove or add more variants, or versions of variants)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other (none of the above)

## Checklist

- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING.md** document.
- [ ] All new and existing tests passed.
