### PR TITLE
docs: add support links for Node.js and npm

### DIFF
--- a/README.md
+++ b/README.md
@@ -286,7 +286,20 @@ for current Engine versions.
 
 ## Supported Node.js versions
 
-This project will support Node.js versions as still under active support as per the [Node.js release schedule](https://github.com/nodejs/Release).
+Support for `node` Docker images is limited to
+[Node.js active versions](https://github.com/nodejs/Release#release-schedule).
+
+Before opening an issue in this repo, please consider if the problem only occurs
+in a `node` Docker environment.
+
+If a problem can also be reproduced without using an image from this repo,
+for example in a non-Docker environment,
+then it should be reported to the corresponding component.
+
+Use the
+[Node.js issues](https://github.com/nodejs/node/issues) or the
+[npm issues](https://github.com/npm/cli/issues) list to check for known issues
+or to report new issues for these components.
 
 ## Supported architectures
 


### PR DESCRIPTION
## Description

Advise that issues should only be opened for problems occurring only in `node` Docker environments.

Add links for Node.js and npm support to [README > Supported Node.js versions](https://github.com/nodejs/docker-node/blob/main/README.md#supported-nodejs-versions)

- https://github.com/nodejs/node/issues
- https://github.com/npm/cli

## Motivation and Context

Although the [SECURITY](https://github.com/nodejs/docker-node/blob/main/SECURITY.md) document advises not to open vulnerability issues for Node.js or npm, there is no corresponding text for regular issues with these components.

Users may think (and do) report issues directly in the `docker-node` repo for component problems that cannot be fixed here.

## Testing Details

N/A

## Types of changes

- [X] Documentation
- [ ] Version change (Update, remove or add more Node.js versions)
- [ ] Variant change (Update, remove or add more variants, or versions of variants)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other (none of the above)

## Checklist

- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING.md** document.
- [X] All new and existing tests passed.
