### PR TITLE
docs: document Debian lifecycle transitions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -127,6 +127,19 @@ for each supported Node.js release line.
 The lowest previously used Alpine Linux release is dropped for future image builds,
 so that only the two latest releases are maintained.
 
+**[Debian](https://www.debian.org/releases/)** provides a new stable release every two years:
+
+> The Debian release life cycle encompasses five years: the first three years of full support
+> followed by two years of Long Term Support (LTS).
+
+If a [Debian LTS](https://wiki.debian.org/LTS) transition causes any architectures used in Docker builds to be dropped,
+they are also dropped from future builds after waiting for the next Node.js release
+following the Debian release transition into LTS support.
+The wait is advised to prevent an architecture being prematurely removed due to the automatic rebuild process
+in [docker-library/official-images](https://github.com/docker-library/official-images).
+
+After the end of Debian LTS support, the corresponding Debian release is dropped for future image builds.
+
 ### Image Creation Automation
 
 - Every 15 minutes, the [workflow](https://github.com/nodejs/docker-node/blob/main/.github/workflows/automatic-updates.yml) within the [nodejs/docker-node](https://github.com/nodejs/docker-node) repo [checks](https://github.com/nodejs/docker-node/blob/main/build-automation.mjs) for new versions of Node.js [published to the website's `index.json` file](https://nodejs.org/download/release/index.json).


### PR DESCRIPTION
## Description

[CONTRIBUTING > Version Updates](https://github.com/nodejs/docker-node/blob/main/CONTRIBUTING.md#version-updates) is updated with information concerning Debian releases and lifecycle transitions.

## Motivation and Context

Debian release lifecycle transitions require re-configuration action of `node` Docker image variants.

[CONTRIBUTING > Version Updates](https://github.com/nodejs/docker-node/blob/main/CONTRIBUTING.md#version-updates) does not yet include any related description.

[Debian Releases > Release life cycle](https://www.debian.org/releases/) states:

> Debian announces its new stable release on a regular basis. The Debian release life cycle encompasses five years: the first three years of full support followed by two years of Long Term Support (LTS).

- Release
- End of Life (EOL) after 3 years
- End of LTS after another 2 years, 5 years in total

When Debian transitions from EOL to LTS, the LTS support team defines and publishes [LTS support architectures](https://wiki.debian.org/LTS) that may be only a subset of the architectures supported during the original release phase.

## Testing Details

## Types of changes

- [X] Documentation
- [ ] Version change (Update, remove or add more Node.js versions)
- [ ] Variant change (Update, remove or add more variants, or versions of variants)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other (none of the above)

## Checklist

- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING.md** document.
- [X] All new and existing tests passed.
