### PR TITLE
docs: move ttshivers to Emeritus

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,6 @@ The official Node.js docker image, made with love by the node community.
   - [Docker Maintainers](#docker-maintainers)
   - [Collaborators](#collaborators)
   - [Emeritus](#emeritus)
-    - [Former Maintainers](#former-maintainers)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
 
@@ -335,7 +334,6 @@ for project roles and decision-making, and [CONTRIBUTING.md](CONTRIBUTING.md) fo
 ### Collaborators
 
 - Tianon Gravi ([tianon](https://github.com/tianon))
-- ttshivers ([ttshivers](https://github.com/ttshivers))
 - [yosifkit](https://github.com/yosifkit)
 - Stewart X Addison ([sxa](https://github.com/sxa))
 - Mike McCready ([MikeMcC399](https://github.com/MikeMcC399))
@@ -345,11 +343,10 @@ Collaborators are managed via the
 
 ### Emeritus
 
-#### Former Maintainers
-
 - Hans Kristian Flaatten ([Starefossen](https://github.com/Starefossen))
 - Mikeal Rogers ([mikeal](https://github.com/mikeal))
 - Christopher Horrell ([chorrell](https://github.com/chorrell))
 - Peter Petrov ([pesho](https://github.com/pesho))
 - John Mitchell ([jlmitch5](https://github.com/jlmitch5))
 - Hugues Malphettes ([hmalphettes](https://github.com/hmalphettes))
+- ttshivers ([ttshivers](https://github.com/ttshivers))


### PR DESCRIPTION
Refs: https://github.com/nodejs/docker-node/issues/2506

## Description

[ttshivers](https://github.com/ttshivers) is moved from:

- [Collaborators](https://github.com/nodejs/docker-node#collaborators)

to

- [Emeritus](https://github.com/nodejs/docker-node#emeritus)

Many thanks to @ttshivers on behalf of the current team for your valuable previous contributions!

## Motivation and Context

During a reorganization related to the [Governance](https://github.com/nodejs/docker-node/blob/main/GOVERNANCE.md) change from Docker Working Group to "open maintainer model" in February 2026, [ttshivers](https://github.com/ttshivers) was added to the published list of [Collaborators](https://github.com/nodejs/docker-node#collaborators).

[ttshivers](https://github.com/ttshivers) was last active in this repo in Oct 2020.

## Testing Details

N/A

## Types of changes

- [X] Documentation
- [ ] Version change (Update, remove or add more Node.js versions)
- [ ] Variant change (Update, remove or add more variants, or versions of variants)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other (none of the above)

## Checklist

- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING.md** document.
- [X] All new and existing tests passed.
