### PR TITLE
ci: use Ubuntu shfmt shell formatter

### DIFF
--- a/.github/workflows/shfmt.yml
+++ b/.github/workflows/shfmt.yml
@@ -4,7 +4,8 @@ on:
   pull_request:
     paths:
       - '**/*.sh'
-      - '.github/workflows/shfmt.yml'
+      - .github/workflows/shfmt.yml
+  workflow_dispatch:
 
 permissions:
   contents: read
@@ -14,8 +15,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-      - run: docker run -v "$(pwd)":/sh -w /sh peterdavehello/shfmt:2.6.3 shfmt -sr -i 2 -l -w -ci .
-      - run: git diff --color --exit-code
+      - name: Install shfmt
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y shfmt
+      - name: Run shfmt
+        run: shfmt -sr -i 2 -l -w -ci -d .
 
   shellcheck:
     runs-on: ubuntu-latest


### PR DESCRIPTION
- closes https://github.com/nodejs/docker-node/issues/2555

## Description

- Replace custom Docker image [peterdavehello/shfmt:2.6.3](https://hub.docker.com/r/peterdavehello/shfmt) in [.github/workflows/shfmt.yml](https://github.com/nodejs/docker-node/blame/main/.github/workflows/shfmt.yml) with Ubuntu package [shfmt](https://packages.ubuntu.com/shfmt) for shell script format linting.

- Use [shfmt -d](https://manpages.ubuntu.com/manpages/noble/man1/shfmt.1.html) for read-only `--diff` linting in CI.

## Motivation and Context

`peterdavehello/shfmt:2.6.3` in [.github/workflows/shfmt.yml](https://github.com/nodejs/docker-node/blame/main/.github/workflows/shfmt.yml) was published in Jan 2019 and is outdated.

Ubuntu offers the package [shfmt](https://packages.ubuntu.com/shfmt) which relieves the need for a specially built Docker image to perform shell script linting in CI. It is also available in Debian. See https://github.com/mvdan/sh.

## Testing Details

Locally in Ubuntu 24.04.4 LTS, execute:

```shell
sudo apt-get update
sudo apt-get install -y shfmt
shfmt -sr -i 2 -l -w -ci -d .
```

and confirm no error reported.

Check for success of job `shfmt` in workflow [.github/workflows/shfmt.yml](https://github.com/nodejs/docker-node/blame/main/.github/workflows/shfmt.yml)

## Types of changes

- [ ] Documentation
- [ ] Version change (Update, remove or add more Node.js versions)
- [ ] Variant change (Update, remove or add more variants, or versions of variants)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [X] Other (none of the above)

## Checklist

- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING.md** document.
- [X] All new and existing tests passed.
