### PR TITLE
chore: add check for baseuri reachability in update.sh script

### DIFF
--- a/update.sh
+++ b/update.sh
@@ -253,11 +253,18 @@ function update_node_version() {
 }
 
 pids=()
+baseuri_checked=""
 
 for version in "${versions[@]}"; do
   parentpath=$(dirname "${version}")
   versionnum=$(basename "${version}")
   baseuri=$(get_config "${parentpath}" "baseuri")
+  if [ "${baseuri_checked}" != "${baseuri}" ]; then
+    if ! curl -sS --fail --compressed --max-time 15 "${baseuri}/index.json" > /dev/null; then
+      fatal "Unable to reach ${baseuri}; please check network connectivity or the baseuri configuration."
+    fi
+    baseuri_checked="${baseuri}"
+  fi
   update_version=$(in_versions_to_update "${version}")
 
   [ "${update_version}" -eq 0 ] && info "Updating version ${version}..."


### PR DESCRIPTION
## Description

Add a check to the [update.sh](https://github.com/nodejs/docker-node/blob/main/update.sh) script for the reachability of the `baseuri` server defined in the [config](https://github.com/nodejs/docker-node/blob/main/config) file, waiting 15 seconds.

Output a clear and short error message then exit fatally.

## Motivation and Context

If the website defined in https://github.com/nodejs/docker-node/blob/85b7a1a979363080df44d46e05570980668e6571/config#L1 is not reachable, then executing `./update.sh` may hang indefinitely or output multiple error messages before failing.

The scripts are written such that there can be a `config` file in each release line directory, although that is not used, so theoretically there can be multiple `baseuri` definitions. In later script rework exercises, such as needed for Alpine Tier 2 and Node 27, we may check if we need this flexibility, or if it could be simplified.

As far as https://nodejs.org/dist is concerned, there is one location for all release lines.

## Testing Details

On Ubuntu 24.04.4 LTS

```shell
git clone https://github.com/nodejs/docker-node
cd docker-node
cat > config <<EOT # change to unreachable port
baseuri     https://nodejs.org:3000/dist
default_variant trixie
alpine_version  3.23
debian_versions bookworm bullseye trixie
EOT
./update.sh # previously waited indefinitely

cat > config <<EOT # change to non-running server
baseuri     https://localhost/dist
default_variant trixie
alpine_version  3.23
debian_versions bookworm bullseye trixie
EOT
./update.sh # previously output many lines of error messages
```

## Test logs

### Unreachable port

```console
$ cat > config <<EOT # change to unreachable port
baseuri     https://nodejs.org:3000/dist
default_variant trixie
alpine_version  3.23
debian_versions bookworm bullseye trixie
EOT
./update.sh # previously waited indefinitely
curl: (28) Connection timed out after 15001 milliseconds
**********
Fatal Error: Unable to reach https://nodejs.org:3000/dist; please check network connectivity or the baseuri configuration.
**********
```

### Non-running server

```console
$ cat > config <<EOT # change to non-running server
baseuri     https://localhost/dist
default_variant trixie
alpine_version  3.23
debian_versions bookworm bullseye trixie
EOT
./update.sh # previously output many lines of error messages
curl: (7) Failed to connect to localhost port 443 after 0 ms: Couldn't connect to server
**********
Fatal Error: Unable to reach https://localhost/dist; please check network connectivity or the baseuri configuration.
**********
```

## Types of changes

- [ ] Documentation
- [ ] Version change (Update, remove or add more Node.js versions)
- [ ] Variant change (Update, remove or add more variants, or versions of variants)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other (none of the above)

## Checklist

- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING.md** document.
- [X] All new and existing tests passed.
