### PR TITLE
feat: drop Debian 12 bookworm s390x variant

### DIFF
--- a/versions.json
+++ b/versions.json
@@ -19,14 +19,12 @@
       "bookworm": [
         "amd64",
         "arm64v8",
-        "ppc64le",
-        "s390x"
+        "ppc64le"
       ],
       "bookworm-slim": [
         "amd64",
         "arm64v8",
-        "ppc64le",
-        "s390x"
+        "ppc64le"
       ],
       "bullseye": [
         "amd64",
@@ -72,14 +70,12 @@
       "bookworm": [
         "amd64",
         "arm64v8",
-        "ppc64le",
-        "s390x"
+        "ppc64le"
       ],
       "bookworm-slim": [
         "amd64",
         "arm64v8",
-        "ppc64le",
-        "s390x"
+        "ppc64le"
       ],
       "bullseye": [
         "amd64",
@@ -130,15 +126,13 @@
         "amd64",
         "arm32v7",
         "arm64v8",
-        "ppc64le",
-        "s390x"
+        "ppc64le"
       ],
       "bookworm-slim": [
         "amd64",
         "arm32v7",
         "arm64v8",
-        "ppc64le",
-        "s390x"
+        "ppc64le"
       ],
       "bullseye": [
         "amd64",


### PR DESCRIPTION
- closes https://github.com/nodejs/docker-node/issues/2556

## Description

- Remove the `s390x` variant from `bookworm` and `bookworm-slim` configurations in [versions.json](https://github.com/nodejs/docker-node/blob/main/versions.json) for each Node.js version.

## Motivation and Context

[bookworm LTS support status](https://wiki.debian.org/LTS/Bookworm) was entered on June 11, 2026 and lasts until June 30, 2028. The supported architectures are reduced to:

`i386`, `amd64`, `arm64`, `armhf` and `ppc64el`

Since this does not include `s390x` any more, this architectural variant must be removed from future `bookworm` builds.

## Testing Details

Check CI [actions/workflows/build-test.yml](https://github.com/nodejs/docker-node/actions/workflows/build-test.yml)

## Types of changes

- [ ] Documentation
- [ ] Version change (Update, remove or add more Node.js versions)
- [X] Variant change (Update, remove or add more variants, or versions of variants)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other (none of the above)

## Checklist

- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING.md** document.
- [X] All new and existing tests passed.
