### PR TITLE
chore: consume dist/index.json when resolving versions

### DIFF
--- a/update.sh
+++ b/update.sh
@@ -115,15 +115,13 @@ function update_node_version() {
     shift
   fi
 
-  fullVersion="$(curl -sSL --compressed "${baseuri}" | grep '<a href="v'"${version}." | sed -E 's!.*<a href="v([^"/]+)/?".*!\1!' | cut -d'.' -f2,3 | sort -V | tail -1)"
+  nodeVersion="$(curl -sSL --compressed "${baseuri}/index.json" | jq -r '[.[] | select(.version | startswith("v'"${version}"'."))] | first | .version | ltrimstr("v")')"
   (
     cp "${template}" "${dockerfile}-tmp"
     local fromprefix=""
     if [ "${arch}" != "amd64" ] && [ "${arch}" != "arm64" ]; then
       fromprefix="${arch}\\/"
     fi
-
-    nodeVersion="${version}.${fullVersion:-0}"
 
     sed -Ei -e 's/^FROM (.*)/FROM '"$fromprefix"'\1/' "${dockerfile}-tmp"
     sed -Ei -e 's/^(ENV NODE_VERSION)=.*/\1='"${nodeVersion}"'/' "${dockerfile}-tmp"


### PR DESCRIPTION
## Description

Resolves #2514 by switching the logic for resolving the full version to index.json instead of parsing the HTML index.

## Motivation and Context

cc https://github.com/nodejs/release-cloudflare-worker/issues/131

## Testing Details

`./update.sh` runs and outputs the expected versions still.

## Example Output(if appropriate)

N/A

## Types of changes

- [ ] Documentation
- [ ] Version change (Update, remove or add more Node.js versions)
- [ ] Variant change (Update, remove or add more variants, or versions of variants)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other (none of the above)

## Checklist

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING.md** document.
- [x] All new and existing tests passed.
