### PR TITLE
docs: update Alpine musl descriptions

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,23 +179,15 @@ This image is based on the popular
 much smaller than most distribution base images (~5MB), and thus leads to much
 slimmer images in general.
 
-This variant is highly recommended when final image size being as small as
-possible is desired. The main caveat to note is that it does use
-[musl libc](https://musl.libc.org/) instead of
-[glibc and friends](https://www.etalabs.net/compare_libcs.html), so certain
-software might run into issues depending on the depth of their libc
-requirements. However, most software doesn't have an issue with this, so this
-variant is usually a very safe choice. See
-[this Hacker News comment thread](https://news.ycombinator.com/item?id=10782897)
-for more discussion of the issues that might arise and some pro/con comparisons
-of using Alpine-based images.
+Alpine images use the C library
+[musl libc](https://musl.libc.org/), not the GNU C library
+[glibc](https://sourceware.org/glibc/) used by Debian.
 
-One common issue that may arise is a missing shared library required for use of
-`process.dlopen`. To add the missing shared libraries to your image:
-
-- Starting from Alpine v3.19, you can use the
-[`gcompat`](https://pkgs.alpinelinux.org/package/v3.19/main/x86/gcompat) package
-to add the missing shared libraries: `apk add --no-cache gcompat`
+Generally, applications written for Debian (`glibc`) will not run under Alpine (`musl`).
+Some compatibility issues may be resolvable by installing the Alpine
+[`gcompat`](https://pkgs.alpinelinux.org/package/v3.23/main/x86/gcompat)
+GNU C Library compatibility layer for musl package.
+Use `apk add --no-cache gcompat` to install.
 
 To minimize image size, it's uncommon for additional related tools
 (such as `git` or `bash`) to be included in Alpine-based images. Using this


### PR DESCRIPTION
## Description

Convert the musl-related information in the README [node:alpine](https://github.com/nodejs/docker-node#nodealpine) section to a shorter form.

Remove the opinion that "this variant is a very safe choice".

## Motivation and Context

The README [node:alpine](https://github.com/nodejs/docker-node#nodealpine) section refers to the use of `musl` instead of `glibc` and suggests that it is a safe choice.

This is in contrast to:

- known compatibility issues for applications written and compiled for `glibc` (Debian, and related distros such as Ubuntu & Fedora) that do not run under `musl`
- Experimental support type category for `musl` on `x64` only (see [Node.js BUILDING > Platform list](https://github.com/nodejs/node/blob/main/BUILDING.md#platform-list)), compared to wide support by Node.js for `glibc` on multiple architectures as Tier 1 / 2 support type

The original text was posted 10 years ago and includes a level of detail that is not necessary for selection or use of `node:alpine` Docker images.

## Testing Details

N/A - documentation change only

## Types of changes

- [X] Documentation
- [ ] Version change (Update, remove or add more Node.js versions)
- [ ] Variant change (Update, remove or add more variants, or versions of variants)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other (none of the above)

## Checklist

<!--
Go over all the following points, and put an `x` in all the boxes that apply.
If you're unsure about any of these, don't hesitate to ask. We're here to help!
-->

- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING.md** document.
- [X] All new and existing tests passed.

