### PR TITLE
chore: add automation for release keys

### DIFF
--- a/.github/workflows/automatic-release-keys.yml
+++ b/.github/workflows/automatic-release-keys.yml
@@ -31,3 +31,4 @@ jobs:
           delete-branch: true
           team-reviewers: |
             nodejs/docker
+            nodejs/releasers

--- a/.github/workflows/automatic-release-keys.yml
+++ b/.github/workflows/automatic-release-keys.yml
@@ -1,0 +1,33 @@
+name: Automatically update Node.js team release keys
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 12 * * 1'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    if: github.repository_owner == 'nodejs'
+    permissions:
+      pull-requests: write
+
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Run automation script
+        run: ./update-keys.sh
+
+      - name: Create update PR
+        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
+        with:
+          token: ${{ secrets.GH_API_TOKEN }}
+          author: 'Node.js GitHub Bot <nodejs-github-bot@users.noreply.github.com>'
+          branch: keys-branch
+          base: main
+          commit-message: 'chore: Node.js release key sync'
+          title: 'chore: Node.js release key sync'
+          body: Open based on changes from `update-keys.sh`. For details on whose key is changing, look at https://github.com/nodejs/node#release-keys
+          delete-branch: true
+          team-reviewers: |
+            nodejs/docker

--- a/.github/workflows/node-keys.yml
+++ b/.github/workflows/node-keys.yml
@@ -1,0 +1,24 @@
+name: Node.js Release Key Check
+
+on:
+  pull_request:
+    paths:
+      - keys/node.keys
+      - .github/workflows/node-keys.yml
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    if: github.repository_owner == 'nodejs'
+
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Run automation script
+        run: ./update-keys.sh
+
+      - name: Ensure no git changes
+        run: git diff --exit-code


### PR DESCRIPTION
<!--
Provide a general summary of your changes in the Title above.
-->

## Description

Either a test job in CI could run if someone touches the keys file, or a periodic sync can just check for changes and create a PR. I opted for the later, but the former would work as well.

## Motivation and Context

https://github.com/nodejs/docker-node/issues/2569
I assume that a daily poll is more than frequent enough, although it's possible that a new Releaser could open the PR manually here while the other upstream PRs are waiting. Any sort issues would eventually get corrected by the PR this action would create.

Potentially the upstream documentation to open the PR here for the keys could be removed if this lands.

## Testing Details

<!--
Please describe in detail how you tested your changes. Include details of
your testing environment, and the tests you ran to see how your change
affects other areas of the code, etc.
-->

## Example Output(if appropriate)

## Types of changes

<!--
What types of changes does your code introduce? Put an `x` in all the boxes that apply.
-->

- [ ] Documentation
- [ ] Version change (Update, remove or add more Node.js versions)
- [ ] Variant change (Update, remove or add more variants, or versions of variants)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Other (none of the above)

## Checklist

<!--
Go over all the following points, and put an `x` in all the boxes that apply.
If you're unsure about any of these, don't hesitate to ask. We're here to help!
-->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING.md** document.
- [ ] All new and existing tests passed.
