### PR TITLE
ci(build-test): cap GITHUB_TOKEN to contents: read

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -15,6 +15,9 @@ on:
       - genMatrix.js
       - ".github/workflows/build-test.yml"
 
+permissions:
+  contents: read
+
 jobs:
   gen-matrix:
     name: generate-matrix


### PR DESCRIPTION
Pins the default `GITHUB_TOKEN` to `contents: read` at workflow level. No GitHub API writes from the workflow.

Post-CVE-2025-30066 hardening pattern. YAML validated locally.