### PR TITLE
chore: remove duplicated security issue choice

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -6,9 +6,6 @@ contact_links:
   - name: Found a problem with Node.js beyond the API reference documentation?
     url: https://github.com/nodejs/nodejs.org/issues/new/choose
     about: Please file an issue in the Node.js website repository.
-  - name: Want to report security issues or vulnerabilites?
-    url: https://github.com/nodejs/docker-node/security/policy
-    about: Please go through our policy for reporting CVEs and security issues.
   - name: Need help with common questions related to using Node.js with Docker?
     url: https://stackoverflow.com/questions/tagged/node.js%2bdocker%2bdockerfile
     about: Please visit Stack Overflow to explore related questions and answers.


### PR DESCRIPTION
## Description

Remove the duplicated entry in [.github/ISSUE_TEMPLATE/config.yml](https://github.com/nodejs/docker-node/blob/main/.github/ISSUE_TEMPLATE/config.yml):

- Want to report security issues or vulnerabilites?

leaving the entry:

- Report a security vulnerability

which links to the [SECURITY](https://github.com/nodejs/docker-node/blob/main/SECURITY.md) document.

## Motivation and Context

https://github.com/nodejs/docker-node/issues/new/choose shows two entries in the template chooser for reporting security issues:

1. Report a security vulnerability
2. Want to report security issues or vulnerabilites (sic)?

<img width="739" height="658" alt="image" src="https://github.com/user-attachments/assets/b265864a-4b21-4fc0-86d0-3dfa4d7556d3" />

<br><br>Both entries link to the same document

- https://github.com/nodejs/docker-node/security/policy

which forwards to:

- https://github.com/nodejs/docker-node/blob/main/SECURITY.md

The first entry "Report a security vulnerability" is added automatically by GitHub, although this appears to be an undocumented feature.

## Testing Details

## Types of changes

- [ ] Documentation
- [ ] Version change (Update, remove or add more Node.js versions)
- [ ] Variant change (Update, remove or add more variants, or versions of variants)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [X] Other (none of the above)

## Checklist

- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING.md** document.
- [X] All new and existing tests passed.
