### PR TITLE
chore: consolidate StackOverflow docker tags

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -2,10 +2,10 @@ blank_issues_enabled: false
 contact_links:
   - name: Need help with Node.js?
     url: https://github.com/nodejs/help
-    about: Please file an issue in our help repo.
+    about: Please file an issue in our help repo
   - name: Found a problem with Node.js beyond the API reference documentation?
     url: https://github.com/nodejs/nodejs.org/issues/new/choose
-    about: Please file an issue in the Node.js website repository.
+    about: Please file an issue in the Node.js website repository
   - name: Need help with common questions related to using Node.js with Docker?
-    url: https://stackoverflow.com/questions/tagged/node.js%2bdocker%2bdockerfile
-    about: Please visit Stack Overflow to explore related questions and answers.
+    url: https://stackoverflow.com/questions/tagged/node.js%2bdocker
+    about: Please visit Stack Overflow to explore related questions and answers


### PR DESCRIPTION
## Description

Consolidate the StackOverflow link tags in [.github/ISSUE_TEMPLATE/config.yml](https://github.com/nodejs/docker-node/blob/main/.github/ISSUE_TEMPLATE/config.yml) to

https://stackoverflow.com/questions/tagged/node.js%2bdocker

removing the `dockerfile` tag.

Remove also the end of sentence punctuation to align with formatting of GitHub auto-generated issue chooser entries.

## Motivation and Context

`dockerfile` is a [tag synomym on StackOverflow](https://stackoverflow.com/tags/synonyms) with target tag `docker`.

Clicking on the current link

https://stackoverflow.com/questions/tagged/node.js%2bdocker%2bdockerfile

shows a search in StackOverflow with duplicated `docker` tags

<img width="1069" height="55" alt="image" src="https://github.com/user-attachments/assets/6f277a59-aaaf-41ea-8145-1b88816c8179" />


## Testing Details

## Types of changes

- [ ] Documentation
- [ ] Version change (Update, remove or add more Node.js versions)
- [ ] Variant change (Update, remove or add more variants, or versions of variants)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [X] Other (none of the above)

## Checklist

- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING.md** document.
- [X] All new and existing tests passed.
