### PR TITLE
Fix: Pre-create node_modules with correct ownership for non-root users

### DIFF
--- a/Dockerfile-alpine.template
+++ b/Dockerfile-alpine.template
@@ -4,6 +4,8 @@ ENV NODE_VERSION=0.0.0
 
 RUN addgroup -g 1000 node \
     && adduser -u 1000 -G node -s /bin/sh -D node \
+    && mkdir -p /home/node/node_modules \
+    && chown -R node:node /home/node/node_modules \
     && apk add --no-cache \
         libstdc++ \
     && apk add --no-cache --virtual .build-deps \

--- a/Dockerfile-debian.template
+++ b/Dockerfile-debian.template
@@ -1,7 +1,9 @@
 FROM buildpack-deps:name
 
 RUN groupadd --gid 1000 node \
-  && useradd --uid 1000 --gid node --shell /bin/bash --create-home node
+  && useradd --uid 1000 --gid node --shell /bin/bash --create-home node \
+  && mkdir -p /home/node/node_modules \
+  && chown -R node:node /home/node/node_modules
 
 ENV NODE_VERSION=0.0.0
 

--- a/Dockerfile-slim.template
+++ b/Dockerfile-slim.template
@@ -1,7 +1,9 @@
 FROM debian:name-slim
 
 RUN groupadd --gid 1000 node \
-  && useradd --uid 1000 --gid node --shell /bin/bash --create-home node
+  && useradd --uid 1000 --gid node --shell /bin/bash --create-home node \
+  && mkdir -p /home/node/node_modules \
+  && chown -R node:node /home/node/node_modules
 
 ENV NODE_VERSION=0.0.0
 


### PR DESCRIPTION
# Description
This PR ensures that the node_modules directory is explicitly created and owned by the node user during the image build process.

Currently, if a volume is mounted to `/home/node/node_modules` and the directory does not exist in the image, Docker creates it with `root:root` ownership. This prevents the non-root node user from performing npm install or updating dependencies at runtime, leading to EACCES errors.

# Changes
Updated the user creation layer to:

- Pre-emptively create the `/home/node/node_modules` directory with `node:node` permissions.

# Why this is necessary

When running in environments like Docker Swarm or Kubernetes, persistent volumes or bind mounts are often used to cache node_modules. If the container process runs as a non-root user (UID 1000), it lacks the privileges to modify directories created by the Docker daemon (UID 0). By defining this directory in the Dockerfile, we establish the correct metadata before any volume masking occurs.

## Testing Details

```bash
docker run --rm -u node -v test_volume:/home/node/node_modules  node:<tag>  sh -c "touch /home/node/node_modules/.test_file && ls -la /home/node/node_modules/.test_file" 
```

### Original behavior (problem)

```bash
touch: cannot touch '/home/node/node_modules/.test_file': Permission denied
```

### Improved behavior (this PR)

```bash
-rw-r--r--    1 node     node            0 May  6 15:35 /home/node/node_modules/.test_file
```

## Types of changes

- [ ] Documentation
- [ ] Version change (Update, remove or add more Node.js versions)
- [ ] Variant change (Update, remove or add more variants, or versions of variants)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other (none of the above)

## Checklist

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING.md** document.
- [ ] All new and existing tests passed.

