### PR TITLE
fix: exit Alpine build on unsupported architectures

### DIFF
--- a/update.sh
+++ b/update.sh
@@ -171,7 +171,7 @@ function update_node_version() {
           alpine_arch+='s390x) OPENSSL_ARCH=linux-s390x;; \\\n        '
         fi
         # shellcheck disable=SC1003
-        alpine_arch+='*) ;; \\'
+        alpine_arch+='*) echo "unsupported architecture"; exit 1 ;; \\'
         sed -Ei -e "s/\"\\$\{ALPINE_ARCH\[@\]\}\"/${alpine_arch}/" "${dockerfile}-tmp"
       fi
     elif is_debian "${variant}"; then


### PR DESCRIPTION
<!--
Provide a general summary of your changes in the Title above.
-->

## Description

If one of the allowlisted architectures from the `version.json` parsed list isn't found, exit the build like on the Debian images.

## Motivation and Context

Noticed that the default case on the Alpine behaved differently from the Debian version. Took the same message from the Debian template.

## Testing Details

<!--
Please describe in detail how you tested your changes. Include details of
your testing environment, and the tests you ran to see how your change
affects other areas of the code, etc.
-->

## Example Output(if appropriate)

## Types of changes

<!--
What types of changes does your code introduce? Put an `x` in all the boxes that apply.
-->

- [ ] Documentation
- [ ] Version change (Update, remove or add more Node.js versions)
- [ ] Variant change (Update, remove or add more variants, or versions of variants)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other (none of the above)

## Checklist

<!--
Go over all the following points, and put an `x` in all the boxes that apply.
If you're unsure about any of these, don't hesitate to ask. We're here to help!
-->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING.md** document.
- [x] All new and existing tests passed.
