### PR TITLE
chore: add check for jq to update.sh script

### DIFF
--- a/update.sh
+++ b/update.sh
@@ -43,6 +43,12 @@ while getopts "sh" opt; do
   esac
 done
 
+if ! command -v jq > /dev/null; then
+  echo "**jq not installed**" >&2
+  echo "Follow the instructions in https://jqlang.org/download/ to install" >&2
+  exit 1
+fi
+
 . functions.sh
 
 cd "$(cd "${0%/*}" && pwd -P)"


### PR DESCRIPTION
## Description

Add a check to the [update.sh](https://github.com/nodejs/docker-node/blob/main/update.sh) script for the availability of the [jq](https://jqlang.org/) command.

Output instructions to install jq from https://jqlang.org/download/ if not found.

## Motivation and Context

PR https://github.com/nodejs/docker-node/pull/2598 added some additional usage of [jq](https://jqlang.org/) in the [update.sh](https://github.com/nodejs/docker-node/blob/main/update.sh) script.

If an attempt is made to run `./update.sh` without [jq](https://jqlang.org/) installed, the error messages are quite noisy and untidy.

## Testing Details

On Ubuntu 24.04.4 LTS

```shell
git clone https://github.com/nodejs/docker-node
cd docker-node

sudo apt-get -y remove jq # if previously installed
./update.sh -h # confirm help is displayed
./update.sh 26 # confirm jq message displayed

sudo apt-get install jq
./update.sh -h # confirm help is displayed
./update.sh 26 # confirm update is run
```

## Test logs

New output is:

```console
**jq not installed**
Follow the instructions in https://jqlang.org/download/ to install
```

Other output, as previously.

## Types of changes

- [ ] Documentation
- [ ] Version change (Update, remove or add more Node.js versions)
- [ ] Variant change (Update, remove or add more variants, or versions of variants)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [X] Other (none of the above)

## Checklist

- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING.md** document.
- [X] All new and existing tests passed.
