### PR TITLE
chore: pull Releaser keys from keyring instead of README

### DIFF
--- a/.github/workflows/node-keys.yml
+++ b/.github/workflows/node-keys.yml
@@ -4,6 +4,7 @@ on:
   pull_request:
     paths:
       - keys/node.keys
+      - update-keys.sh
       - .github/workflows/node-keys.yml
 
 permissions:

--- a/update-keys.sh
+++ b/update-keys.sh
@@ -1,3 +1,7 @@
 #!/bin/sh -ex
 
-curl -fsSLo- --compressed https://github.com/nodejs/node/raw/main/README.md | awk '/--recv-keys.*#/{ gsub(/^.*--recv-keys\s+/,"");gsub(/\s+#.*$/,""); print }' > keys/node.keys
+curl -fsSLO --compressed "https://github.com/nodejs/release-keys/raw/refs/heads/main/gpg-only-active-keys/pubring.kbx"
+
+gpg --no-default-keyring --keyring "./pubring.kbx" --keyid-format long --with-colons --fingerprint | awk -F: '/^pub:.*/ { getline; print $10}' > keys/node.keys
+
+rm pubring.kbx


### PR DESCRIPTION
<!--
Provide a general summary of your changes in the Title above.
-->

## Description

Doesn't replace the way the keys are embedded in the Dockerfiles, but use the newer keyring file to read the fingerprints.

## Motivation and Context

<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
-->

## Testing Details

<!--
Please describe in detail how you tested your changes. Include details of
your testing environment, and the tests you ran to see how your change
affects other areas of the code, etc.
-->

## Example Output(if appropriate)

## Types of changes

<!--
What types of changes does your code introduce? Put an `x` in all the boxes that apply.
-->

- [ ] Documentation
- [ ] Version change (Update, remove or add more Node.js versions)
- [ ] Variant change (Update, remove or add more variants, or versions of variants)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Other (none of the above)

## Checklist

<!--
Go over all the following points, and put an `x` in all the boxes that apply.
If you're unsure about any of these, don't hesitate to ask. We're here to help!
-->

- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING.md** document.
- [x] All new and existing tests passed.
