### PR TITLE
build: remove unused i386 architecture

### DIFF
--- a/Dockerfile-debian.template
+++ b/Dockerfile-debian.template
@@ -12,7 +12,6 @@ RUN ARCH= && dpkgArch="$(dpkg --print-architecture)" \
     s390x) ARCH='s390x';; \
     arm64) ARCH='arm64';; \
     armhf) ARCH='armv7l';; \
-    i386) ARCH='x86';; \
     *) echo "unsupported architecture"; exit 1 ;; \
   esac \
   # use pre-existing gpg directory, see https://github.com/nodejs/docker-node/pull/1895#issuecomment-1550389150

--- a/Dockerfile-slim.template
+++ b/Dockerfile-slim.template
@@ -12,7 +12,6 @@ RUN ARCH= OPENSSL_ARCH= && dpkgArch="$(dpkg --print-architecture)" \
       s390x) ARCH='s390x' OPENSSL_ARCH='linux*-s390x';; \
       arm64) ARCH='arm64' OPENSSL_ARCH='linux-aarch64';; \
       armhf) ARCH='armv7l' OPENSSL_ARCH='linux-armv4';; \
-      i386) ARCH='x86' OPENSSL_ARCH='linux-elf';; \
       *) echo "unsupported architecture"; exit 1 ;; \
     esac \
     && set -ex \

--- a/architectures
+++ b/architectures
@@ -3,6 +3,5 @@ amd64          alpine3.22,alpine3.23,bookworm,bookworm-slim,bullseye,bullseye-sl
 arm32v6        alpine3.22,alpine3.23
 arm32v7        alpine3.22,alpine3.23,bookworm,bookworm-slim,bullseye,bullseye-slim,trixie,trixie-slim
 arm64v8        alpine3.22,alpine3.23,bookworm,bookworm-slim,bullseye,bullseye-slim,trixie,trixie-slim
-i386           alpine3.22,alpine3.23
 ppc64le        bookworm,bookworm-slim,trixie,trixie-slim
 s390x          alpine3.22,alpine3.23,bookworm,bookworm-slim,trixie,trixie-slim


### PR DESCRIPTION
## Description

Remove `i386` from:

- [architectures](https://github.com/nodejs/docker-node/blob/main/architectures)
- [Dockerfile-debian.template](https://github.com/nodejs/docker-node/blob/main/Dockerfile-debian.template)
- [Dockerfile-slim.template](https://github.com/nodejs/docker-node/blob/main/Dockerfile-slim.template)

## Motivation and Context

The architecture `i386` was last used with Node.js 10 and it was taken out of active usage with PR https://github.com/nodejs/docker-node/pull/1478 in 2021.

Cross-check with no usage of `i386` in current [versions.json](https://github.com/nodejs/docker-node/blob/main/versions.json)

## Testing Details

Smoke test with:

```
./update.sh -s
cd 24/trixie-slim
docker build -t trixie-slim-test .
cd ../..
git restore .
```

## Example Output (if appropriate)

Confirmed successful from above test

## Types of changes

- [ ] Documentation
- [ ] Version change (Update, remove or add more Node.js versions)
- [X] Variant change (Update, remove or add more variants, or versions of variants)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other (none of the above)

## Checklist

- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING.md** document.
- [X] All new and existing tests passed.
