### PR TITLE
docs: disable markdown-link-check for https://slack-invite.openjsf.org/

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,7 +15,9 @@ the Node.js TSC as final arbiter.
 
 ## Discussion Areas
 
+<!-- markdown-link-check-disable -->
 You can use Node.js channels (prefixed by `#nodejs-`) in the [OpenJSF Slack](https://slack-invite.openjsf.org/) workspace for discussions.
+<!-- markdown-link-check-enable -->
 
 - [#nodejs-distributions](https://openjs-foundation.slack.com/archives/C0ALS3UDE8G) covers discussions for this repo (`docker-node`).
 


### PR DESCRIPTION
## Description

In the [CONTRIBUTING](https://github.com/nodejs/docker-node/blob/main/CONTRIBUTING.md) document disable [markdown-link-check](https://github.com/tcort/markdown-link-check) from attempting to check https://slack-invite.openjsf.org/

## Motivation and Context

The [.github/workflows/markdown-link-check.yml](https://github.com/nodejs/docker-node/blob/main/.github/workflows/markdown-link-check.yml) workflow has started failing with:

```text
  ERROR: 1 dead link found in ./CONTRIBUTING.md !
  [✖] https://slack-invite.openjsf.org/ → Status: 403
```

This is a link which expects a user to log in. HTTP 403 equates to "Forbidden".

## Testing Details

On Ubuntu `24.04.4` LTS, with Node.js `24.15.0` LTS

```shell
npm install markdown-link-check@3.14.2 -g
find . -name "*.md"  ! -path "./.git/*" | xargs -n 1 markdown-link-check -c markdown_link_check_config.json
```

No dead links should be reported.

## Example Output(if appropriate)


## Types of changes

- [ ] Documentation
- [ ] Version change (Update, remove or add more Node.js versions)
- [ ] Variant change (Update, remove or add more variants, or versions of variants)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other (none of the above)

## Checklist

- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING.md** document.
- [X] All new and existing tests passed.
