### PR TITLE
docs: update Alpine size descriptions

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,14 +173,15 @@ need to install, thus reducing the overall size of all images on your system.
 
 ### `node:alpine`
 
-This image is based on the popular
-[Alpine Linux project](https://alpinelinux.org), available in
-[the `alpine` official image](https://hub.docker.com/_/alpine). Alpine Linux is
-much smaller than most distribution base images (~5MB), and thus leads to much
-slimmer images in general.
+This image is based on
+[Alpine Linux](https://alpinelinux.org). Because base
+[alpine](https://hub.docker.com/_/alpine) images are smaller
+than corresponding base
+[debian](https://hub.docker.com/_/debian) images, the resulting
+`node:alpine` Docker images are around 25% smaller than the
+Debian-based `node:slim` images.
 
-This variant is highly recommended when final image size being as small as
-possible is desired. The main caveat to note is that it does use
+The main caveat to note is that it does use
 [musl libc](https://musl.libc.org/) instead of
 [glibc and friends](https://www.etalabs.net/compare_libcs.html), so certain
 software might run into issues depending on the depth of their libc
@@ -197,13 +198,14 @@ One common issue that may arise is a missing shared library required for use of
 [`gcompat`](https://pkgs.alpinelinux.org/package/v3.19/main/x86/gcompat) package
 to add the missing shared libraries: `apk add --no-cache gcompat`
 
-To minimize image size, it's uncommon for additional related tools
-(such as `git` or `bash`) to be included in Alpine-based images. Using this
-image as a base, add the things you need in your own Dockerfile
-(see the [`alpine` image description](https://hub.docker.com/_/alpine/) for
-examples of how to install packages if you are unfamiliar).
+Tools such as `git` or `bash` are not included in `node:alpine*` based images. The
+[Alpine documentation](https://docs.alpinelinux.org/) describes how to find and
+install additional packages using `apk` (Alpine Package Keeper).
 
-To make the image size even smaller, you can [bundle without npm/yarn](./docs/BestPractices.md#smaller-images-without-npmyarn).
+The
+[Best Practices document](./docs/BestPractices.md), in the section
+[Smaller images without npm/yarn](./docs/BestPractices.md#smaller-images-without-npmyarn),
+shows how to produce a custom image by removing package managers in a multi-stage build.
 
 ### `node:bullseye`
 


### PR DESCRIPTION
- closes https://github.com/nodejs/docker-node/issues/2432

## Description

Convert the size-related information in the README [node:alpine](https://github.com/nodejs/docker-node#nodealpine) section to fact-based, verifiable statements.

Remove opinionated recommendation statements.

## Motivation and Context

The README [node:alpine](https://github.com/nodejs/docker-node#nodealpine) section has a high emphasis on image size as the basis for selection. It quotes the size of the original base image without comparing the size of the images after Node.js has been added.

It unconditionally recommends `node:alpine` on the basis of size. This is without regard for the currently higher Tier 1 / 2 status of Debian images. This may lead users to chose Alpine images where `node:slim` Docker images may be a better fit.

## Testing Details

N/A - documentation change only

## Types of changes

- [X] Documentation
- [ ] Version change (Update, remove or add more Node.js versions)
- [ ] Variant change (Update, remove or add more variants, or versions of variants)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other (none of the above)

## Checklist

<!--
Go over all the following points, and put an `x` in all the boxes that apply.
If you're unsure about any of these, don't hesitate to ask. We're here to help!
-->

- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING.md** document.
- [X] All new and existing tests passed.
