### PR TITLE
ci: ignore openjs-foundation.slack.com for markdown link checks

### DIFF
--- a/markdown_link_check_config.json
+++ b/markdown_link_check_config.json
@@ -17,6 +17,9 @@
     },
     {
       "pattern": "^https://sourceware\\.org/"
+    },
+    {
+      "pattern": "^https://openjs-foundation\\.slack\\.com/"
     }
   ]
 }


### PR DESCRIPTION
## Description

Add https://openjs-foundation.slack.com to `ignorePatterns` in https://github.com/nodejs/docker-node/blob/main/markdown_link_check_config.json

## Motivation and Context

Links in [CONTRIBUTING > Discussion Areas](https://github.com/nodejs/docker-node/blob/main/CONTRIBUTING.md#discussion-areas) are now causing 403 Forbidden errors when running `check:markdown-links`:

  ERROR: 2 dead links found!
  [✖] https://openjs-foundation.slack.com/archives/C0ALS3UDE8G → Status: 403
  [✖] https://openjs-foundation.slack.com/archives/C019MGJQ8RH → Status: 403

These links can however be accessed in Google Chrome in an incognito window, so it appears that Slack has increased security against automated checks.

## Testing Details

## Types of changes

- [ ] Documentation
- [ ] Version change (Update, remove or add more Node.js versions)
- [ ] Variant change (Update, remove or add more variants, or versions of variants)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [X] Other (none of the above)

## Checklist

- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING.md** document.
- [X] All new and existing tests passed.
