### PR TITLE
feat: Node.js 26.1.0 Debian

### DIFF
--- a/26/bookworm-slim/Dockerfile
+++ b/26/bookworm-slim/Dockerfile
@@ -3,7 +3,7 @@ FROM debian:bookworm-slim
 RUN groupadd --gid 1000 node \
   && useradd --uid 1000 --gid node --shell /bin/bash --create-home node
 
-ENV NODE_VERSION=26.0.0
+ENV NODE_VERSION=26.1.0
 
 RUN ARCH= OPENSSL_ARCH= && dpkgArch="$(dpkg --print-architecture)" \
     && case "${dpkgArch##*-}" in \

--- a/26/bookworm/Dockerfile
+++ b/26/bookworm/Dockerfile
@@ -3,7 +3,7 @@ FROM buildpack-deps:bookworm
 RUN groupadd --gid 1000 node \
   && useradd --uid 1000 --gid node --shell /bin/bash --create-home node
 
-ENV NODE_VERSION=26.0.0
+ENV NODE_VERSION=26.1.0
 
 RUN ARCH= && dpkgArch="$(dpkg --print-architecture)" \
   && case "${dpkgArch##*-}" in \

--- a/26/bullseye-slim/Dockerfile
+++ b/26/bullseye-slim/Dockerfile
@@ -3,7 +3,7 @@ FROM debian:bullseye-slim
 RUN groupadd --gid 1000 node \
   && useradd --uid 1000 --gid node --shell /bin/bash --create-home node
 
-ENV NODE_VERSION=26.0.0
+ENV NODE_VERSION=26.1.0
 
 RUN ARCH= OPENSSL_ARCH= && dpkgArch="$(dpkg --print-architecture)" \
     && case "${dpkgArch##*-}" in \

--- a/26/bullseye/Dockerfile
+++ b/26/bullseye/Dockerfile
@@ -3,7 +3,7 @@ FROM buildpack-deps:bullseye
 RUN groupadd --gid 1000 node \
   && useradd --uid 1000 --gid node --shell /bin/bash --create-home node
 
-ENV NODE_VERSION=26.0.0
+ENV NODE_VERSION=26.1.0
 
 RUN ARCH= && dpkgArch="$(dpkg --print-architecture)" \
   && case "${dpkgArch##*-}" in \

--- a/26/trixie-slim/Dockerfile
+++ b/26/trixie-slim/Dockerfile
@@ -3,7 +3,7 @@ FROM debian:trixie-slim
 RUN groupadd --gid 1000 node \
   && useradd --uid 1000 --gid node --shell /bin/bash --create-home node
 
-ENV NODE_VERSION=26.0.0
+ENV NODE_VERSION=26.1.0
 
 RUN ARCH= OPENSSL_ARCH= && dpkgArch="$(dpkg --print-architecture)" \
     && case "${dpkgArch##*-}" in \

--- a/26/trixie/Dockerfile
+++ b/26/trixie/Dockerfile
@@ -3,7 +3,7 @@ FROM buildpack-deps:trixie
 RUN groupadd --gid 1000 node \
   && useradd --uid 1000 --gid node --shell /bin/bash --create-home node
 
-ENV NODE_VERSION=26.0.0
+ENV NODE_VERSION=26.1.0
 
 RUN ARCH= && dpkgArch="$(dpkg --print-architecture)" \
   && case "${dpkgArch##*-}" in \


### PR DESCRIPTION
## Description

Provides Node.js 26.1.0 for Debian only

Dockerfiles produced with `./update.sh -s 26`

## Motivation and Context

[Node.js 26.1.0](https://nodejs.org/en/blog/release/v26.1.0) was released on 2026-05-07.
https://nodejs.org/download/release/v26.1.0/ shows timestamp 07-May-2026 10:03 UTC

musl builds on https://unofficial-builds.nodejs.org/download/release/v26.1.0/ are as yet unavailable
https://unofficial-builds.nodejs.org/logs/202605071005-v26.1.0/ show that a build was started, however it seems to have trouble to proceed, and there is no official support available to remediate, therefore it is difficult to predict if / when this might be remedied.

## Testing Details

Smoke test with:

```
cd 24/trixie-slim
docker build -t trixie-slim-test .
```

## Example Output (if appropriate)

```text
$ docker build -q -t trixie-slim-test .
sha256:7da0ab3167f7a825ad23cba927f5b391766487a4ae5cdc1ff7b6761984b093ea
```

## Types of changes

- [ ] Documentation
- [x] Version change (Update, remove or add more Node.js versions)
- [ ] Variant change (Update, remove or add more variants, or versions of variants)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other (none of the above)

## Checklist

- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING.md** document.
- [X] All new and existing tests passed.
