### PR TITLE
docs: deprecate bullseye (end of 5 year lifecycle on 2026-08-31)

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,6 +214,12 @@ This image is based on version 11 of
 [Debian](https://debian.org), available in
 [the `debian` official image](https://hub.docker.com/_/debian).
 
+[Debian `bullseye`](https://www.debian.org/releases/bullseye/)
+reaches the end of its 5-year lifecycle on Aug 31, 2026.
+Users should plan to migrate to a higher Debian version
+using `bookworm` / `booworm-slim` (Debian 12) or `trixie` / `trixie-slim` (Debian 13) images.
+New `bullseye` and `bullseye-slim` images will no longer be published after the above date.
+
 ### `node:bookworm`
 
 This image is based on version 12 of


### PR DESCRIPTION
## Description

Add note to [README > node:bullseye](https://github.com/nodejs/docker-node#nodebullseye) that [Debian `bullseye`](https://www.debian.org/releases/bullseye/) reaches the end of its 5-year lifecycle on Aug 31, 2026.

## Motivation and Context

Users should plan to migrate before Debian `bullseye` is no longer supported.

A follow-on change after end of Aug 2026 will be needed to remove `bullseye` from the configuration and this documentation change advises users in advance.

## Testing Details

N/A

## Types of changes

- [X] Documentation
- [ ] Version change (Update, remove or add more Node.js versions)
- [ ] Variant change (Update, remove or add more variants, or versions of variants)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other (none of the above)

## Checklist

- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING.md** document.
- [X] All new and existing tests passed.

