### PR TITLE
ci: declare read-all permissions on build-test workflow

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -15,6 +15,8 @@ on:
       - genMatrix.js
       - ".github/workflows/build-test.yml"
 
+permissions: read-all
+
 jobs:
   gen-matrix:
     name: generate-matrix


### PR DESCRIPTION
Pins `build-test.yml` to `read-all` at workflow scope. Both jobs are read-only: `gen-matrix` runs checkout + `tj-actions/changed-files` (computes the diff from the event payload, no API write) + `actions/github-script`. `build` runs `docker/build-push-action` with `push: false, load: true` so the image stays local. So `read-all` is the actual minimum.

The repo already runs `scorecard.yml`, so the [OpenSSF Scorecard Token-Permissions check](https://github.com/ossf/scorecard/blob/main/docs/checks.md#token-permissions) is observable; only explicit per-workflow declarations count toward it.

Worth flagging that this workflow uses `tj-actions/changed-files` at line 31, the exact action behind [CVE-2025-30066](https://github.com/advisories/GHSA-mrrh-fwg8-r2c3). When that action got compromised in March 2025, the malicious version dumped the runner's `GITHUB_TOKEN` through workflow logs; the blast radius for any downstream repo equalled the token's issued scope. A workflow pinned to read-all would have leaked a read-only token; one inheriting the legacy write default leaked something that could push to branches. The explicit cap is exactly the bound that matters here.

Matches the `read-all` shorthand already used in `scorecard.yml`. YAML validated locally with `yaml.safe_load`.