### PR TITLE
docs: describe strategy for Alpine new release

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -33,6 +33,11 @@ New **npm** releases are not tracked. We simply use the npm version bundled in t
 from templates starting with the Node 26 images.
 
 **[Alpine Linux](https://alpinelinux.org/releases/)** latest two releases are used.
+When Alpine Linux makes a new branch available, which is planned for May and November each year,
+this branch is adopted as a new base image and it becomes the default
+for each supported Node.js release line.
+The lowest previously used Alpine Linux release is dropped for future image builds,
+so that only the two latest releases are maintained.
 
 ### Image Creation Automation
 


### PR DESCRIPTION
## Description

Describe in the [CONTRIBUTING > Version Updates](https://github.com/nodejs/docker-node/blob/main/CONTRIBUTING.md#version-updates) document section that Alpine Linux new releases become the new default version for each active Node.js release line.

The previous statement that the latest two Alpine Linux releases are used is expanded for additional clarity.

## Motivation and Context

Undocumented past practice has been to promote each latest Alpine Linux release to default.

[Alpine Linux Release Branches](https://alpinelinux.org/releases/) states:

> There are several release branches for Alpine Linux available at the same time. Each May and November we make a release branch from edge. The main repository is typically supported for 2 years and the community repository is supported until next stable release.

## Testing Details

N/A

## Types of changes

- [X] Documentation
- [ ] Version change (Update, remove or add more Node.js versions)
- [ ] Variant change (Update, remove or add more variants, or versions of variants)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other (none of the above)

## Checklist

- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING.md** document.
- [X] All new and existing tests passed.
