### PR TITLE
ci: ignore sourceware.org for markdown link checks

### DIFF
--- a/markdown_link_check_config.json
+++ b/markdown_link_check_config.json
@@ -14,6 +14,9 @@
     },
     {
       "pattern": "^https://www\\.etalabs\\.net/"
+    },
+    {
+      "pattern": "^https://sourceware\\.org/"
     }
   ]
 }


### PR DESCRIPTION
## Description

In [markdown_link_check_config.json](https://github.com/nodejs/docker-node/blob/main/markdown_link_check_config.json)

- Add the following to `ignorePatterns`:
  - https://sourceware.org

## Motivation and Context

The workflow [.github/workflows/markdown-link-check.yml](https://github.com/nodejs/docker-node/blob/main/.github/workflows/markdown-link-check.yml) is sporadically failing with Status 0 errors:

```console
  [✖] https://sourceware.org/glibc/ → Status: 0
```

See [workflow logs](https://github.com/nodejs/docker-node/actions/workflows/markdown-link-check.yml)

The following manually executed command is succeeding, although it is very slow:

```shell
curl -I https://sourceware.org/glibc/
```

## Types of changes

- [ ] Documentation
- [ ] Version change (Update, remove or add more Node.js versions)
- [ ] Variant change (Update, remove or add more variants, or versions of variants)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other (none of the above)

## Checklist

- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING.md** document.
- [X] All new and existing tests passed.
