### PR TITLE
docs: document use of latest two Alpine releases

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -32,6 +32,8 @@ New **npm** releases are not tracked. We simply use the npm version bundled in t
 **[Yarn v1 Classic](https://classic.yarnpkg.com/)** is no longer maintained upstream, and it is removed when constructing Dockerfiles
 from templates starting with the Node 26 images.
 
+**[Alpine Linux](https://alpinelinux.org/releases/)** latest two releases are used.
+
 ### Image Creation Automation
 
 - Every 15 minutes, the [workflow](https://github.com/nodejs/docker-node/blob/main/.github/workflows/automatic-updates.yml) within the [nodejs/docker-node](https://github.com/nodejs/docker-node) repo [checks](https://github.com/nodejs/docker-node/blob/main/build-automation.mjs) for new versions of Node.js [published to the website's `index.json` file](https://nodejs.org/download/release/index.json).


### PR DESCRIPTION
- closes https://github.com/nodejs/docker-node/issues/2072

## Description

Alpine is added to the [CONTRIBUTING > Version Updates](https://github.com/nodejs/docker-node/blob/main/CONTRIBUTING.md) document section to specify that the latest two Alpine Linux versions are used.

## Motivation and Context

The [CONTRIBUTING > Version Updates](https://github.com/nodejs/docker-node/blob/main/CONTRIBUTING.md) document section does not cover updates to Alpine, leaving it unclear how they should be handled. In practice, and according to https://github.com/nodejs/docker-node/issues/2072#issuecomment-2078095156:

> We only support 2 (Alpine releases) at the recommendation of the Official Images repo as there is a lot of build required for these images, and there is no upstream support or binaries for Alpine that would reduce that workload if more were added back

https://alpinelinux.org/releases/ states:

> Each May and November we make a release branch from edge. The main repository is typically supported for 2 years and the community repository is supported until next stable release.

| Branch | Date       | docker-node | End-of-support |
| ------ | ---------- | ----------- | -------------- |
| v3.23  | 2025-12-03 | Active      | 2027-11-01     |
| v3.22  | 2025-05-30 | Active      | 2027-05-01     |
| v3.21  | 2024-12-05 | Removed     | 2026-11-01     |

## Testing Details

N/A

## Types of changes

- [X] Documentation
- [ ] Version change (Update, remove or add more Node.js versions)
- [ ] Variant change (Update, remove or add more variants, or versions of variants)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other (none of the above)

## Checklist

- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING.md** document.
- [X] All new and existing tests passed.
