### PR TITLE
docs: add supported architectures section

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,8 @@ The official Node.js docker image, made with love by the node community.
 - [License](#license)
 - [Supported Docker versions](#supported-docker-versions)
 - [Supported Node.js versions](#supported-nodejs-versions)
+- [Supported architectures](#supported-architectures)
+  - [musl builds for Alpine](#musl-builds-for-alpine)
 - [Yarn v1 Classic bundling](#yarn-v1-classic-bundling)
 - [Governance and Current Members](#governance-and-current-members)
   - [Docker Maintainers](#docker-maintainers)
@@ -285,6 +287,23 @@ for current Engine versions.
 ## Supported Node.js versions
 
 This project will support Node.js versions as still under active support as per the [Node.js release schedule](https://github.com/nodejs/Release).
+
+## Supported architectures
+
+`node` images are built for the Linux operating system and architecture combinations defined in [versions.json](https://github.com/nodejs/docker-node/blob/main/versions.json).
+
+- The [Node.js Platform list](https://github.com/nodejs/node/blob/main/BUILDING.md#official-binary-platforms-and-toolchains) defines [Support Tiers](https://github.com/nodejs/node/blob/main/BUILDING.md#strategy) 1, 2 and Experimental for platform and architecture combinations of Node.js builds and for each separate Node.js release line
+- The [Docker official images library](https://github.com/docker-library/official-images#architectures-other-than-amd64) lists the supported architectures in the Docker build environment
+
+Each of the architectures for Debian images belong to the Node.js support tier 1 or 2, recommended for production applications.
+
+### musl builds for Alpine
+
+`musl` builds for `amd64` are listed under support tier "Experimental" and are tested by the Node.js build process before being used in Docker images. "Experimental" status for Node.js is defined as:
+
+> Experimental: May not compile or test suite may not pass. The core team does not create releases for these platforms. Test failures on experimental platforms do not block releases. Contributions to improve support for these platforms are welcome.
+
+`musl` builds for other architectures, including `arm64`, are not tested before release.
 
 ## Yarn v1 Classic bundling
 


### PR DESCRIPTION
- closes https://github.com/nodejs/docker-node/issues/2492

## Description

Add a new section "Supported architectures" to the [README.md](https://github.com/nodejs/docker-node/blob/main/README.md) document.

## Motivation and Context

The [README.md](https://github.com/nodejs/docker-node/blob/main/README.md) document does not currently describe the support status of the underlying architectures used in the `node` Docker images.

Debian images (`trixie`, `bookworm` & `bullseye`) all use architectures covered in [Node.js Support tiers](https://github.com/nodejs/node/blob/main/BUILDING.md#strategy) 1 & 2. These are `glibc` C library based.

Alpine images rely on `musl` C library support from [nodejs/unofficial-builds](https://github.com/nodejs/unofficial-builds#readme) that are classified as "Experimental".

`node:alpine*` images are in wide and successful use since their introduction 10 years ago. Users who choose these images should nevertheless be made aware of the support status of the images. [Docker Hub node](https://hub.docker.com/_/node) does not describe support categories.

https://github.com/nodejs/node/issues/62764 seeks to promote Alpine from "Experimental" to "Tier 2" and awareness of the current status may assist in recruiting volunteers to provide additional support and achieve the needed support level promotion.

## Testing Details

N/A - documentation change only

## Types of changes

- [X] Documentation
- [ ] Version change (Update, remove or add more Node.js versions)
- [ ] Variant change (Update, remove or add more variants, or versions of variants)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other (none of the above)

## Checklist

<!--
Go over all the following points, and put an `x` in all the boxes that apply.
If you're unsure about any of these, don't hesitate to ask. We're here to help!
-->

- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING.md** document.
- [X] All new and existing tests passed.
